### PR TITLE
Align Elasticsearch configurations with Elasticsearch v3

### DIFF
--- a/src/Core/CrestApps.OrchardCore.OpenAI.Azure.Core/Elasticsearch/ElasticsearchServerOptions.cs
+++ b/src/Core/CrestApps.OrchardCore.OpenAI.Azure.Core/Elasticsearch/ElasticsearchServerOptions.cs
@@ -48,24 +48,24 @@ public sealed class ElasticsearchServerOptions
 
     /// <summary>
     /// The authentication-type used by the data-source.
-    /// Supports: `encoded_api_key` and `key_and_key_id`.
+    /// Supports: `Base64ApiKey` and `KeyIdAndKey`.
     /// </summary>
     public string AuthenticationType { get; set; }
 
     /// <summary>
-    /// When using `key_and_key_id` authentication-type, this is the key-id.
+    /// Required when using `KeyIdAndKey` authentication type, this is the key-id.
     /// </summary>
     public string KeyId { get; set; }
 
     /// <summary>
-    /// When using `key_and_key_id` authentication-type, this is the key.
+    /// Required when using `KeyIdAndKey` authentication type, this is the key.
     /// </summary>
     public string Key { get; set; }
 
     /// <summary>
-    /// When using `encoded_api_key` authentication-type, this is the encoded key.
+    /// Required when using `Base64ApiKey` authentication type, this is the encoded key.
     /// </summary>
-    public string EncodedApiKey { get; set; }
+    public string Base64ApiKey { get; set; }
 
     /// <summary>
     /// Whether the configuration section exists.

--- a/src/Core/CrestApps.OrchardCore.OpenAI.Azure.Core/Elasticsearch/Handlers/ElasticsearchOpenAIDataSourceHandler.cs
+++ b/src/Core/CrestApps.OrchardCore.OpenAI.Azure.Core/Elasticsearch/Handlers/ElasticsearchOpenAIDataSourceHandler.cs
@@ -90,13 +90,13 @@ public sealed class ElasticsearchOpenAIDataSourceHandler : IAzureOpenAIDataSourc
 
         if (_elasticsearchOptions.AuthenticationType is not null)
         {
-            if (string.Equals("key_and_key_id", _elasticsearchOptions.AuthenticationType, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals("KeyIdAndKey", _elasticsearchOptions.AuthenticationType, StringComparison.OrdinalIgnoreCase))
             {
                 credentials = DataSourceAuthentication.FromKeyAndKeyId(_elasticsearchOptions.Key, _elasticsearchOptions.KeyId);
             }
-            else if (string.Equals("encoded_api_key", _elasticsearchOptions.AuthenticationType, StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals("Base64ApiKey", _elasticsearchOptions.AuthenticationType, StringComparison.OrdinalIgnoreCase))
             {
-                credentials = DataSourceAuthentication.FromEncodedApiKey(_elasticsearchOptions.EncodedApiKey);
+                credentials = DataSourceAuthentication.FromEncodedApiKey(_elasticsearchOptions.Base64ApiKey);
             }
         }
 

--- a/src/Modules/CrestApps.OrchardCore.OpenAI.Azure/README.md
+++ b/src/Modules/CrestApps.OrchardCore.OpenAI.Azure/README.md
@@ -231,24 +231,24 @@ If your Elasticsearch cluster has security enabled, you’ll also need to genera
 
 You can use this key in one of two ways:
 
-##### Option 1: Using `encoded_api_key`
+##### Option 1: Using `Base64ApiKey`
 
-Use the Base64-encoded key directly by setting `AuthenticationType` to `encoded_api_key`. For example, in your `appsettings.json`:
+Use the Base64-encoded key directly by setting `AuthenticationType` to `Base64ApiKey`. For example, in your `appsettings.json`:
 
 ```json
 {
   "OrchardCore": {
     "OrchardCore_Elasticsearch": {
-      "AuthenticationType": "encoded_api_key",
-      "EncodedApiKey": "<!-- Base64 encoded key -->"
+      "AuthenticationType": "Base64ApiKey",
+      "Base64ApiKey": "<!-- Base64 encoded key -->"
     }
   }
 }
 ```
 
-##### Option 2: Using `key_and_key_id`
+##### Option 2: Using `KeyIdAndKey`
 
-You can also use the `key_and_key_id` authentication type, which requires both the API key ID and the key itself.
+You can also use the `KeyIdAndKey` authentication type, which requires both the API key ID and the key itself.
 
 To obtain these:
 
@@ -270,7 +270,7 @@ Then configure `appsettings.json` like this:
 {
   "OrchardCore": {
     "OrchardCore_Elasticsearch": {
-      "AuthenticationType": "key_and_key_id",
+      "AuthenticationType": "KeyIdAndKey",
       "KeyId": "<!-- Key ID -->",
       "Key": "<!-- Key -->"
     }


### PR DESCRIPTION
This pull request updates the naming conventions for authentication types in the Elasticsearch configuration to improve clarity and consistency. The changes include renaming authentication types and related properties, updating logic in the handler class, and reflecting these changes in the documentation.

### Updates to authentication types and properties:
* Renamed `encoded_api_key` to `Base64ApiKey` and `key_and_key_id` to `KeyIdAndKey` in the `AuthenticationType` property and associated fields (`KeyId`, `Key`, and `Base64ApiKey`) in `ElasticsearchServerOptions`.

### Updates to handler logic:
* Updated conditional checks in `ElasticsearchOpenAIDataSourceHandler` to use the new authentication type names (`Base64ApiKey` and `KeyIdAndKey`) and their corresponding properties (`Base64ApiKey` and `KeyId`).

### Documentation updates:
* Updated the README to reflect the new authentication type names (`Base64ApiKey` and `KeyIdAndKey`) and their usage in `appsettings.json`. [[1]](diffhunk://#diff-64e3732f502b35b2f0c6699a0a85e0808e0cd4ee7654db521d72e049f67465a7L234-R251) [[2]](diffhunk://#diff-64e3732f502b35b2f0c6699a0a85e0808e0cd4ee7654db521d72e049f67465a7L273-R273)