### PR TITLE
NEST-596: Inherit parent props file if one exists. For example to override TargetFrameworks.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -109,4 +109,8 @@
     <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
 
   </PropertyGroup>
+
+  <!-- Inherit parent props file if one exists. For example to override TargetFrameworks. -->
+  <Import Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+          Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 </Project>


### PR DESCRIPTION
Fix #120 