### PR TITLE
Ignore bad AI Settings

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI/Services/AIProviderOptionsConfiguration.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Services/AIProviderOptionsConfiguration.cs
@@ -32,84 +32,91 @@ internal sealed class AIProviderOptionsConfiguration : IConfigureOptions<AIProvi
             return;
         }
 
-        var providerSettingsElements = JsonSerializer.Deserialize<JsonElement>(providerSettings.AsJsonNode());
-
-        var providerSettingsObject = JsonObject.Create(providerSettingsElements);
-
-        if (providerSettingsObject is null)
+        try
         {
-            _logger.LogWarning("The 'providers' in 'CrestApps_AI:Providers' is invalid.");
+            var providerSettingsElements = JsonSerializer.Deserialize<JsonElement>(providerSettings.AsJsonNode());
 
-            return;
+            var providerSettingsObject = JsonObject.Create(providerSettingsElements);
+
+            if (providerSettingsObject is null)
+            {
+                _logger.LogWarning("The 'providers' in 'CrestApps_AI:Providers' is invalid.");
+
+                return;
+            }
+
+            foreach (var providerPair in providerSettingsObject)
+            {
+                var providerName = providerPair.Key;
+                var providerNode = providerPair.Value;
+
+                var connectionsNode = providerNode["Connections"];
+
+                if (connectionsNode is null)
+                {
+                    _logger.LogWarning("The provider with the name '{Name}' has no connections. This provider will be ignore and not used.", providerName);
+
+                    continue;
+                }
+
+                var collectionsElement = JsonSerializer.Deserialize<JsonElement>(connectionsNode);
+
+                var connectionsObject = JsonObject.Create(collectionsElement);
+
+                if (connectionsObject is null || connectionsObject.Count == 0)
+                {
+                    _logger.LogWarning("The provider with the name '{Name}' has no connection. This provider will be ignore and not used.", providerName);
+
+                    continue;
+                }
+
+                var connections = new Dictionary<string, AIProviderConnectionEntry>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var connectionPair in connectionsObject)
+                {
+                    connections.Add(connectionPair.Key, connectionPair.Value.Deserialize<AIProviderConnectionEntry>());
+                }
+
+                if (connections.Count == 0)
+                {
+                    _logger.LogWarning("The provider with the name '{Name}' has no valid connections. This provider will be ignore and not used.", providerName);
+
+                    continue;
+                }
+
+                var provider = new AIProvider()
+                {
+                    Connections = connections,
+                };
+
+                var defaultConnectionName = providerNode["DefaultConnectionName"]?.GetValue<string>();
+
+                if (!string.IsNullOrEmpty(defaultConnectionName))
+                {
+                    provider.DefaultConnectionName = defaultConnectionName;
+                }
+                else
+                {
+                    provider.DefaultConnectionName = connections.FirstOrDefault().Key;
+                }
+
+                var defaultDeploymentName = providerNode["DefaultDeploymentName"]?.GetValue<string>();
+
+                if (!string.IsNullOrEmpty(defaultDeploymentName))
+                {
+                    provider.DefaultDeploymentName = defaultDeploymentName;
+                }
+                else
+                {
+                    provider.DefaultDeploymentName = connections.FirstOrDefault().Value?.GetDefaultDeploymentName(false);
+                }
+
+                options.Providers.Add(providerName, provider);
+            }
         }
-
-        foreach (var providerPair in providerSettingsObject)
+        catch (Exception ex)
         {
-            var providerName = providerPair.Key;
-            var providerNode = providerPair.Value;
-
-            var connectionsNode = providerNode["Connections"];
-
-            if (connectionsNode is null)
-            {
-                _logger.LogWarning("The provider with the name '{Name}' has no connections. This provider will be ignore and not used.", providerName);
-
-                continue;
-            }
-
-            var collectionsElement = JsonSerializer.Deserialize<JsonElement>(connectionsNode);
-
-            var connectionsObject = JsonObject.Create(collectionsElement);
-
-            if (connectionsObject is null || connectionsObject.Count == 0)
-            {
-                _logger.LogWarning("The provider with the name '{Name}' has no connection. This provider will be ignore and not used.", providerName);
-
-                continue;
-            }
-
-            var connections = new Dictionary<string, AIProviderConnectionEntry>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var connectionPair in connectionsObject)
-            {
-                connections.Add(connectionPair.Key, connectionPair.Value.Deserialize<AIProviderConnectionEntry>());
-            }
-
-            if (connections.Count == 0)
-            {
-                _logger.LogWarning("The provider with the name '{Name}' has no valid connections. This provider will be ignore and not used.", providerName);
-
-                continue;
-            }
-
-            var provider = new AIProvider()
-            {
-                Connections = connections,
-            };
-
-            var defaultConnectionName = providerNode["DefaultConnectionName"]?.GetValue<string>();
-
-            if (!string.IsNullOrEmpty(defaultConnectionName))
-            {
-                provider.DefaultConnectionName = defaultConnectionName;
-            }
-            else
-            {
-                provider.DefaultConnectionName = connections.FirstOrDefault().Key;
-            }
-
-            var defaultDeploymentName = providerNode["DefaultDeploymentName"]?.GetValue<string>();
-
-            if (!string.IsNullOrEmpty(defaultDeploymentName))
-            {
-                provider.DefaultDeploymentName = defaultDeploymentName;
-            }
-            else
-            {
-                provider.DefaultDeploymentName = connections.FirstOrDefault().Value?.GetDefaultDeploymentName(false);
-            }
-
-            options.Providers.Add(providerName, provider);
+            _logger.LogError(ex, "Invalid 'CrestApps_AI:Providers' configuration. Please refer to the documentation for instructions on how to set it up correctly.");
         }
     }
 }


### PR DESCRIPTION
Fix #88

This pull request enhances error handling in the `Configure` method of the `AIProviderOptionsConfiguration` class by adding a `try-catch` block to manage potential exceptions during deserialization and provider configuration. The key changes include wrapping the configuration logic in a `try` block and logging errors with a descriptive message when exceptions occur.

### Error handling improvements:

* Added a `try-catch` block around the deserialization and configuration logic in the `Configure` method to handle exceptions gracefully. [[1]](diffhunk://#diff-2be2995f795364f1703c8cbd063859c5e535c555da40ebced6730bc3f3599324R35-R36) [[2]](diffhunk://#diff-2be2995f795364f1703c8cbd063859c5e535c555da40ebced6730bc3f3599324R117-R121)
* Introduced error logging using `_logger.LogError` to provide a clear message when the `CrestApps_AI:Providers` configuration is invalid, along with a reference to the documentation for setup guidance.