### PR TITLE
Add ways to configure clients

### DIFF
--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AICompletionContext.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AICompletionContext.cs
@@ -11,4 +11,6 @@ public class AICompletionContext
     public bool UserMarkdownInResponse { get; set; }
 
     public bool DisableTools { get; set; }
+
+    public bool UseCaching { get; set; } = true;
 }

--- a/src/Core/CrestApps.OrchardCore.AI.Core/CrestApps.OrchardCore.AI.Core.csproj
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/CrestApps.OrchardCore.AI.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="YesSql.Abstractions" />
     <PackageReference Include="OrchardCore.ContentManagement.Abstractions" />
     <PackageReference Include="OrchardCore.Liquid.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.AI" />
     <PackageReference Include="Markdig" />
   </ItemGroup>
 

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Models/AIProfileMetadata.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Models/AIProfileMetadata.cs
@@ -15,4 +15,6 @@ public class AIProfileMetadata
     public int? MaxTokens { get; set; }
 
     public int? PastMessagesCount { get; set; }
+
+    public bool UseCaching { get; set; } = true;
 }

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Models/DefaultAIOptions.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Models/DefaultAIOptions.cs
@@ -13,4 +13,10 @@ public sealed class DefaultAIOptions
     public float PresencePenalty = 0;
 
     public int PastMessagesCount = 10;
