### PR TITLE
Fix MCP resources and improbe the sample project

### DIFF
--- a/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/McpResourceUri.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Mcp.Core/McpResourceUri.cs
@@ -23,10 +23,13 @@ public static partial class McpResourceUri
     {
         variables = null;
 
-        if (string.IsNullOrEmpty(uriTemplate) || string.IsNullOrEmpty(actualUri))
+        if (string.IsNullOrWhiteSpace(uriTemplate) || string.IsNullOrWhiteSpace(actualUri))
         {
             return false;
         }
+
+        uriTemplate = uriTemplate.Trim();
+        actualUri = actualUri.Trim();
 
         // Collect all variable matches first so we know which is the last one.
         var matches = new List<(int Index, int Length, string Name)>();
@@ -101,7 +104,7 @@ public static partial class McpResourceUri
     /// </summary>
     public static bool IsTemplate(string uri)
     {
-        return !string.IsNullOrEmpty(uri) && uri.Contains('{');
+        return !string.IsNullOrWhiteSpace(uri) && uri.AsSpan().Trim().Contains('{');
     }
 
     [GeneratedRegex(@"\{(\w+)\}")]

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/mcp/server.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/mcp/server.md
@@ -29,20 +29,52 @@ The MCP server exposes the following capabilities:
 
 ## Prompt Support
 
-The MCP server exposes MCP prompts registered in Orchard Core. Prompts can be:
+MCP **Prompts** are reusable prompt templates that MCP clients can discover and invoke. They allow you to define pre-configured system or user messages that external AI agents can request on demand — for example, a "summarize" prompt that instructs the model to summarize a given document, or a "translate" prompt that translates text into a target language.
 
-- Created and managed via the admin UI under **Artificial Intelligence → MCP Prompts**
-- Registered programmatically in code
-- Discovered by external MCP clients via `ListPrompts` and invoked via `GetPrompt`
+Prompts are listed by clients via `ListPrompts` and invoked via `GetPrompt`, which returns the prompt messages for the client to include in its conversation.
+
+### Managing Prompts via Admin UI
+
+1. Navigate to **Artificial Intelligence** → **MCP Prompts**
+2. Click **Add Prompt** to create a new prompt
+3. Fill in the required fields:
+   - **Name**: A unique identifier for the prompt (used by MCP clients to reference it)
+   - **Display Text**: A human-readable name shown in the admin list
+   - **Description**: Optional description that helps clients understand what the prompt does
+4. Add one or more **Messages** to the prompt:
+   - Each message has a **Role** (e.g., `system`, `user`) and **Content** (the message text)
+   - Messages are returned in order when a client calls `GetPrompt`
+5. Save the prompt
+
+Prompts can also be registered programmatically in code or imported via recipes.
 
 ## Resource Support
 
-The MCP server exposes MCP resources registered in Orchard Core, allowing clients to access various data sources through the MCP protocol.
+MCP **Resources** represent data that MCP clients can read. A resource has a URI that the client uses to request its content. Resources come in two flavors:
+
+- **Static Resources**: Have a fixed URI with no variable placeholders (e.g., `recipe-schema://abc123/recipe`). They return the same data every time and appear in `ListResources`.
+- **Templated Resources**: Have a URI containing `{variable}` placeholders (e.g., `file://abc123/{fileName}`). The client fills in the variables when reading the resource. These appear in `ListResourceTemplates` and allow dynamic content resolution.
 
 Resources can be:
-- Created and managed via the admin UI under **Artificial Intelligence → MCP Resources**
+- Created and managed via the admin UI under **Artificial Intelligence** → **MCP Resources**
 - Registered programmatically in code
 - Discovered and accessed by external MCP clients
+
+### Managing Resources via Admin UI
+
+1. Navigate to **Artificial Intelligence** → **MCP Resources**
+2. Click **Add Resource** to create a new resource
+3. Select a **Resource Type** (e.g., File, Content Item, Recipe Step Schema). Each type defines what kind of data the resource serves and which URI variables are available.
+4. Fill in the required fields:
+   - **Display Text**: A friendly name for the resource shown in the admin list
+   - **Path**: The path portion of the URI. For templated resources, include variable placeholders from the supported variables list shown in the UI (e.g., `{fileName}`, `{contentType}`)
+   - **Name**: The MCP resource name (used by clients to identify the resource)
+   - **Title**: Optional human-readable title
+   - **Description**: Optional description that helps clients understand the resource
+   - **MIME Type**: The content type of the resource (e.g., `application/json`, `text/plain`)
+5. Save the resource
+
+The system automatically constructs the full URI by prepending the scheme and a unique resource ID to your path. For example, if you select the **File** resource type and enter `{fileName}` as the path, the full URI might be `file://abc123/{fileName}`.
 
 ### Built-in Resource Types
 
@@ -71,20 +103,6 @@ Each resource instance has a URI that is auto-constructed by the system as:
 - **`{path}`**: the user-defined path portion with optional variable placeholders
 
 When creating a resource in the admin UI, you only provide the **path** portion. The system automatically prepends the scheme and resource ID.
-
-### Creating Resources via Admin UI
-
-1. Navigate to **Artificial Intelligence** → **MCP Resources**
-2. Click **Add Resource**
-3. Select a resource type (e.g., File, Content Item, Recipe Step Schema)
-4. Fill in the required fields:
-   - **Display Text**: A friendly name for the resource
-   - **Path**: The path portion of the URI, using any supported variables shown in the UI
-   - **Name**: The MCP resource name (used by clients)
-   - **Title**: Optional human-readable title
-   - **Description**: Optional description
-   - **MIME Type**: Content type of the resource
-5. Save the resource
 
 ### Registering Custom Resource Types
 

--- a/src/CrestApps.OrchardCore.Documentations/docs/changelog/v2.0.0.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/changelog/v2.0.0.md
@@ -90,6 +90,8 @@ A new suite of modules for multi-channel communication:
 - **MCP Prompts and Resources** — Prompts and resources can be added and managed via the admin UI.
 - **Templated Resources** — Support for dynamic MCP resources defined with URI templates.
 - **Stdio Transport** — Connect to local MCP servers (e.g., Docker containers) via Standard Input/Output.
+- **Template URI Whitespace Handling** — Resource URI templates and incoming URIs are now trimmed of leading/trailing whitespace before matching, preventing mismatches caused by accidental spaces in URI definitions.
+- **File Resource Directory Rejection** — The file resource handler now returns a descriptive error when the resolved path is a directory instead of a file, rather than attempting to read directory content.
 
 ### AI Agent (`CrestApps.OrchardCore.AI.Agent`)
 

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Drivers/McpResourceDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Drivers/McpResourceDisplayDriver.cs
@@ -95,7 +95,7 @@ internal sealed class McpResourceDisplayDriver : DisplayDriver<McpResource>
         };
 
         // Build the full URI from the user-provided path.
