### PR TITLE
Add a workaround for the [RequiredFeatures("")] issue

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI.Agent/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Agent/Startup.cs
@@ -11,6 +11,7 @@ using CrestApps.OrchardCore.AI.Agent.Workflows;
 using CrestApps.OrchardCore.AI.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using OrchardCore.Environment.Shell;
 using OrchardCore.Modules;
 
 namespace CrestApps.OrchardCore.AI.Agent;
@@ -81,15 +82,27 @@ public sealed class RecipesStartup : StartupBase
 [RequireFeatures(AIConstants.Feature.OrchardCoreAIAgent, "OrchardCore.Tenants")]
 public sealed class TenantsStartup : StartupBase
 {
+    private readonly ShellSettings _shellSettings;
+
     internal readonly IStringLocalizer S;
 
-    public TenantsStartup(IStringLocalizer<TenantsStartup> stringLocalizer)
+    public TenantsStartup(
+        ShellSettings shellSettings,
+        IStringLocalizer<TenantsStartup> stringLocalizer)
     {
+        _shellSettings = shellSettings;
         S = stringLocalizer;
     }
 
     public override void ConfigureServices(IServiceCollection services)
     {
+        if (!_shellSettings.IsDefaultShell())
+        {
+            // This check is added as a workaround for the issue described
+            // at: https://github.com/OrchardCMS/OrchardCore/issues/18194
+            return;
+        }
+
         services.AddAITool<ListStartupRecipesTool>(ListStartupRecipesTool.TheName, (o) =>
         {
             o.Title = S["List Startup Recipes"];


### PR DESCRIPTION
This is a workaround for the issue described at https://github.com/OrchardCMS/OrchardCore/issues/18194

This pull request introduces several updates, including dependency version adjustments, new functionality, and cleanup tasks. Key changes involve updating package versions, enhancing module startup behavior, adding a cleanup script, and refining code for consistency. Below is a categorized summary of the most important changes:

### Dependency and Framework Updates:
* Updated `OrchardCoreVersion` to target version range `[2.1.0, 2.2.0)` in `Directory.Packages.props`. This ensures compatibility with the latest stable Orchard Core release.
* Upgraded `YesSql.Abstractions` to version `5.3.0` and added `YesSql.Core` version `5.3.0` in `Directory.Packages.props`.
* Added `Microsoft.AspNetCore.Authentication.OpenIdConnect` version `8.0.10` for `.NET 8.0` in `Directory.Packages.props`.

### Build and Project Configuration:
* Introduced conditional import in `Directory.Build.props` to inherit parent properties, allowing overrides such as `TargetFrameworks`.

### Codebase Enhancements:
* Added a check in `TenantsStartup` (`Startup.cs`) to skip configuration for non-default shells, addressing an issue with Orchard Core tenants.
* Updated `EditProfileTools.Edit.cshtml` to use the `@Model` prefix for consistency in Razor syntax.

### Documentation Updates:
* Updated `README.md` to reflect the new Orchard Core version dependency and removed instructions for adding a preview package feed, streamlining the documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-L159)

### Utility Additions:
* Added a `cleanup.bat` script to recursively delete `bin` and `obj` folders, simplifying local development cleanup tasks.