+
+    public int? MaximumIterationsPerRequest { get; set; } = 1;
+
+    public bool EnableOpenTelemetry { get; set; }
+
+    public bool EnableDistributedCaching { get; set; } = true;
 }

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/AICompletionServiceBase.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/AICompletionServiceBase.cs
@@ -1,0 +1,88 @@
+﻿using CrestApps.OrchardCore.AI.Core.Models;
+using CrestApps.OrchardCore.AI.Models;
+
+namespace CrestApps.OrchardCore.AI.Core.Services;
+
+public abstract class AICompletionServiceBase
+{
+    protected readonly AIProviderOptions ProviderOptions;
+
+    protected AICompletionServiceBase(AIProviderOptions providerOptions)
+    {
+        ProviderOptions = providerOptions;
+    }
+
+    protected virtual string GetDefaultConnectionName(AIProvider provider)
+    {
+        return provider.DefaultConnectionName;
+    }
+
+    protected virtual string GetDefaultDeploymentName(AIProvider provider)
+    {
+        return provider.DefaultDeploymentName;
+    }
+
+    protected async Task<Tuple<AIProviderConnection, string>> GetConnectionAsync(AICompletionContext context, string providerName)
+    {
+        string deploymentName = null;
+
+        if (ProviderOptions.Providers.TryGetValue(providerName, out var provider))
+        {
+            var connectionName = GetDefaultConnectionName(provider);
+
+            deploymentName = GetDefaultDeploymentName(provider);
+
+            var deployment = await GetDeploymentAsync(context);
+
+            if (deployment is not null)
+            {
+                connectionName = deployment.ConnectionName;
+                deploymentName = deployment.Name;
+            }
+
+            if (!string.IsNullOrEmpty(connectionName) && provider.Connections.TryGetValue(connectionName, out var connectionProperties))
+            {
+                return new Tuple<AIProviderConnection, string>(connectionProperties, deploymentName);
+            }
+        }
+
+        return new Tuple<AIProviderConnection, string>(null, deploymentName);
+    }
+
+    protected static int GetTotalMessagesToSkip(int totalMessages, int pastMessageCount)
+    {
+        if (pastMessageCount > 0 && totalMessages > pastMessageCount)
+        {
+            return totalMessages - pastMessageCount;
+        }
+
+        return 0;
+    }
+
+
+    protected virtual Task<AIDeployment> GetDeploymentAsync(AICompletionContext content)
+    {
+        return Task.FromResult<AIDeployment>(null);
+    }
+
+    protected static string GetSystemMessage(AICompletionContext context, AIProfileMetadata metadata)
+    {
+        var systemMessage = string.Empty;
+
+        if (!string.IsNullOrEmpty(context.SystemMessage))
+        {
+            systemMessage = context.SystemMessage;
+        }
+        else if (!string.IsNullOrEmpty(metadata.SystemMessage))
+        {
+            systemMessage = metadata.SystemMessage;
+        }
+
+        if (context.UserMarkdownInResponse)
+        {
+            systemMessage += Environment.NewLine + AIConstants.SystemMessages.UseMarkdownSyntax;
+        }
+
+        return systemMessage;
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/AICompletionServiceBase.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/AICompletionServiceBase.cs
@@ -1,4 +1,4 @@
-﻿using CrestApps.OrchardCore.AI.Core.Models;
+using CrestApps.OrchardCore.AI.Core.Models;
 using CrestApps.OrchardCore.AI.Models;
 
 namespace CrestApps.OrchardCore.AI.Core.Services;
@@ -58,7 +58,6 @@ public abstract class AICompletionServiceBase
 
         return 0;
     }
-
 
     protected virtual Task<AIDeployment> GetDeploymentAsync(AICompletionContext content)
     {

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/DeploymentNamedAICompletionService.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/DeploymentNamedAICompletionService.cs
@@ -1,0 +1,34 @@
+﻿using CrestApps.OrchardCore.AI.Core.Models;
+using CrestApps.OrchardCore.AI.Models;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.OrchardCore.AI.Core.Services;
+
+public abstract class DeploymentNamedAICompletionService : NamedAICompletionService
+{
+    private readonly IAIDeploymentStore _deploymentStore;
+
+    public DeploymentNamedAICompletionService(
+        string name,
+        IDistributedCache distributedCache,
+        ILoggerFactory loggerFactory,
+        AIProviderOptions providerOptions,
+        DefaultAIOptions defaultOptions,
+        IAIToolsService toolsService,
+        IAIDeploymentStore deploymentStore)
+        : base(name, distributedCache, loggerFactory, providerOptions, defaultOptions, toolsService)
+    {
+        _deploymentStore = deploymentStore;
+    }
+
+    protected override async Task<AIDeployment> GetDeploymentAsync(AICompletionContext content)
+    {
+        if (!string.IsNullOrEmpty(content.Profile?.DeploymentId))
+        {
+            return await _deploymentStore.FindByIdAsync(content.Profile.DeploymentId);
+        }
+
+        return null;
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.OpenAI.Core/Handlers/OpenAIProfileHandler.cs
+++ b/src/Core/CrestApps.OrchardCore.OpenAI.Core/Handlers/OpenAIProfileHandler.cs
@@ -108,6 +108,13 @@ public sealed class OpenAIProfileHandler : AIProfileHandlerBase
             metadata.PastMessagesCount = pastMessagesCount;
         }
 
+        var useCaching = metadataNode[nameof(metadata.UseCaching)]?.GetValue<bool?>();
+
+        if (useCaching.HasValue)
+        {
+            metadata.UseCaching = useCaching.Value;
+        }
+
         profile.Put(metadata);
 
         return Task.CompletedTask;

--- a/src/Core/CrestApps.OrchardCore.OpenAI.Core/Services/OpenAICompletionService.cs
+++ b/src/Core/CrestApps.OrchardCore.OpenAI.Core/Services/OpenAICompletionService.cs
@@ -10,20 +10,17 @@ using OpenAI;
 
 namespace CrestApps.OrchardCore.AI.OpenAI.Services;
 
-public sealed class OpenAICompletionService : NamedAICompletionService
+public sealed class OpenAICompletionService : DeploymentNamedAICompletionService
 {
-    private readonly IDistributedCache _distributedCache;
-
     public OpenAICompletionService(
-        IAIDeploymentStore deploymentStore,
-        IDistributedCache distributedCache,
-        IOptions<AIProviderOptions> providerOptions,
-        IAIToolsService toolsService,
-        IOptions<DefaultAIOptions> defaultOptions,
-        ILogger<OpenAICompletionService> logger)
-        : base(OpenAIDeploymentProvider.ProviderName, providerOptions.Value, defaultOptions.Value, toolsService, deploymentStore, logger)
+       ILoggerFactory loggerFactory,
+       IDistributedCache distributedCache,
+       IOptions<AIProviderOptions> providerOptions,
+       IAIToolsService toolsService,
+       IOptions<DefaultAIOptions> defaultOptions,
+       IAIDeploymentStore deploymentStore
+       ) : base(OpenAIDeploymentProvider.ProviderName, distributedCache, loggerFactory, providerOptions.Value, defaultOptions.Value, toolsService, deploymentStore)
     {
-        _distributedCache = distributedCache;
     }
 
     protected override string ProviderName
@@ -31,15 +28,7 @@ public sealed class OpenAICompletionService : NamedAICompletionService
 
     protected override IChatClient GetChatClient(AIProviderConnection connection, AICompletionContext context, string deploymentName)
     {
-        var azureClient = new OpenAIClient(connection.GetApiKey())
+        return new OpenAIClient(connection.GetApiKey())
             .AsChatClient(connection.GetDefaultDeploymentName());
-
-        return new ChatClientBuilder(azureClient)
-            .UseDistributedCache(_distributedCache)
-            .UseFunctionInvocation(null, (options) =>
-            {
-                // Set the maximum number of iterations per request to 1 as a safe net to prevent infinite function calling.
-                options.MaximumIterationsPerRequest = 1;
-            }).Build();
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIProfileDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIProfileDisplayDriver.cs
@@ -20,6 +20,7 @@ public sealed class AIProfileDisplayDriver : DisplayDriver<AIProfile>
     private readonly ILiquidTemplateManager _liquidTemplateManager;
     private readonly IAIToolsService _toolsService;
     private readonly IServiceProvider _serviceProvider;
+    private readonly DefaultAIOptions _defaultAIOptions;
     private readonly AIProviderOptions _connectionOptions;
 
     internal readonly IStringLocalizer S;
@@ -30,12 +31,14 @@ public sealed class AIProfileDisplayDriver : DisplayDriver<AIProfile>
         IAIToolsService toolsService,
         IServiceProvider serviceProvider,
         IOptions<AIProviderOptions> connectionOptions,
+        IOptions<DefaultAIOptions> defaultAIOptions,
         IStringLocalizer<AIProfileDisplayDriver> stringLocalizer)
     {
         _profileStore = profileStore;
         _liquidTemplateManager = liquidTemplateManager;
         _toolsService = toolsService;
         _serviceProvider = serviceProvider;
+        _defaultAIOptions = defaultAIOptions.Value;
         _connectionOptions = connectionOptions.Value;
         S = stringLocalizer;
     }
@@ -136,6 +139,7 @@ public sealed class AIProfileDisplayDriver : DisplayDriver<AIProfile>
             model.MaxTokens = metadata.MaxTokens;
             model.TopP = metadata.TopP;
             model.UseCaching = metadata.UseCaching;
+            model.AllowCaching = _defaultAIOptions.EnableDistributedCaching;
 
             model.IsSystemMessageLocked = profile.GetSettings<AIProfileSettings>().LockSystemMessage;
         }).Location("Content:10");
@@ -240,7 +244,11 @@ public sealed class AIProfileDisplayDriver : DisplayDriver<AIProfile>
         metadata.Temperature = parametersModel.Temperature;
         metadata.MaxTokens = parametersModel.MaxTokens;
         metadata.TopP = parametersModel.TopP;
-        metadata.UseCaching = parametersModel.UseCaching;
+
+        if (_defaultAIOptions.EnableDistributedCaching)
+        {
+            metadata.UseCaching = parametersModel.UseCaching;
+        }
 
         var settings = profile.GetSettings<AIProfileSettings>();
 

--- a/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIProfileDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIProfileDisplayDriver.cs
@@ -135,6 +135,7 @@ public sealed class AIProfileDisplayDriver : DisplayDriver<AIProfile>
             model.Temperature = metadata.Temperature;
             model.MaxTokens = metadata.MaxTokens;
             model.TopP = metadata.TopP;
+            model.UseCaching = metadata.UseCaching;
 
             model.IsSystemMessageLocked = profile.GetSettings<AIProfileSettings>().LockSystemMessage;
         }).Location("Content:10");
