### PR TITLE
Make CrestApps.OrchardCore.Resources available via dependency only (release/1.2 branch)

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI/CrestApps.OrchardCore.AI.csproj
+++ b/src/Modules/CrestApps.OrchardCore.AI/CrestApps.OrchardCore.AI.csproj
@@ -38,4 +38,13 @@
     <ProjectReference Include="..\..\Core\CrestApps.OrchardCore.SignalR.Core\CrestApps.OrchardCore.SignalR.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- 
+      Ensure this module directly depends on the required package so that when someone installs it, 
+      they won't need to manually include the Resources. 
+      This guarantees the module functions correctly and resolves the feature dependency.
+    -->
+    <ProjectReference Include="..\CrestApps.OrchardCore.Resources\CrestApps.OrchardCore.Resources.csproj" PrivateAssets="none" />
+  </ItemGroup>
+
 </Project>

--- a/src/Modules/CrestApps.OrchardCore.AI/Manifest.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Manifest.cs
@@ -14,7 +14,11 @@ using OrchardCore.Modules.Manifest;
     Name = "AI Services",
     Description = "Provides AI services.",
     Category = "Artificial Intelligence",
-    EnabledByDependencyOnly = true
+    EnabledByDependencyOnly = true,
+    Dependencies =
+    [
+        "CrestApps.OrchardCore.Resources",
+    ]
 )]
 
 [assembly: Feature(

--- a/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
@@ -63,7 +63,6 @@ public sealed class Startup : StartupBase
             .AddDisplayDriver<AIProfile, AIProfileToolsDisplayDriver>()
             .AddScoped<IAICompletionServiceHandler, FunctionInvocationAICompletionServiceHandler>();
 
-
 #pragma warning disable CS0618 // Type or member is obsolete
         services.AddDataMigration<ProfileStoreMigrations>();
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Modules/CrestApps.OrchardCore.Resources/Manifest.cs
+++ b/src/Modules/CrestApps.OrchardCore.Resources/Manifest.cs
@@ -12,5 +12,5 @@ using OrchardCore.Modules.Manifest;
     [
         "OrchardCore.Resources",
     ],
-    IsAlwaysEnabled = true
+    IsAlwaysEnabled = false
 )]


### PR DESCRIPTION
Fixes the following issues in `release/1.2` branch:

Fix https://github.com/CrestApps/CrestApps.OrchardCore/issues/141
Fix https://github.com/CrestApps/CrestApps.OrchardCore/issues/140