-        entry.Resource.Uri = Handlers.McpResourceHandler.BuildUri(entry.Source, entry.ItemId, model.Path);
+        entry.Resource.Uri = Handlers.McpResourceHandler.BuildUri(entry.Source, entry.ItemId, model.Path?.Trim());
 
         entry.Resource.Name = model.Name ?? string.Empty;
         entry.Resource.Title = entry.DisplayText;

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Handlers/FileResourceTypeHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Handlers/FileResourceTypeHandler.cs
@@ -59,6 +59,11 @@ public sealed class FileResourceTypeHandler : McpResourceTypeHandlerBase
             return CreateErrorResult(resource.Resource.Uri, $"File not found: {fileName}");
         }
 
+        if (fileInfo.IsDirectory)
+        {
+            return CreateErrorResult(resource.Resource.Uri, $"The path '{fileName}' is a directory, not a file. Only file resources are supported.");
+        }
+
         if (_logger.IsEnabled(LogLevel.Debug))
         {
             _logger.LogDebug("Reading file resource from provider '{ProviderName}': {FileName}", providerName, fileName);

--- a/src/Startup/CrestApps.OrchardCore.Samples.McpClient/Pages/Prompts.cshtml
+++ b/src/Startup/CrestApps.OrchardCore.Samples.McpClient/Pages/Prompts.cshtml
@@ -11,7 +11,7 @@
 }
 
 <div class="d-flex align-items-center gap-3 mb-3">