@@ -239,6 +240,7 @@ public sealed class AIProfileDisplayDriver : DisplayDriver<AIProfile>
         metadata.Temperature = parametersModel.Temperature;
         metadata.MaxTokens = parametersModel.MaxTokens;
         metadata.TopP = parametersModel.TopP;
+        metadata.UseCaching = parametersModel.UseCaching;
 
         var settings = profile.GetSettings<AIProfileSettings>();
 

--- a/src/Modules/CrestApps.OrchardCore.AI/README.md
+++ b/src/Modules/CrestApps.OrchardCore.AI/README.md
@@ -18,7 +18,10 @@ Before utilizing any AI features, ensure the necessary settings are configured. 
         "TopP": 1,
         "FrequencyPenalty": 0,
         "PresencePenalty": 0,
-        "PastMessagesCount": 10
+        "PastMessagesCount": 10,
+        "MaximumIterationsPerRequest": 1,
+        "EnableOpenTelemetry": false,
+        "EnableDistributedCaching": true
       },
       "Providers": {
         "<!-- Provider name goes here -->": {

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/ProfileMetadataViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/ProfileMetadataViewModel.cs
@@ -26,6 +26,8 @@ public class ProfileMetadataViewModel
     [Range(2, 20)]
     public int? PastMessagesCount { get; set; }
 
+    public bool UseCaching { get; set; }
+
     [BindNever]
     public bool IsSystemMessageLocked { get; set; }
 

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/ProfileMetadataViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/ProfileMetadataViewModel.cs
@@ -33,4 +33,7 @@ public class ProfileMetadataViewModel
 
     [BindNever]
     public IEnumerable<SelectListItem> Deployments { get; set; }
+
+    [BindNever]
+    public bool AllowCaching { get; set; }
 }

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/AIProfileParameters.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/AIProfileParameters.Edit.cshtml
@@ -63,15 +63,18 @@
     </div>
 </div>
 
-<div class="@Orchard.GetWrapperClasses()">
-    <div class="@Orchard.GetEndClasses(true)">
-        <div class="form-check">
-            <input type="checkbox" class="form-check-input" asp-for="UseCaching">
-            <label class="form-check-label" asp-for="UseCaching">@T["Use caching"]</label>
-            <span class="hint dashed">@T["When enabled, prompts will utilize semantic caching to reduce AI service costs and improve speed and performance."]</span>
+@if (Model.AllowCaching)
+{
+    <div class="@Orchard.GetWrapperClasses()">
+        <div class="@Orchard.GetEndClasses(true)">
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" asp-for="UseCaching">
+                <label class="form-check-label" asp-for="UseCaching">@T["Use caching"]</label>
+                <span class="hint dashed">@T["When enabled, prompts will utilize semantic caching to reduce AI service costs and improve speed and performance."]</span>
+            </div>
         </div>
     </div>
-</div>
+}
 
 <style asp-name="codemirror"></style>
 <style asp-name="mdecss" asp-src="~/OrchardCore.Markdown/Styles/mde.min.css" debug-src="~/OrchardCore.Markdown/Styles/mde.css"></style>

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/AIProfileParameters.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/AIProfileParameters.Edit.cshtml
@@ -63,6 +63,16 @@
     </div>
 </div>
 
+<div class="@Orchard.GetWrapperClasses()">
+    <div class="@Orchard.GetEndClasses(true)">
+        <div class="form-check">
+            <input type="checkbox" class="form-check-input" asp-for="UseCaching">
+            <label class="form-check-label" asp-for="UseCaching">@T["Use caching"]</label>
+            <span class="hint dashed">@T["When enabled, prompts will utilize semantic caching to reduce AI service costs and improve speed and performance."]</span>
+        </div>
+    </div>
+</div>
+
 <style asp-name="codemirror"></style>
 <style asp-name="mdecss" asp-src="~/OrchardCore.Markdown/Styles/mde.min.css" debug-src="~/OrchardCore.Markdown/Styles/mde.css"></style>
 

--- a/src/Modules/CrestApps.OrchardCore.Ollama/Services/OllamaAIChatCompletionService.cs
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/Services/OllamaAIChatCompletionService.cs
@@ -11,34 +11,23 @@ namespace CrestApps.OrchardCore.AI.Ollama.Services;
 
 public sealed class OllamaAIChatCompletionService : NamedAICompletionService
 {
-    private readonly IDistributedCache _distributedCache;
-
     public OllamaAIChatCompletionService(
-        IAIDeploymentStore deploymentStore,
-        IDistributedCache distributedCache,
-        IOptions<AIProviderOptions> providerOptions,
-        IAIToolsService toolsService,
-        IOptions<DefaultAIOptions> defaultOptions,
-        ILogger<OllamaAIChatCompletionService> logger)
-        : base(OllamaProfileSource.Key, providerOptions.Value, defaultOptions.Value, toolsService, deploymentStore, logger)
+           ILoggerFactory loggerFactory,
+           IDistributedCache distributedCache,
+           IOptions<AIProviderOptions> providerOptions,
+           IAIToolsService toolsService,
+           IOptions<DefaultAIOptions> defaultOptions
+           ) : base(OllamaProfileSource.Key, distributedCache, loggerFactory, providerOptions.Value, defaultOptions.Value, toolsService)
     {
-        _distributedCache = distributedCache;
     }
 
-    protected override string ProviderName => OllamaProfileSource.Key;
+    protected override string ProviderName
+        => OllamaProfileSource.Key;
 
     protected override IChatClient GetChatClient(AIProviderConnection connection, AICompletionContext context, string deploymentName)
     {
         var endpoint = new Uri(connection.GetStringValue("Endpoint"));
 
-        var azureClient = new OllamaChatClient(endpoint, connection.GetDefaultDeploymentName());
-
-        return new ChatClientBuilder(azureClient)
-            .UseDistributedCache(_distributedCache)
-            .UseFunctionInvocation(null, (options) =>
-            {
-                // Set the maximum number of iterations per request to 1 as a safe net to prevent infinite function calling.
-                options.MaximumIterationsPerRequest = 1;
-            }).Build();
+        return new OllamaChatClient(endpoint, connection.GetDefaultDeploymentName());
     }
 }


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the AI completion services within the CrestApps OrchardCore AI project. The changes include adding new properties for caching and telemetry, refactoring the base service classes for better code reuse, and updating dependencies.

