### PR TITLE
Fix Typo

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI/Views/AIProfileParameters.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/AIProfileParameters.Edit.cshtml
@@ -10,7 +10,7 @@
 <div class="@Orchard.GetWrapperClasses()">
     <label asp-for="SystemMessage" class="@Orchard.GetLabelClasses()">@T["System description"]</label>
     <div class="@Orchard.GetEndClasses()">
-        <div class="hint mb-1 mt-2">@T["The system message in DeepSeek sets the AI's behavior and response style, guiding how it interacts in a conversation."]</div>
+        <div class="hint mb-1 mt-2">@T["The system message sets the AI's behavior and response style, guiding how it interacts in a conversation."]</div>
         <textarea asp-for="SystemMessage" class="form-control content-preview-text" rows="5" disabled="@Model.IsSystemMessageLocked"></textarea>
     </div>
 </div>


### PR DESCRIPTION
This pull request includes a minor change to the `AIProfileParameters.Edit.cshtml` file. The change updates the hint text to remove the reference to "DeepSeek" in the system message description.

* [`src/Modules/CrestApps.OrchardCore.AI/Views/AIProfileParameters.Edit.cshtml`](diffhunk://#diff-e896d539c7ac94679e00eabf6ea876fcc5ff6cddce1bdf3c2feadc0e4092b6eaL13-R13): Updated the hint text to remove the reference to "DeepSeek" in the system message description.