-    <p class="text-muted mb-0">Prompts registered on the MCP server. Click "Get Prompt" to retrieve details.</p>
+    <p class="text-muted mb-0">Prompts registered on the MCP server. Click "Get" to retrieve details.</p>
     <form method="post" asp-page-handler="Refresh" class="d-inline">
         <button class="btn btn-secondary btn-sm" type="submit">Refresh</button>
     </form>
@@ -24,8 +24,11 @@
     </div>
 
     <ul class="list-group" id="promptsList">
-        @foreach (var prompt in Model.Prompts)
+        @for (var i = 0; i < Model.Prompts.Count; i++)
         {
+            var prompt = Model.Prompts[i];
+            var resultId = $"result-prompt-{i}";
+
             <li class="list-group-item searchable-item" data-search-text="@prompt.Name?.ToLowerInvariant() @prompt.Description?.ToLowerInvariant()">
                 <div class="d-flex justify-content-between align-items-start">
                     <div>
@@ -35,10 +38,11 @@
                             <div class="text-muted">@prompt.Description</div>
                         }
                     </div>
-                    <form method="post" asp-page-handler="GetPrompt">
-                        <input type="hidden" name="promptName" value="@prompt.Name" />
-                        <button class="btn btn-primary btn-sm" type="submit">Get Prompt</button>
-                    </form>
+                    <div class="prompt-form" data-prompt-name="@prompt.Name" data-result-target="#@resultId">
+                        <button class="btn btn-primary btn-sm btn-get-prompt" type="button">Get</button>
+                    </div>
+                </div>
+                <div id="@resultId" class="mt-3" style="display:none">
                 </div>
             </li>
         }
@@ -51,39 +55,68 @@ else
     <p class="text-muted">No prompts were returned by the MCP server.</p>
 }
 
-@if (Model.PromptResult is not null)
-{
-    <div class="card mt-4">
-        <div class="card-header">Prompt Details: @Model.SelectedPromptName</div>
-        <div class="card-body">
-            @if (!string.IsNullOrWhiteSpace(Model.PromptResult.Description))
-            {
-                <p><strong>Description:</strong> @Model.PromptResult.Description</p>
-            }
-
-            @if (Model.PromptResult.Messages?.Count > 0)
-            {
-                <h6>Messages</h6>
-                @foreach (var message in Model.PromptResult.Messages)
-                {
-                    <div class="card mb-2">
-                        <div class="card-body p-2">
-                            <span class="badge bg-secondary me-1">@message.Role</span>
-                            <span>@message.Content</span>
-                        </div>
-                    </div>
-                }
-            }
-            else
-            {
-                <p class="text-muted">No messages returned for this prompt.</p>
-            }
-        </div>
-    </div>
-}
-
 <script>
     (function () {
+        // Handle Get button clicks via AJAX.
+        document.querySelectorAll('.btn-get-prompt').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var container = btn.closest('.prompt-form');
+                var promptName = container.dataset.promptName;
+                var resultDiv = document.querySelector(container.dataset.resultTarget);
+
+                btn.disabled = true;
+                btn.textContent = 'Loading…';
+                resultDiv.style.display = 'block';
+                resultDiv.innerHTML = '<p class="text-muted">Loading…</p>';
+
+                var formData = new FormData();
+                formData.append('promptName', promptName);
+
+                fetch('?handler=GetPrompt', {
+                    method: 'POST',
+                    headers: {
+                        'RequestVerificationToken': document.querySelector('input[name="__RequestVerificationToken"]')?.value || ''
+                    },
+                    body: formData
+                })
+                .then(function (response) { return response.json(); })
+                .then(function (data) {
+                    if (data.error) {
+                        resultDiv.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(data.error) + '</div>';
+                        return;
+                    }
+
+                    var html = '';
+
+                    if (data.description) {
+                        html += '<p><strong>Description:</strong> ' + escapeHtml(data.description) + '</p>';
+                    }
+
+                    if (data.messages && data.messages.length > 0) {
+                        html += '<h6>Messages</h6>';
+                        data.messages.forEach(function (msg) {
+                            html += '<div class="card mb-2"><div class="card-body p-2">';
+                            html += '<span class="badge bg-secondary me-1">' + escapeHtml(msg.role) + '</span>';
+                            html += '<span>' + escapeHtml(msg.content || '') + '</span>';
+                            html += '</div></div>';
+                        });
+                    } else {
+                        html += '<p class="text-muted mb-0">No messages returned for this prompt.</p>';
+                    }
+
+                    resultDiv.innerHTML = html;
+                })
+                .catch(function (err) {
+                    resultDiv.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(err.message || 'An error occurred.') + '</div>';
+                })
+                .finally(function () {
+                    btn.disabled = false;
+                    btn.textContent = 'Get';
+                });
+            });
+        });
+
+        // Client-side search.
         var searchInput = document.getElementById('promptSearch');
         if (!searchInput) return;
         var items = document.querySelectorAll('#promptsList .searchable-item');