### Enhancements and Refactorings:

* **Caching and Telemetry:**
  - Added `UseCaching` property to `AICompletionContext` and `AIProfileMetadata` classes to enable caching. [[1]](diffhunk://#diff-5a1817428d3e67f12d461848b79f128cb652f758a6173defc6a5a520884fcd28R14-R15) [[2]](diffhunk://#diff-60f0fbb99a90d48413d5c7439ec260a53c6b8a1a0aa58977f731571eb0cdcbc5R18-R19)
  - Introduced `EnableOpenTelemetry` and `EnableDistributedCaching` properties in `DefaultAIOptions` class.

* **Refactoring Base Services:**
  - Created `AICompletionServiceBase` abstract class to encapsulate common logic for AI completion services.
  - Introduced `DeploymentNamedAICompletionService` class for services that require deployment-specific logic.

* **Dependency Updates:**
  - Updated `Microsoft.Extensions.AI.Abstractions` to `Microsoft.Extensions.AI` in the project file.

* **Service-Specific Changes:**
  - Modified `NamedAICompletionService` to inherit from `AICompletionServiceBase` and refactored methods to use new properties and methods. [[1]](diffhunk://#diff-d3b6007d7da4c95601d4dc8596bed829ece4fd772ff63b93c0eb7bd6de22812dR4-R104) [[2]](diffhunk://#diff-d3b6007d7da4c95601d4dc8596bed829ece4fd772ff63b93c0eb7bd6de22812dL123-R128) [[3]](diffhunk://#diff-d3b6007d7da4c95601d4dc8596bed829ece4fd772ff63b93c0eb7bd6de22812dL157-R178)
  - Updated `DeepSeekAICompletionService` to inherit from `DeploymentNamedAICompletionService` and refactored accordingly.
  - Refactored `AzureAISearchCompletionService` to inherit from `AICompletionServiceBase` and use common logic. [[1]](diffhunk://#diff-185227a0a56c5a7bb27f7f04bdb098e0681935044d714f5fedfa7f38de4fd5abR10) [[2]](diffhunk://#diff-185227a0a56c5a7bb27f7f04bdb098e0681935044d714f5fedfa7f38de4fd5abL24-L31) [[3]](diffhunk://#diff-185227a0a56c5a7bb27f7f04bdb098e0681935044d714f5fedfa7f38de4fd5abR46-L50) [[4]](diffhunk://#diff-185227a0a56c5a7bb27f7f04bdb098e0681935044d714f5fedfa7f38de4fd5abL62-R68)