### PR TITLE
Update AI packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,11 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Miscellaneous Packages -->
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="9.2.1" />
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="9.3.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.13.2" />
+    <PackageVersion Include="OllamaSharp" Version="5.1.18" />
     <PackageVersion Include="YesSql.Abstractions" Version="5.1.1" />
-    <PackageVersion Include="ModelContextProtocol" Version="0.1.0-preview.13" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.2.0-preview.1" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.1.0-preview.7" />
   </ItemGroup>
   <ItemGroup>
@@ -64,26 +65,25 @@
   <ItemGroup>
     <!-- Microsoft Packages -->
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.2.0-beta.4" />
-    <PackageVersion Include="Azure.Identity" Version="1.13.2" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.0" />
     <PackageVersion Include="Azure.ResourceManager.CognitiveServices" Version="1.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Core" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.5.0-preview.1.25262.9" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0-preview.1.25262.9" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Ollama" Version="9.5.0-preview.1.25262.9" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.5.0-preview.1.25262.9" />
-    <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.5.0-preview.1.25262.9" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.5.0-preview.1.25265.7" />
+    <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.5.0-preview.1.25265.7" />
   </ItemGroup>
   <ItemGroup>
     <!-- Testing Packages -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Aspire Packages -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="9.3.0" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="9.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/IMcpClientTransportProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/IMcpClientTransportProvider.cs
@@ -1,5 +1,5 @@
 using CrestApps.OrchardCore.AI.Mcp.Core.Models;
-using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Client;
 
 namespace CrestApps.OrchardCore.AI.Mcp.Core;
 

--- a/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/McpService.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/McpService.cs
@@ -1,7 +1,6 @@
 using CrestApps.OrchardCore.AI.Mcp.Core.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
-using ModelContextProtocol.Protocol.Transport;
 
 namespace CrestApps.OrchardCore.AI.Mcp.Core;
 

--- a/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/Services/SseClientTransportProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/Services/SseClientTransportProvider.cs
@@ -1,5 +1,5 @@
 using CrestApps.OrchardCore.AI.Mcp.Core.Models;
-using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Client;
 using OrchardCore.Entities;
 
 namespace CrestApps.OrchardCore.AI.Mcp.Core.Services;
@@ -8,7 +8,7 @@ public sealed class SseClientTransportProvider : IMcpClientTransportProvider
 {
     public bool CanHandle(McpConnection connection)
         => connection.Source == McpConstants.TransportTypes.Sse;
-    
+
     public IClientTransport Get(McpConnection connection)
     {
         var metadata = connection.As<SseMcpConnectionMetadata>();

--- a/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/Services/StdioClientTransportProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/Services/StdioClientTransportProvider.cs
@@ -1,5 +1,5 @@
 using CrestApps.OrchardCore.AI.Mcp.Core.Models;
-using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Client;
 using OrchardCore.Entities;
 
 namespace CrestApps.OrchardCore.AI.Mcp.Core.Services;

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpConnectionFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpConnectionFields.Edit.cshtml
@@ -1,6 +1,5 @@
 @using CrestApps.OrchardCore.AI.Mcp.Core
 @using CrestApps.OrchardCore.AI.Mcp.ViewModels
-@using ModelContextProtocol.Protocol.Transport
 @using OrchardCore
 
 @model McpConnectionFieldsViewModel

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/SseMcpConnectionFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/SseMcpConnectionFields.Edit.cshtml
@@ -1,6 +1,5 @@
 @using CrestApps.OrchardCore.AI.Mcp.Core
 @using CrestApps.OrchardCore.AI.Mcp.ViewModels
-@using ModelContextProtocol.Protocol.Transport
 @using OrchardCore
 
 @model SseConnectionFieldsViewModel

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/StdioMcpConnectionFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/StdioMcpConnectionFields.Edit.cshtml
@@ -1,6 +1,5 @@
 @using CrestApps.OrchardCore.AI.Mcp.Core
 @using CrestApps.OrchardCore.AI.Mcp.ViewModels
-@using ModelContextProtocol.Protocol.Transport
 @using OrchardCore
 
 @model StdioConnectionFieldsViewModel

--- a/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI" />
-    <PackageReference Include="Microsoft.Extensions.AI.Ollama" />
+    <PackageReference Include="OllamaSharp" />
     <PackageReference Include="OrchardCore.Module.Targets" />
     <PackageReference Include="OrchardCore.ContentManagement" />
     <PackageReference Include="OrchardCore.ContentTypes.Abstractions" />

--- a/src/Modules/CrestApps.OrchardCore.Ollama/Services/OllamaAIChatCompletionClient.cs
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/Services/OllamaAIChatCompletionClient.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OllamaSharp;
 
 namespace CrestApps.OrchardCore.Ollama.Services;
 
@@ -27,6 +28,6 @@ internal sealed class OllamaAIChatCompletionClient : NamedAICompletionClient
 
     protected override IChatClient GetChatClient(AIProviderConnectionEntry connection, AICompletionContext context, string deploymentName)
     {
-        return new OllamaChatClient(connection.GetEndpoint(), connection.GetDefaultDeploymentName());
+        return new OllamaApiClient(connection.GetEndpoint(), connection.GetDefaultDeploymentName());
     }
 }


### PR DESCRIPTION
This pull request includes updates to package dependencies and refactors to replace the `ModelContextProtocol.Protocol.Transport` namespace with `ModelContextProtocol.Client`. Additionally, it introduces the `OllamaSharp` library to replace `Microsoft.Extensions.AI.Ollama`. Below are the most important changes grouped by theme:

### Dependency Updates:
* Updated several package versions in `Directory.Packages.props`, including `Aspire.Hosting.MongoDB` (9.2.1 → 9.3.0), `Azure.Identity` (1.13.2 → 1.14.0), and `Microsoft.NET.Test.Sdk` (17.13.0 → 17.14.0). Also replaced `Microsoft.Extensions.AI.Ollama` with `OllamaSharp`. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L9-R13) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L67-R86)

### Namespace Refactoring:
* Replaced `ModelContextProtocol.Protocol.Transport` with `ModelContextProtocol.Client` across multiple files, including `IMcpClientTransportProvider.cs`, `McpService.cs`, and several service and view files. [[1]](diffhunk://#diff-57ad6346d7cb5ee5e31cb590778766b3dacc790b8e477106984a6f63c688d212L2-R2) [[2]](diffhunk://#diff-1bf6957ca8ef6dff337fefe33704c4ec40c723c8d08b0752f75a9686a66043e1L4) [[3]](diffhunk://#diff-016daf9857a3316f409729fbaf13da3872e0431fc586602bc63b1fb190527563L2-R2) [[4]](diffhunk://#diff-3b8f67680432ccd7b93b4b8257e603e19e4bdafb625384d55136e2135e5ffc20L2-R2) [[5]](diffhunk://#diff-9b4bde4a8ab51bde7917bf39d7b7a49b1e1ad6700d5d097d0a87990ff74e5453L3) [[6]](diffhunk://#diff-93fdb955f07236ca4f5c6f86852a7936b83b3973d5f2940310b8e64a317812aeL3) [[7]](diffhunk://#diff-0367eb5e36376e615f324c7c18514eeb3118eb83d87bbfa22d8f74a374e7d398L3)

### Ollama Integration:
* Updated `CrestApps.OrchardCore.Ollama.csproj` to use `OllamaSharp` instead of `Microsoft.Extensions.AI.Ollama`.
* Replaced `OllamaChatClient` with `OllamaApiClient` in `OllamaAIChatCompletionClient.cs` to align with the new library.