@@ -98,5 +131,15 @@ else
             });
             noResults.style.display = visible === 0 && query ? '' : 'none';
         });
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.appendChild(document.createTextNode(text));
+            return div.innerHTML;
+        }
     })();
 </script>
+
+@* Antiforgery token for AJAX calls *@
+<form id="__AjaxAntiForgeryForm" method="post" style="display:none">
+</form>

--- a/src/Startup/CrestApps.OrchardCore.Samples.McpClient/Pages/Tools.cshtml
+++ b/src/Startup/CrestApps.OrchardCore.Samples.McpClient/Pages/Tools.cshtml
@@ -1,5 +1,6 @@
 @page
 @model CrestApps.OrchardCore.Samples.McpClient.Pages.ToolsModel
+@using System.Text.Json
 
 <h1>Tools</h1>
 
@@ -29,6 +30,9 @@
             var tool = Model.Tools[i];
             var collapseId = $"collapse-tool-{i}";
             var headerId = $"header-tool-{i}";
+            var resultId = $"result-tool-{i}";
+            var inputSchema = tool.ProtocolTool?.InputSchema;
+            var schemaJson = inputSchema.HasValue ? inputSchema.Value.GetRawText() : "{}";
 
             <div class="accordion-item searchable-item" data-search-text="@tool.Name?.ToLowerInvariant() @tool.Description?.ToLowerInvariant()">
                 <h2 class="accordion-header" id="@headerId">
@@ -42,15 +46,13 @@
                 </h2>
                 <div id="@collapseId" class="accordion-collapse collapse" data-bs-parent="#toolsAccordion">
                     <div class="accordion-body">
-                        <form method="post" asp-page-handler="CallTool">
-                            <input type="hidden" name="toolName" value="@tool.Name" />
-                            <div class="mb-3">
-                                <label class="form-label">Arguments (JSON)</label>
-                                <textarea name="arguments" class="form-control font-monospace" rows="3" placeholder='{"key": "value"}'></textarea>
-                                <div class="form-text">Provide tool arguments as a JSON object. Leave empty for no arguments.</div>
-                            </div>
-                            <button class="btn btn-primary btn-sm" type="submit">Call Tool</button>
-                        </form>
+                        <div class="tool-form" data-tool-name="@tool.Name" data-schema="@schemaJson" data-result-target="#@resultId">
+                            <div class="tool-arguments"></div>
+                            <button class="btn btn-primary btn-sm btn-call-tool" type="button">Call Tool</button>
+                        </div>
+
+                        <div id="@resultId" class="mt-3" style="display:none">
+                        </div>
                     </div>
                 </div>
             </div>
@@ -64,35 +66,191 @@ else
     <p class="text-muted">No tools were returned by the MCP server.</p>
 }
 
