### PR TITLE
Relable Connections menu item to Providers Connections

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI/README.md
+++ b/src/Modules/CrestApps.OrchardCore.AI/README.md
@@ -62,7 +62,7 @@ The **AI Connection Management** feature enhances **AI Services** by providing a
 
 1. **Navigate to AI Settings**  
    - Go to **"Artificial Intelligence"** in the admin menu.  
-   - Click **"Connections"** to configure a new connection.  
+   - Click **"Provider Connections"** to configure a new connection.  
 
 2. **Add a New Connection**  
    - Click **"Add Connection"**, select a provider, and enter the required details.  

--- a/src/Modules/CrestApps.OrchardCore.AI/Services/AIConnectionsAdminMenu.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Services/AIConnectionsAdminMenu.cs
@@ -17,7 +17,7 @@ public sealed class AIConnectionsAdminMenu : AdminNavigationProvider
     {
         builder
             .Add(S["Artificial Intelligence"], ai => ai
-                .Add(S["Connections"], S["Connections"].PrefixPosition(), connections => connections
+                .Add(S["Provider Connections"], S["Provider Connections"].PrefixPosition(), connections => connections
                     .AddClass("openai-connections")
                     .Id("openaiConnection")
                     .Action("Index", "ProviderConnections", AIConstants.Feature.Area)


### PR DESCRIPTION
This pull request updates the terminology for AI connection management in the `CrestApps.OrchardCore.AI` module to improve clarity. The term "Connections" has been replaced with "Provider Connections" in both the user interface and internal code references.

### Updates to terminology:

* Updated the user-facing label in the README documentation to replace **"Connections"** with **"Provider Connections"** for configuring new AI service connections. (`src/Modules/CrestApps.OrchardCore.AI/README.md`, [src/Modules/CrestApps.OrchardCore.AI/README.mdL65-R65](diffhunk://#diff-69fd55cd5c82dc5ddfd2b7a9abfcff4135dd2a4db1527739915278147fc44a75L65-R65))
* Modified the admin menu in the code to reflect the change from **"Connections"** to **"Provider Connections"**, ensuring consistency in the navigation structure. (`src/Modules/CrestApps.OrchardCore.AI/Services/AIConnectionsAdminMenu.cs`, [src/Modules/CrestApps.OrchardCore.AI/Services/AIConnectionsAdminMenu.csL20-R20](diffhunk://#diff-bb3deab726b40e8544a47a16c0d23ff9dcce0f59e2538c9132826b51de8d0675L20-R20))