-@if (Model.CallResult is not null)
-{
-    <div class="card mt-4">
-        <div class="card-header">Result: @Model.SelectedToolName</div>
-        <div class="card-body">
-            @if (Model.CallResult.Content?.Count > 0)
-            {
-                @foreach (var content in Model.CallResult.Content)
-                {
-                    if (content is ModelContextProtocol.Protocol.TextContentBlock textBlock)
-                    {
-                        <pre class="bg-light p-3 rounded mb-2">@textBlock.Text</pre>
-                    }
-                    else
-                    {
-                        <p class="text-muted">Unsupported content type: @content.Type</p>
-                    }
-                }
-            }
-            else
-            {
-                <p class="text-muted">No content returned.</p>
-            }
-        </div>
-    </div>
-}
-
 <script>
     (function () {
+        // Build dynamic argument inputs from JSON Schema.
+        document.querySelectorAll('.tool-form').forEach(function (form) {
+            var schema;
+            try {
+                schema = JSON.parse(form.dataset.schema || '{}');
+            } catch (e) {
+                schema = {};
+            }
+
+            var container = form.querySelector('.tool-arguments');
+            var properties = schema.properties || {};
+            var required = schema.required || [];
+            var keys = Object.keys(properties);
+
+            if (keys.length === 0) {
+                return;
+            }
+
+            var row = document.createElement('div');
+            row.className = 'row g-2 mb-2';
+
+            keys.forEach(function (key) {
+                var prop = properties[key];
+                var isRequired = required.indexOf(key) !== -1;
+                var col = document.createElement('div');
+                col.className = 'col-md-6 col-lg-4';
+
+                var label = document.createElement('label');
+                label.className = 'form-label small mb-0';
+                label.textContent = key;
+                if (isRequired) {
+                    var badge = document.createElement('span');
+                    badge.className = 'text-danger ms-1';
+                    badge.textContent = '*';
+                    label.appendChild(badge);
+                }
+
+                var input;
+                var propType = prop.type || 'string';
+
+                if (propType === 'boolean') {
+                    input = document.createElement('select');
+                    input.className = 'form-select form-select-sm';
+                    var optEmpty = document.createElement('option');
+                    optEmpty.value = '';
+                    optEmpty.textContent = '— select —';
+                    var optTrue = document.createElement('option');
+                    optTrue.value = 'true';
+                    optTrue.textContent = 'true';
+                    var optFalse = document.createElement('option');
+                    optFalse.value = 'false';
+                    optFalse.textContent = 'false';
+                    input.appendChild(optEmpty);
+                    input.appendChild(optTrue);
+                    input.appendChild(optFalse);
+                } else if (propType === 'integer' || propType === 'number') {
+                    input = document.createElement('input');
+                    input.type = 'number';
+                    input.className = 'form-control form-control-sm';
+                    if (propType === 'integer') {
+                        input.step = '1';
+                    } else {
+                        input.step = 'any';
+                    }
+                } else {
+                    input = document.createElement('input');
+                    input.type = 'text';
+                    input.className = 'form-control form-control-sm';
+                }
+
+                input.dataset.argName = key;
+                input.dataset.argType = propType;
+
+                if (prop.description) {
+                    input.title = prop.description;
+                    input.placeholder = prop.description;
+                } else {
+                    input.placeholder = key;
+                }
+
+                if (isRequired) {
+                    input.required = true;
+                }
+
+                col.appendChild(label);
+                col.appendChild(input);
+                row.appendChild(col);
+            });
+
+            container.appendChild(row);
+        });
+
+        // Handle Call Tool button clicks via AJAX.
+        document.querySelectorAll('.btn-call-tool').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var form = btn.closest('.tool-form');
+                var toolName = form.dataset.toolName;
+                var resultDiv = document.querySelector(form.dataset.resultTarget);
+
+                // Collect arguments from dynamic inputs.
+                var args = {};
+                var missing = false;
+                form.querySelectorAll('[data-arg-name]').forEach(function (input) {
+                    var name = input.dataset.argName;
+                    var type = input.dataset.argType;
+                    var value = input.value.trim();
+
+                    if (input.required && !value) {
+                        input.reportValidity();
+                        missing = true;
+                        return;
+                    }
+
+                    if (value === '') {
+                        return;
+                    }
+
+                    if (type === 'boolean') {
+                        args[name] = value === 'true';
+                    } else if (type === 'integer') {
+                        args[name] = parseInt(value, 10);
+                    } else if (type === 'number') {
+                        args[name] = parseFloat(value);
+                    } else {
+                        args[name] = value;
+                    }
+                });
+
+                if (missing) {
+                    return;
+                }
+
+                btn.disabled = true;
+                btn.textContent = 'Calling…';
+                resultDiv.style.display = 'block';
+                resultDiv.innerHTML = '<p class="text-muted">Loading…</p>';
+
+                var formData = new FormData();
+                formData.append('toolName', toolName);
+                formData.append('arguments', JSON.stringify(args));
+
+                fetch('?handler=CallTool', {
+                    method: 'POST',
+                    headers: {
+                        'RequestVerificationToken': document.querySelector('input[name="__RequestVerificationToken"]')?.value || ''
+                    },
+                    body: formData
+                })
+                .then(function (response) { return response.json(); })
+                .then(function (data) {
+                    if (data.error) {
+                        resultDiv.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(data.error) + '</div>';
+                        return;
+                    }
+                    if (!data.contents || data.contents.length === 0) {
+                        resultDiv.innerHTML = '<p class="text-muted mb-0">No content returned.</p>';
+                        return;
+                    }
+                    var alertClass = data.isError ? 'alert-warning' : '';
+                    var html = '';
+                    if (data.isError) {
+                        html += '<div class="alert alert-warning mb-2"><strong>Tool returned an error</strong></div>';
+                    }
+                    data.contents.forEach(function (c) {
+                        if (c.type === 'text') {
+                            html += '<pre class="bg-light p-3 rounded mb-2" style="max-height:400px;overflow:auto">' + escapeHtml(c.text) + '</pre>';
+                        } else {
+                            html += '<p class="text-muted">Unsupported content type: ' + escapeHtml(c.contentType || 'unknown') + '</p>';
+                        }
+                    });
+                    resultDiv.innerHTML = html;
+                })
+                .catch(function (err) {
+                    resultDiv.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(err.message || 'An error occurred.') + '</div>';
+                })
+                .finally(function () {
+                    btn.disabled = false;
+                    btn.textContent = 'Call Tool';
+                });
+            });
+        });
+
+        // Client-side search.
         var searchInput = document.getElementById('toolSearch');
         if (!searchInput) return;
         var items = document.querySelectorAll('#toolsAccordion .searchable-item');
@@ -107,5 +265,15 @@ else
             });
             noResults.style.display = visible === 0 && query ? '' : 'none';
         });
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.appendChild(document.createTextNode(text));
+            return div.innerHTML;
+        }
     })();
 </script>
+
+@* Antiforgery token for AJAX calls *@
+<form id="__AjaxAntiForgeryForm" method="post" style="display:none">
+</form>

--- a/tests/CrestApps.OrchardCore.Tests/Core/Mcp/McpResourceUriTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Core/Mcp/McpResourceUriTests.cs
@@ -103,4 +103,167 @@ public sealed class McpResourceUriTests
 
         Assert.Equal(expected, result);
     }
+
+    [Theory]
+    [InlineData("file://id/{fileName} ", "file://id/test", "fileName", "test")]
+    [InlineData("  file://id/{fileName}", "file://id/test", "fileName", "test")]
+    [InlineData("file://id/{fileName}", "  file://id/test  ", "fileName", "test")]
+    [InlineData("  file://id/{fileName}  ", "  file://id/test  ", "fileName", "test")]
+    public void TryMatch_WithWhitespace_TrimsAndMatchesCorrectly(string template, string uri, string expectedVar, string expectedValue)
+    {
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.True(result);
+        Assert.NotNull(variables);
+        Assert.Equal(expectedValue, variables[expectedVar]);
+    }
+
+    [Theory]
+    [InlineData("   ", "file://server/test")]
+    [InlineData("file://server/{path}", "   ")]
+    [InlineData("   ", "   ")]
+    public void TryMatch_WithWhitespaceOnlyInputs_ReturnsFalse(string template, string uri)
+    {
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.False(result);
+        Assert.Null(variables);
+    }
+
+    [Theory]
+    [InlineData("  {path}  ", true)]
+    [InlineData("   ", false)]
+    [InlineData("  no-template  ", false)]
+    public void IsTemplate_WithWhitespace_TrimsAndReturnsExpected(string uri, bool expected)
+    {
+        var result = McpResourceUri.IsTemplate(uri);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void TryMatch_WithEncodedUri_DecodesValues()
+    {
+        var template = "file://server/{path}";
+        var uri = "file://server/my%20file%20name.txt";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.True(result);
+        Assert.Equal("my file name.txt", variables["path"]);
+    }
+
+    [Fact]
+    public void TryMatch_LastVariable_MatchesMultiplePathSegments()
+    {
+        var template = "file://server/{path}";
+        var uri = "file://server/docs/reports/2024/report.pdf";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.True(result);
+        Assert.Equal("docs/reports/2024/report.pdf", variables["path"]);
+    }
+
+    [Fact]
+    public void TryMatch_NonLastVariable_MatchesSingleSegmentOnly()
+    {
+        var template = "content://{type}/{id}";
+        var uri = "content://Article/abc123";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.True(result);
+        Assert.Equal("Article", variables["type"]);
+        Assert.Equal("abc123", variables["id"]);
+    }
+
+    [Fact]
+    public void TryMatch_NonLastVariable_DoesNotMatchMultipleSegments()
+    {
+        var template = "content://{type}/{id}";
+        var uri = "content://Article/Sub/abc123";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        // {type} matches "Article", {id} (last var) matches "Sub/abc123"
+        Assert.True(result);
+        Assert.Equal("Article", variables["type"]);
+        Assert.Equal("Sub/abc123", variables["id"]);
+    }
+
+    [Fact]
+    public void TryMatch_VariablesAreCaseInsensitive()
+    {
+        var template = "file://server/{FileName}";
+        var uri = "file://server/test.txt";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.True(result);
+        Assert.Equal("test.txt", variables["FileName"]);
+        Assert.Equal("test.txt", variables["filename"]);
+    }
+
+    [Fact]
+    public void TryMatch_WithSpecialCharactersInLiteral_EscapesCorrectly()
+    {
+        var template = "schema://host.name/{param}";
+        var uri = "schema://host.name/value";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.True(result);
+        Assert.Equal("value", variables["param"]);
+    }
+
+    [Fact]
+    public void TryMatch_WithThreeVariables_ExtractsAll()
+    {
+        var template = "data://{org}/{repo}/{file}";
+        var uri = "data://myorg/myrepo/src/main.cs";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.True(result);
+        Assert.Equal("myorg", variables["org"]);
+        Assert.Equal("myrepo", variables["repo"]);
+        Assert.Equal("src/main.cs", variables["file"]);
+    }
+
+    [Fact]
+    public void TryMatch_EmptyVariableValue_DoesNotMatch()
+    {
+        var template = "file://server/{path}";
+        var uri = "file://server/";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        // .+ requires at least one character
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void TryMatch_ExactLiteralNoVariables_MatchesExactly()
+    {
+        var template = "static://exact/uri/path";
+        var uri = "static://exact/uri/path";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.True(result);
+        Assert.NotNull(variables);
+        Assert.Empty(variables);
+    }
+
+    [Fact]
+    public void TryMatch_ExactLiteralNoVariables_DoesNotMatchDifferentUri()
+    {
+        var template = "static://exact/uri/path";
+        var uri = "static://exact/uri/other";
+
+        var result = McpResourceUri.TryMatch(template, uri, out var variables);
+
+        Assert.False(result);
+    }
 }


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the MCP server, its documentation, and the sample MCP client UI. The main changes enhance the reliability of URI template matching, improve error handling for file resources, and modernize the MCP client UI for prompts and tools with a more interactive, AJAX-based experience. Documentation has been expanded for clarity on MCP prompts and resources, and new features are highlighted in the changelog.

**Core functionality and reliability improvements:**

* Trim leading/trailing whitespace from resource URI templates and actual URIs before matching, preventing mismatches due to accidental spaces. Also, update checks for whitespace-only strings in `McpResourceUri.cs`. [[1]](diffhunk://#diff-2147a4f22d1ef5bb2514e2c7fadb44967cbd8260a57cd4d6532a92c3bf053b4bL26-R33) [[2]](diffhunk://#diff-2147a4f22d1ef5bb2514e2c7fadb44967cbd8260a57cd4d6532a92c3bf053b4bL104-R107) [[3]](diffhunk://#diff-492758fe7188c7b77c945bc8478041b589da7a0592d2c8a9f59a64b08436f24dL98-R98)
* The file resource handler now returns a clear error if the resolved path is a directory instead of a file, improving error feedback for invalid file resource requests.

**Documentation enhancements:**

* Expanded and clarified documentation for MCP Prompts and Resources, including detailed admin UI instructions, explanation of static vs. templated resources, and improved resource management sections. [[1]](diffhunk://#diff-fa3bcb9fef004a5188ab92dea10cf83a1b8b843c137632a666a337efe69919c8L32-R78) [[2]](diffhunk://#diff-fa3bcb9fef004a5188ab92dea10cf83a1b8b843c137632a666a337efe69919c8L75-L88)
* Changelog updated to mention new whitespace handling for URI templates and improved error handling for file resources.

**Sample MCP client UI improvements (Prompts and Tools):**

* Refactored the Prompts page to use AJAX for fetching prompt details, providing a smoother user experience and removing server-rendered prompt detail cards. [[1]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L14-R14) [[2]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L27-R31) [[3]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L38-R45) [[4]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L54-R119) [[5]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56R134-R145) [[6]](diffhunk://#diff-3ad6203492bc458ae9c1bba78fdfdc90098b27fc603a27a5ff96c1ef1b3c0851L20-L23) [[7]](diffhunk://#diff-3ad6203492bc458ae9c1bba78fdfdc90098b27fc603a27a5ff96c1ef1b3c0851L42-L66)
* The Tools page now prepares for dynamic argument forms and AJAX-based tool invocation, laying groundwork for future enhancements. [[1]](diffhunk://#diff-6ad5acb3ed1171288ae4239b3099c8ff120347a4268657e8ebce7102b72452d8R3) [[2]](diffhunk://#diff-6ad5acb3ed1171288ae4239b3099c8ff120347a4268657e8ebce7102b72452d8R33-R35) [[3]](diffhunk://#diff-6ad5acb3ed1171288ae4239b3099c8ff120347a4268657e8ebce7102b72452d8L45-L53)

**Minor UI and usability tweaks:**

* Updated button labels and improved prompt listing logic for clarity and accessibility in the sample client. [[1]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L14-R14) [[2]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L27-R31)

**References:** [[1]](diffhunk://#diff-2147a4f22d1ef5bb2514e2c7fadb44967cbd8260a57cd4d6532a92c3bf053b4bL26-R33) [[2]](diffhunk://#diff-2147a4f22d1ef5bb2514e2c7fadb44967cbd8260a57cd4d6532a92c3bf053b4bL104-R107) [[3]](diffhunk://#diff-492758fe7188c7b77c945bc8478041b589da7a0592d2c8a9f59a64b08436f24dL98-R98) [[4]](diffhunk://#diff-d4f83f0d8927a40a2f826b656fb2f977b847b64917a869d6bd00159eb82da3a2R62-R66) [[5]](diffhunk://#diff-fa3bcb9fef004a5188ab92dea10cf83a1b8b843c137632a666a337efe69919c8L32-R78) [[6]](diffhunk://#diff-fa3bcb9fef004a5188ab92dea10cf83a1b8b843c137632a666a337efe69919c8L75-L88) [[7]](diffhunk://#diff-91d7db76244c2f8495cd97ea6e1c190729b91fc7fc298a9e5b2c7309f417b510R93-R94) [[8]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L14-R14) [[9]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L27-R31) [[10]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L38-R45) [[11]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56L54-R119) [[12]](diffhunk://#diff-d6962cb28aee762cd8a4313d1f91e7a4c7411c33663393ca9e9a6b0242232b56R134-R145) [[13]](diffhunk://#diff-3ad6203492bc458ae9c1bba78fdfdc90098b27fc603a27a5ff96c1ef1b3c0851L20-L23) [[14]](diffhunk://#diff-3ad6203492bc458ae9c1bba78fdfdc90098b27fc603a27a5ff96c1ef1b3c0851L42-L66) [[15]](diffhunk://#diff-6ad5acb3ed1171288ae4239b3099c8ff120347a4268657e8ebce7102b72452d8R3) [[16]](diffhunk://#diff-6ad5acb3ed1171288ae4239b3099c8ff120347a4268657e8ebce7102b72452d8R33-R35) [[17]](diffhunk://#diff-6ad5acb3ed1171288ae4239b3099c8ff120347a4268657e8ebce7102b72452d8L45-L53)