### PR TITLE
Remove deployments from connections

### DIFF
--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/IAIDeploymentManager.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/IAIDeploymentManager.cs
@@ -15,4 +15,36 @@ public interface IAIDeploymentManager : INamedSourceCatalogManager<AIDeployment>
     /// containing the model deployments for the specified provider and connection.
     /// </returns>
     ValueTask<IEnumerable<AIDeployment>> GetAllAsync(string providerName, string connectionName);
+
+    /// <summary>
+    /// Asynchronously retrieves all deployments of the specified type.
+    /// </summary>
+    /// <param name="type">The deployment type to filter by.</param>
+    /// <returns>
+    /// A ValueTask that represents the asynchronous operation. The result is an <see cref="IEnumerable{AIDeployment}"/>
+    /// containing all deployments matching the specified type.
+    /// </returns>
+    ValueTask<IEnumerable<AIDeployment>> GetByTypeAsync(AIDeploymentType type);
+
+    /// <summary>
+    /// Resolves the default deployment of a given type for a specific connection.
+    /// Returns the deployment marked as IsDefault for that type on the connection,
+    /// or the first deployment of that type on the connection if none is marked as default.
+    /// </summary>
+    ValueTask<AIDeployment> GetDefaultAsync(string providerName, string connectionName, AIDeploymentType type);
+
+    /// <summary>
+    /// Resolves a deployment using the full fallback chain:
+    /// 1. If deploymentId is provided, returns that specific deployment.
+    /// 2. If connectionName is provided, returns the default deployment of the given type for that connection.
+    /// 3. Falls back to the global default deployment for the given type (from DefaultAIDeploymentSettings).
+    /// Returns null if no deployment can be resolved.
+    /// </summary>
+    ValueTask<AIDeployment> ResolveAsync(AIDeploymentType type, string deploymentId = null, string providerName = null, string connectionName = null);
+
+    /// <summary>
+    /// Gets all deployments of a given type, optionally filtered by provider.
+    /// Results are suitable for dropdown population, grouped by connection.
+    /// </summary>
+    ValueTask<IEnumerable<AIDeployment>> GetAllByTypeAsync(AIDeploymentType type, string providerName = null);
 }

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Json/AIProviderConnectionJsonConverter.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Json/AIProviderConnectionJsonConverter.cs
@@ -23,6 +23,7 @@ public sealed class AIProviderConnectionJsonConverter : JsonConverter<AIProvider
                 ?? GetString(node, "ProviderName"),
             Name = GetString(node, nameof(AIProviderConnection.Name)),
             DisplayText = GetString(node, nameof(AIProviderConnection.DisplayText)),
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
             ChatDeploymentName = GetString(node, nameof(AIProviderConnection.ChatDeploymentName))
                 ?? GetString(node, "DefaultDeploymentName"),
             EmbeddingDeploymentName = GetString(node, nameof(AIProviderConnection.EmbeddingDeploymentName))
@@ -31,6 +32,7 @@ public sealed class AIProviderConnectionJsonConverter : JsonConverter<AIProvider
                 ?? GetString(node, "DefaultImagesDeploymentName"),
             UtilityDeploymentName = GetString(node, nameof(AIProviderConnection.UtilityDeploymentName))
                 ?? GetString(node, "DefaultUtilityDeploymentName"),
+#pragma warning restore CS0618
             IsDefault = GetBool(node, nameof(AIProviderConnection.IsDefault)),
             CreatedUtc = GetDateTime(node, nameof(AIProviderConnection.CreatedUtc)),
             Author = GetString(node, nameof(AIProviderConnection.Author)),
@@ -56,10 +58,12 @@ public sealed class AIProviderConnectionJsonConverter : JsonConverter<AIProvider
         WriteString(writer, nameof(AIProviderConnection.Source), value.Source);
         WriteString(writer, nameof(AIProviderConnection.Name), value.Name);
         WriteString(writer, nameof(AIProviderConnection.DisplayText), value.DisplayText);
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
         WriteString(writer, nameof(AIProviderConnection.ChatDeploymentName), value.ChatDeploymentName);
         WriteString(writer, nameof(AIProviderConnection.EmbeddingDeploymentName), value.EmbeddingDeploymentName);
         WriteString(writer, nameof(AIProviderConnection.ImagesDeploymentName), value.ImagesDeploymentName);
         WriteString(writer, nameof(AIProviderConnection.UtilityDeploymentName), value.UtilityDeploymentName);
+#pragma warning restore CS0618
         writer.WriteBoolean(nameof(AIProviderConnection.IsDefault), value.IsDefault);
         writer.WriteString(nameof(AIProviderConnection.CreatedUtc), value.CreatedUtc);
         WriteString(writer, nameof(AIProviderConnection.Author), value.Author);

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AICompletionContext.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AICompletionContext.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace CrestApps.OrchardCore.AI.Models;
 
 public class AICompletionContext
@@ -30,7 +32,24 @@ public class AICompletionContext
 
     public string DataSourceId { get; set; }
 
-    public string DeploymentId { get; set; }
+    public string ChatDeploymentId { get; set; }
+
+    public string UtilityDeploymentId { get; set; }
+
+    [Obsolete("Use ChatDeploymentId instead. Retained for backward compatibility.")]
+    [JsonIgnore]
+    public string DeploymentId
+    {
+        get => ChatDeploymentId;
+        set => ChatDeploymentId = value;
+    }
+
+    [JsonInclude]
+    [JsonPropertyName("DeploymentId")]
+    private string _deploymentIdBackingField
+    {
+        set => ChatDeploymentId = value;
+    }
 
     public Dictionary<string, object> AdditionalProperties { get; } = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIDeployment.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIDeployment.cs
@@ -27,6 +27,18 @@ public class AIDeployment : SourceCatalogEntry, INameAwareModel, ISourceAwareMod
 
     public string ConnectionNameAlias { get; set; }
 
+    /// <summary>
+    /// Gets or sets the type of this deployment (Chat, Utility, Embedding, Image, SpeechToText).
+    /// Determines what capability this deployment provides.
+    /// </summary>
+    public AIDeploymentType Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this deployment is the default for its <see cref="Type"/>
+    /// within its connection. Each connection can have at most one default per type.
+    /// </summary>
+    public bool IsDefault { get; set; }
+
     public DateTime CreatedUtc { get; set; }
 
     public string Author { get; set; }
@@ -42,6 +54,8 @@ public class AIDeployment : SourceCatalogEntry, INameAwareModel, ISourceAwareMod
             Source = Source,
             ConnectionName = ConnectionName,
             ConnectionNameAlias = ConnectionNameAlias,
+            Type = Type,
+            IsDefault = IsDefault,
             CreatedUtc = CreatedUtc,
             Author = Author,
             OwnerId = OwnerId,

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIDeploymentType.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIDeploymentType.cs
@@ -1,0 +1,10 @@
+namespace CrestApps.OrchardCore.AI.Models;
+
+public enum AIDeploymentType
+{
+    Chat,
+    Utility,
+    Embedding,
+    Image,
+    SpeechToText,
+}

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIProfile.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIProfile.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using CrestApps.OrchardCore.Models;
 using CrestApps.OrchardCore.Services;
 
@@ -27,9 +28,30 @@ public sealed class AIProfile : SourceCatalogEntry, INameAwareModel, IDisplayTex
     public string ConnectionName { get; set; }
 
     /// <summary>
-    /// Gets or sets the deployment identifier associated with the profile.
+    /// Gets or sets the chat deployment identifier for this profile.
     /// </summary>
-    public string DeploymentId { get; set; }
+    public string ChatDeploymentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the utility deployment identifier for this profile.
+    /// When not set, falls back to the global default utility deployment.
+    /// </summary>
+    public string UtilityDeploymentId { get; set; }
+
+    [Obsolete("Use ChatDeploymentId instead. Retained for backward compatibility.")]
+    [JsonIgnore]
+    public string DeploymentId
+    {
+        get => ChatDeploymentId;
+        set => ChatDeploymentId = value;
+    }
+
+    [JsonInclude]
+    [JsonPropertyName("DeploymentId")]
+    private string _deploymentIdBackingField
+    {
+        set => ChatDeploymentId = value;
+    }
 
     /// <summary>
     /// Gets or sets the type of title used in the session.
@@ -92,7 +114,8 @@ public sealed class AIProfile : SourceCatalogEntry, INameAwareModel, IDisplayTex
             Type = Type,
             OrchestratorName = OrchestratorName,
             ConnectionName = ConnectionName,
-            DeploymentId = DeploymentId,
+            ChatDeploymentId = ChatDeploymentId,
+            UtilityDeploymentId = UtilityDeploymentId,
             TitleType = TitleType,
             WelcomeMessage = WelcomeMessage,
             PromptSubject = PromptSubject,

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIProviderConnection.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIProviderConnection.cs
@@ -12,12 +12,16 @@ public sealed class AIProviderConnection : SourceCatalogEntry, INameAwareModel, 
 
     public string DisplayText { get; set; }
 
+    [Obsolete("Use typed AIDeployment records instead. This property is retained for backward compatibility and migration.")]
     public string ChatDeploymentName { get; set; }
 
+    [Obsolete("Use typed AIDeployment records instead. This property is retained for backward compatibility and migration.")]
     public string EmbeddingDeploymentName { get; set; }
 
+    [Obsolete("Use typed AIDeployment records instead. This property is retained for backward compatibility and migration.")]
     public string ImagesDeploymentName { get; set; }
 
+    [Obsolete("Use typed AIDeployment records instead. This property is retained for backward compatibility and migration.")]
     public string UtilityDeploymentName { get; set; }
 
     public bool IsDefault { get; set; }
@@ -44,10 +48,12 @@ public sealed class AIProviderConnection : SourceCatalogEntry, INameAwareModel, 
             Name = Name,
             DisplayText = DisplayText,
             IsDefault = IsDefault,
+#pragma warning disable CS0618 // Type or member is obsolete
             ChatDeploymentName = ChatDeploymentName,
             EmbeddingDeploymentName = EmbeddingDeploymentName,
             ImagesDeploymentName = ImagesDeploymentName,
             UtilityDeploymentName = UtilityDeploymentName,
+#pragma warning restore CS0618
             CreatedUtc = CreatedUtc,
             Author = Author,
             OwnerId = OwnerId,

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIProviderOptions.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AIProviderOptions.cs
@@ -13,12 +13,16 @@ public sealed class AIProvider
 {
     public string DefaultConnectionName { get; set; }
 
+    [Obsolete("Use typed AIDeployment records with IsDefault instead. Retained for backward compatibility.")]
     public string DefaultChatDeploymentName { get; set; }
 
+    [Obsolete("Use typed AIDeployment records with IsDefault instead. Retained for backward compatibility.")]
     public string DefaultEmbeddingDeploymentName { get; set; }
 
+    [Obsolete("Use typed AIDeployment records with IsDefault instead. Retained for backward compatibility.")]
     public string DefaultImagesDeploymentName { get; set; }
 
+    [Obsolete("Use typed AIDeployment records with IsDefault instead. Retained for backward compatibility.")]
     public string DefaultUtilityDeploymentName { get; set; }
 
     public IDictionary<string, AIProviderConnectionEntry> Connections { get; set; }

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/ChatInteraction.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/ChatInteraction.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using CrestApps.OrchardCore.Models;
 
 namespace CrestApps.OrchardCore.AI.Models;
@@ -29,9 +30,30 @@ public sealed class ChatInteraction : CatalogItem, ISourceAwareModel
     public string Source { get; set; }
 
     /// <summary>
-    /// Gets or sets the deployment identifier (AI model) to use.
+    /// Gets or sets the chat deployment identifier (AI model) to use.
     /// </summary>
-    public string DeploymentId { get; set; }
+    public string ChatDeploymentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the utility deployment identifier for this interaction.
+    /// When not set, falls back to the global default utility deployment.
+    /// </summary>
+    public string UtilityDeploymentId { get; set; }
+
+    [Obsolete("Use ChatDeploymentId instead. Retained for backward compatibility.")]
+    [JsonIgnore]
+    public string DeploymentId
+    {
+        get => ChatDeploymentId;
+        set => ChatDeploymentId = value;
+    }
+
+    [JsonInclude]
+    [JsonPropertyName("DeploymentId")]
+    private string _deploymentIdBackingField
+    {
+        set => ChatDeploymentId = value;
+    }
 
     /// <summary>
     /// Gets or sets the connection name for the AI provider.

--- a/src/Core/CrestApps.OrchardCore.AI.Chat.Interactions.Core/Services/TabularBatchProcessor.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Chat.Interactions.Core/Services/TabularBatchProcessor.cs
@@ -259,7 +259,7 @@ public sealed class TabularBatchProcessor : ITabularBatchProcessor
             var completionContext = new AICompletionContext
             {
                 ConnectionName = sourceContext.ConnectionName,
-                DeploymentId = sourceContext.DeploymentId,
+                ChatDeploymentId = sourceContext.ChatDeploymentId,
                 SystemMessage = await GetBatchSystemMessageAsync(batch, sourceContext.SystemMessage),
                 Temperature = sourceContext.Temperature ?? 0.1f, // Use low temperature for consistent row processing
                 TopP = sourceContext.TopP ?? 1.0f,

--- a/src/Core/CrestApps.OrchardCore.AI.Core/DictionaryExtensions.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/DictionaryExtensions.cs
@@ -25,36 +25,44 @@ public static class DictionaryExtensions
         return uri;
     }
 
+    [Obsolete("Deployment names on connections are deprecated. Use the deployment resolver instead.")]
     public static string GetChatDeploymentName(this IDictionary<string, object> entry, bool throwException = true)
         => entry.GetStringValue("ChatDeploymentName", throwException)
             ?? entry.GetStringValue("DefaultChatDeploymentName", throwException)
             ?? entry.GetStringValue("DefaultDeploymentName", throwException);
 
+    [Obsolete("Deployment names on connections are deprecated. Use the deployment resolver instead.")]
     public static string GetEmbeddingDeploymentName(this IDictionary<string, object> entry, bool throwException = true)
         => entry.GetStringValue("EmbeddingDeploymentName", throwException)
             ?? entry.GetStringValue("DefaultEmbeddingDeploymentName", throwException);
 
+    [Obsolete("Deployment names on connections are deprecated. Use the deployment resolver instead.")]
     public static string GetImagesDeploymentName(this IDictionary<string, object> entry, bool throwException = true)
         => entry.GetStringValue("ImagesDeploymentName", throwException)
             ?? entry.GetStringValue("DefaultImagesDeploymentName", throwException);
 
+    [Obsolete("Deployment names on connections are deprecated. Use the deployment resolver instead.")]
     public static string GetUtilityDeploymentName(this IDictionary<string, object> entry, bool throwException = true)
         => entry.GetStringValue("UtilityDeploymentName", throwException)
             ?? entry.GetStringValue("DefaultUtilityDeploymentName", throwException);
 
+    [Obsolete("Deployment names on connections are deprecated. Use the deployment resolver instead.")]
     public static string GetChatDeploymentOrDefaultName(this IDictionary<string, object> entry, bool throwException = true)
         => entry.GetStringValue("ChatDeploymentName", false)
         ?? entry.GetStringValue("DeploymentName", false)
         ?? entry.GetStringValue("DefaultDeploymentName", throwException);
 
+    [Obsolete("Deployment names on connections are deprecated. Use the deployment resolver instead.")]
     public static string GetEmbeddingDeploymentOrDefaultName(this IDictionary<string, object> entry, bool throwException = true)
         => entry.GetStringValue("EmbeddingDeploymentName", false)
         ?? entry.GetStringValue("DefaultEmbeddingDeploymentName", throwException);
 
+    [Obsolete("Deployment names on connections are deprecated. Use the deployment resolver instead.")]
     public static string GetImagesDeploymentOrDefaultName(this IDictionary<string, object> entry, bool throwException = true)
         => entry.GetStringValue("ImagesDeploymentName", false)
         ?? entry.GetStringValue("DefaultImagesDeploymentName", throwException);
 
+    [Obsolete("Deployment names on connections are deprecated. Use the deployment resolver instead.")]
     public static string GetUtilityDeploymentOrDefaultName(this IDictionary<string, object> entry, bool throwException = true)
         => entry.GetStringValue("UtilityDeploymentName", false)
         ?? entry.GetStringValue("DefaultUtilityDeploymentName", throwException);

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/AIDeploymentHandler.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/AIDeploymentHandler.cs
@@ -44,6 +44,11 @@ public sealed class AIDeploymentHandler : CatalogEntryHandlerBase<AIDeployment>
             context.Result.Fail(new ValidationResult(S["Deployment Name is required."], [nameof(AIDeployment.Name)]));
         }
 
+        if (!Enum.IsDefined(context.Model.Type))
+        {
+            context.Result.Fail(new ValidationResult(S["The deployment type '{0}' is not valid.", context.Model.Type], [nameof(AIDeployment.Type)]));
+        }
+
         var hasConnectionName = true;
 
         if (string.IsNullOrWhiteSpace(context.Model.ConnectionName))
@@ -116,6 +121,20 @@ public sealed class AIDeploymentHandler : CatalogEntryHandlerBase<AIDeployment>
         else if (!string.IsNullOrEmpty(providerName) && _providerOptions.Providers.TryGetValue(providerName, out var provider))
         {
             deployment.ConnectionName = provider.DefaultConnectionName;
+        }
+
+        var typeValue = data[nameof(AIDeployment.Type)]?.GetValue<string>();
+
+        if (!string.IsNullOrEmpty(typeValue) && Enum.TryParse<AIDeploymentType>(typeValue, ignoreCase: true, out var type))
+        {
+            deployment.Type = type;
+        }
+
+        var isDefault = data[nameof(AIDeployment.IsDefault)]?.GetValue<bool>();
+
+        if (isDefault.HasValue)
+        {
+            deployment.IsDefault = isDefault.Value;
         }
 
         var properties = data[nameof(AIDeployment.Properties)]?.AsObject();

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/AIDeploymentProfileHandler.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/AIDeploymentProfileHandler.cs
@@ -30,19 +30,20 @@ public sealed class AIDeploymentProfileHandler : CatalogEntryHandlerBase<AIProfi
 
     public override async Task ValidatingAsync(ValidatingContext<AIProfile> context)
     {
-        if (!string.IsNullOrEmpty(context.Model.DeploymentId) && await _deploymentsCatalog.FindByIdAsync(context.Model.DeploymentId) is null)
+        if (!string.IsNullOrEmpty(context.Model.ChatDeploymentId) && await _deploymentsCatalog.FindByIdAsync(context.Model.ChatDeploymentId) is null)
         {
-            context.Result.Fail(new ValidationResult(S["Invalid DeploymentId provided."], [nameof(AIProfile.DeploymentId)]));
+            context.Result.Fail(new ValidationResult(S["Invalid DeploymentId provided."], [nameof(AIProfile.ChatDeploymentId)]));
         }
     }
 
     private static Task PopulateAsync(AIProfile profile, JsonNode data)
     {
-        var deploymentId = data[nameof(AIProfile.DeploymentId)]?.GetValue<string>()?.Trim();
+        var deploymentId = data[nameof(AIProfile.ChatDeploymentId)]?.GetValue<string>()?.Trim()
+            ?? data["DeploymentId"]?.GetValue<string>()?.Trim();
 
         if (!string.IsNullOrEmpty(deploymentId))
         {
-            profile.DeploymentId = deploymentId;
+            profile.ChatDeploymentId = deploymentId;
         }
 
         var connectionName = data[nameof(AIProfile.ConnectionName)]?.GetValue<string>()?.Trim();

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/AIProfileHandler.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/AIProfileHandler.cs
@@ -134,11 +134,12 @@ public sealed class AIProfileHandler : CatalogEntryHandlerBase<AIProfile>
             profile.TitleType = titleType.Value;
         }
 
-        var deploymentId = data[nameof(AIProfile.DeploymentId)]?.GetValue<string>()?.Trim();
+        var deploymentId = data[nameof(AIProfile.ChatDeploymentId)]?.GetValue<string>()?.Trim()
+            ?? data["DeploymentId"]?.GetValue<string>()?.Trim();
 
         if (!string.IsNullOrEmpty(deploymentId))
         {
-            profile.DeploymentId = deploymentId;
+            profile.ChatDeploymentId = deploymentId;
         }
 
         var connectionName = data[nameof(AIProfile.ConnectionName)]?.GetValue<string>()?.Trim();

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/AIProviderConnectionHandler.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/AIProviderConnectionHandler.cs
@@ -66,10 +66,12 @@ public sealed class AIProviderConnectionHandler : CatalogEntryHandlerBase<AIProv
             context.Result.Fail(new ValidationResult(S["Invalid source."], [nameof(AIProviderConnection.Source)]));
         }
 
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
         if (string.IsNullOrWhiteSpace(context.Model.ChatDeploymentName))
         {
             context.Result.Fail(new ValidationResult(S["Chat Deployment name is required."], [nameof(AIProviderConnection.ChatDeploymentName)]));
         }
+#pragma warning restore CS0618
     }
 
     public override Task InitializedAsync(InitializedContext<AIProviderConnection> context)
@@ -99,6 +101,7 @@ public sealed class AIProviderConnectionHandler : CatalogEntryHandlerBase<AIProv
             }
         }
 
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
         var defaultDeploymentName = data[nameof(AIProviderConnection.ChatDeploymentName)]?.GetValue<string>()?.Trim();
 
         if (!string.IsNullOrEmpty(defaultDeploymentName))
@@ -126,6 +129,7 @@ public sealed class AIProviderConnectionHandler : CatalogEntryHandlerBase<AIProv
         {
             connection.ImagesDeploymentName = imagesDeploymentName;
         }
+#pragma warning restore CS0618
 
         var isDefault = data[nameof(AIProviderConnection.IsDefault)]?.GetValue<bool>();
 

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/DataSourceIndexProfileHandlerBase.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Handlers/DataSourceIndexProfileHandlerBase.cs
@@ -20,6 +20,7 @@ public abstract class DataSourceIndexProfileHandlerBase : IndexProfileHandlerBas
     {
         const int defaultDimensions = 1536;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         if (string.IsNullOrEmpty(metadata?.EmbeddingProviderName) ||
             string.IsNullOrEmpty(metadata.EmbeddingConnectionName) ||
             string.IsNullOrEmpty(metadata.EmbeddingDeploymentName))
@@ -33,6 +34,7 @@ public abstract class DataSourceIndexProfileHandlerBase : IndexProfileHandlerBas
                 metadata.EmbeddingProviderName,
                 metadata.EmbeddingConnectionName,
                 metadata.EmbeddingDeploymentName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (embeddingGenerator == null)
             {

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Models/DataSourceIndexProfileMetadata.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Models/DataSourceIndexProfileMetadata.cs
@@ -6,17 +6,27 @@ namespace CrestApps.OrchardCore.AI.Core.Models;
 public sealed class DataSourceIndexProfileMetadata
 {
     /// <summary>
+    /// Gets or sets the deployment identifier for the embedding service.
+    /// When set, the deployment resolver uses this to locate the correct
+    /// provider, connection, and deployment automatically.
+    /// </summary>
+    public string EmbeddingDeploymentId { get; set; }
+
+    /// <summary>
     /// Gets or sets the provider name for the embedding service.
     /// </summary>
+    [Obsolete("Use EmbeddingDeploymentId instead. This property is retained for backward compatibility.")]
     public string EmbeddingProviderName { get; set; }
 
     /// <summary>
     /// Gets or sets the connection name for the embedding service.
     /// </summary>
+    [Obsolete("Use EmbeddingDeploymentId instead. This property is retained for backward compatibility.")]
     public string EmbeddingConnectionName { get; set; }
 
     /// <summary>
     /// Gets or sets the deployment name for the embedding service.
     /// </summary>
+    [Obsolete("Use EmbeddingDeploymentId instead. This property is retained for backward compatibility.")]
     public string EmbeddingDeploymentName { get; set; }
 }

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Models/DefaultAIDeploymentSettings.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Models/DefaultAIDeploymentSettings.cs
@@ -1,0 +1,36 @@
+namespace CrestApps.OrchardCore.AI.Core.Models;
+
+/// <summary>
+/// Global site settings for default AI deployments by type.
+/// Configurable under Settings >> Artificial Intelligence >> Default Deployments.
+/// These provide the ultimate fallback when a specific deployment of a given type
+/// is not configured at the connection or profile level.
+/// </summary>
+public sealed class DefaultAIDeploymentSettings
+{
+    /// <summary>
+    /// Gets or sets the default utility deployment identifier.
+    /// Used globally for auxiliary tasks such as planning, intent detection,
+    /// query rewriting, and chart generation when no specific utility deployment is configured.
+    /// </summary>
+    public string DefaultUtilityDeploymentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default embedding deployment identifier.
+    /// Used globally for embedding generation in document indexing, data sources,
+    /// and vector search when no specific embedding deployment is configured.
+    /// </summary>
+    public string DefaultEmbeddingDeploymentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default image generation deployment identifier.
+    /// Used globally for image generation when no specific image deployment is configured.
+    /// </summary>
+    public string DefaultImageDeploymentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default speech-to-text deployment identifier.
+    /// Used globally for speech-to-text transcription when no specific deployment is configured.
+    /// </summary>
+    public string DefaultSpeechToTextDeploymentId { get; set; }
+}

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Orchestration/DefaultOrchestrator.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Orchestration/DefaultOrchestrator.cs
@@ -27,6 +27,7 @@ public sealed class DefaultOrchestrator : IOrchestrator
     private readonly IAICompletionService _completionService;
     private readonly IAIClientFactory _aiClientFactory;
     private readonly IAITemplateService _aiTemplateService;
+    private readonly IAIDeploymentManager _deploymentManager;
     private readonly AIProviderOptions _providerOptions;
     private readonly IToolRegistry _toolRegistry;
     private readonly ITextTokenizer _tokenizer;
@@ -37,6 +38,7 @@ public sealed class DefaultOrchestrator : IOrchestrator
         IAICompletionService completionService,
         IAIClientFactory aiClientFactory,
         IAITemplateService aiTemplateService,
+        IAIDeploymentManager deploymentManager,
         IOptions<AIProviderOptions> providerOptions,
         IToolRegistry toolRegistry,
         ITextTokenizer tokenizer,
@@ -46,6 +48,7 @@ public sealed class DefaultOrchestrator : IOrchestrator
         _completionService = completionService;
         _aiClientFactory = aiClientFactory;
         _aiTemplateService = aiTemplateService;
+        _deploymentManager = deploymentManager;
         _providerOptions = providerOptions.Value;
         _toolRegistry = toolRegistry;
         _tokenizer = tokenizer;
@@ -188,7 +191,7 @@ public sealed class DefaultOrchestrator : IOrchestrator
                 var planningContext = new AICompletionContext
                 {
                     ConnectionName = context.CompletionContext.ConnectionName,
-                    DeploymentId = context.CompletionContext.DeploymentId,
+                    ChatDeploymentId = context.CompletionContext.ChatDeploymentId,
                     DisableTools = true,
                     SystemMessage = planningSystemPrompt,
                     Temperature = 0.1f,
@@ -411,19 +414,49 @@ public sealed class DefaultOrchestrator : IOrchestrator
             connectionName = provider.DefaultConnectionName;
         }
 
+        // Try the deployment resolver first for a Utility deployment.
+        var utilityDeployment = await _deploymentManager.ResolveAsync(
+            AIDeploymentType.Utility,
+            deploymentId: context.CompletionContext?.UtilityDeploymentId,
+            providerName: providerName,
+            connectionName: connectionName);
+
+        if (utilityDeployment != null)
+        {
+            var resolvedConnectionName = utilityDeployment.ConnectionName ?? connectionName;
+
+            return await _aiClientFactory.CreateChatClientAsync(providerName, resolvedConnectionName, utilityDeployment.Name);
+        }
+
+        // Fall back to chat deployment via the resolver.
+        var chatDeployment = await _deploymentManager.ResolveAsync(
+            AIDeploymentType.Chat,
+            deploymentId: context.CompletionContext?.ChatDeploymentId,
+            providerName: providerName,
+            connectionName: connectionName);
+
+        if (chatDeployment != null)
+        {
+            var resolvedConnectionName = chatDeployment.ConnectionName ?? connectionName;
+
+            return await _aiClientFactory.CreateChatClientAsync(providerName, resolvedConnectionName, chatDeployment.Name);
+        }
+
+        // Fall back to legacy dictionary-based resolution.
         if (string.IsNullOrEmpty(connectionName) ||
             !provider.Connections.TryGetValue(connectionName, out var connection))
         {
             return null;
         }
 
-        // Prefer the utility deployment, fall back to the default deployment.
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
         var deploymentName = connection.GetUtilityDeploymentOrDefaultName(throwException: false);
 
         if (string.IsNullOrEmpty(deploymentName))
         {
             deploymentName = connection.GetChatDeploymentOrDefaultName(throwException: false);
         }
+#pragma warning restore CS0618
 
         if (string.IsNullOrEmpty(deploymentName))
         {

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/AIClientProviderBase.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/AIClientProviderBase.cs
@@ -19,7 +19,9 @@ public abstract class AIClientProviderBase : IAIClientProvider
     {
         if (string.IsNullOrEmpty(deploymentName))
         {
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
             deploymentName = connection.GetChatDeploymentOrDefaultName(false);
+#pragma warning restore CS0618
         }
 
         if (string.IsNullOrEmpty(deploymentName))
@@ -38,7 +40,9 @@ public abstract class AIClientProviderBase : IAIClientProvider
     {
         if (string.IsNullOrEmpty(deploymentName))
         {
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
             deploymentName = connection.GetEmbeddingDeploymentOrDefaultName(false);
+#pragma warning restore CS0618
         }
 
         if (string.IsNullOrEmpty(deploymentName))
@@ -59,7 +63,9 @@ public abstract class AIClientProviderBase : IAIClientProvider
     {
         if (string.IsNullOrEmpty(deploymentName))
         {
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
             deploymentName = connection.GetImagesDeploymentOrDefaultName(false);
+#pragma warning restore CS0618
         }
 
         if (string.IsNullOrEmpty(deploymentName))

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/AICompletionServiceBase.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/AICompletionServiceBase.cs
@@ -7,6 +7,7 @@ public abstract class AICompletionServiceBase
 {
     protected readonly AIProviderOptions ProviderOptions;
     protected readonly IAITemplateService AITemplateService;
+    protected readonly IAIDeploymentManager DeploymentResolver;
 
     protected AICompletionServiceBase(
         AIProviderOptions providerOptions,
@@ -14,6 +15,15 @@ public abstract class AICompletionServiceBase
     {
         ProviderOptions = providerOptions;
         AITemplateService = aiTemplateService;
+    }
+
+    protected AICompletionServiceBase(
+        AIProviderOptions providerOptions,
+        IAITemplateService aiTemplateService,
+        IAIDeploymentManager deploymentResolver)
+        : this(providerOptions, aiTemplateService)
+    {
+        DeploymentResolver = deploymentResolver;
     }
 
     protected virtual string GetDefaultConnectionName(AIProvider provider, string connectionName)
@@ -30,7 +40,9 @@ public abstract class AICompletionServiceBase
     {
         if (connectionName is not null && provider.Connections.TryGetValue(connectionName, out var connection))
         {
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
             var deploymentName = connection.GetChatDeploymentOrDefaultName();
+#pragma warning restore CS0618
 
             if (!string.IsNullOrEmpty(deploymentName))
             {
@@ -38,7 +50,40 @@ public abstract class AICompletionServiceBase
             }
         }
 
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
         return provider.DefaultChatDeploymentName;
+#pragma warning restore CS0618
+    }
+
+    /// <summary>
+    /// Resolves a deployment name and connection name using the <see cref="IAIDeploymentManager"/>
+    /// with fallback to the legacy dictionary-based resolution.
+    /// </summary>
+    protected virtual async ValueTask<(string DeploymentName, string ConnectionName)> ResolveDeploymentAsync(
+        AIDeploymentType type,
+        AIProvider provider,
+        string providerName,
+        string connectionName,
+        string deploymentId = null)
+    {
+        if (DeploymentResolver != null)
+        {
+            var deployment = await DeploymentResolver.ResolveAsync(
+                type,
+                deploymentId: deploymentId,
+                providerName: providerName,
+                connectionName: connectionName);
+
+            if (deployment != null)
+            {
+                return (deployment.Name, deployment.ConnectionName ?? connectionName);
+            }
+        }
+
+        // Fall back to legacy dictionary-based resolution.
+        var legacyName = GetDefaultDeploymentName(provider, connectionName);
+
+        return (legacyName, connectionName);
     }
 
     protected static int GetTotalMessagesToSkip(int totalMessages, int pastMessageCount)

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/AIProviderConnectionsOptionsConfiguration.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/AIProviderConnectionsOptionsConfiguration.cs
@@ -69,10 +69,12 @@ public sealed class AIProviderConnectionsOptionsConfiguration : IConfigureOption
                     continue;
                 }
 
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
                 mappingContext.Values["ChatDeploymentName"] = connection.ChatDeploymentName;
                 mappingContext.Values["EmbeddingDeploymentName"] = connection.EmbeddingDeploymentName;
                 mappingContext.Values["UtilityDeploymentName"] = connection.UtilityDeploymentName;
                 mappingContext.Values["ImagesDeploymentName"] = connection.ImagesDeploymentName;
+#pragma warning restore CS0618
                 mappingContext.Values["ConnectionNameAlias"] = connection.Name;
 
                 _handlers.Invoke((handler, ctx) => handler.Initializing(ctx), mappingContext, _logger);
@@ -80,6 +82,7 @@ public sealed class AIProviderConnectionsOptionsConfiguration : IConfigureOption
                 provider.Connections[connection.ItemId] = new AIProviderConnectionEntry(mappingContext.Values);
             }
 
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
             if (defaultConnection is not null)
             {
                 provider.DefaultConnectionName = defaultConnection.ItemId;
@@ -91,6 +94,7 @@ public sealed class AIProviderConnectionsOptionsConfiguration : IConfigureOption
                 {
                     provider.DefaultChatDeploymentName = provider.Connections.FirstOrDefault().Value.GetChatDeploymentOrDefaultName();
                 }
+#pragma warning restore CS0618
 
                 if (string.IsNullOrEmpty(provider.DefaultConnectionName))
                 {

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/DataExtractionService.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/DataExtractionService.cs
@@ -267,12 +267,14 @@ public sealed class DataExtractionService
             return null;
         }
 
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
         var deploymentName = connection.GetUtilityDeploymentName(throwException: false);
 
         if (string.IsNullOrEmpty(deploymentName))
         {
             deploymentName = connection.GetChatDeploymentName(throwException: false);
         }
+#pragma warning restore CS0618
 
         if (string.IsNullOrEmpty(deploymentName))
         {

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/DataSourceIndexingService.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/DataSourceIndexingService.cs
@@ -383,6 +383,7 @@ public sealed class DataSourceIndexingService
 
         var profileMetadata = masterProfile.As<DataSourceIndexProfileMetadata>();
 
+#pragma warning disable CS0618 // Type or member is obsolete
         if (string.IsNullOrEmpty(profileMetadata.EmbeddingProviderName) ||
             string.IsNullOrEmpty(profileMetadata.EmbeddingConnectionName) ||
             string.IsNullOrEmpty(profileMetadata.EmbeddingDeploymentName))
@@ -394,6 +395,7 @@ public sealed class DataSourceIndexingService
             profileMetadata.EmbeddingProviderName,
             profileMetadata.EmbeddingConnectionName,
             profileMetadata.EmbeddingDeploymentName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (embeddingGenerator == null)
         {
@@ -615,6 +617,7 @@ public sealed class DataSourceIndexingService
         // Get the embedding configuration from the master index profile.
         var profileMetadata = masterProfile.As<DataSourceIndexProfileMetadata>();
 
+#pragma warning disable CS0618 // Type or member is obsolete
         if (string.IsNullOrEmpty(profileMetadata.EmbeddingProviderName) ||
             string.IsNullOrEmpty(profileMetadata.EmbeddingConnectionName) ||
             string.IsNullOrEmpty(profileMetadata.EmbeddingDeploymentName))
@@ -627,6 +630,7 @@ public sealed class DataSourceIndexingService
             profileMetadata.EmbeddingProviderName,
             profileMetadata.EmbeddingConnectionName,
             profileMetadata.EmbeddingDeploymentName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (embeddingGenerator == null)
         {

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/DefaultAIDeploymentManager.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/DefaultAIDeploymentManager.cs
@@ -1,18 +1,24 @@
+using CrestApps.OrchardCore.AI.Core.Models;
 using CrestApps.OrchardCore.AI.Models;
 using CrestApps.OrchardCore.Core.Services;
 using CrestApps.OrchardCore.Services;
 using Microsoft.Extensions.Logging;
+using OrchardCore.Settings;
 
 namespace CrestApps.OrchardCore.AI.Core.Services;
 
 public sealed class DefaultAIDeploymentManager : NamedSourceCatalogManager<AIDeployment>, IAIDeploymentManager
 {
+    private readonly ISiteService _siteService;
+
     public DefaultAIDeploymentManager(
         INamedSourceCatalog<AIDeployment> deploymentStore,
         IEnumerable<ICatalogEntryHandler<AIDeployment>> handlers,
+        ISiteService siteService,
         ILogger<DefaultAIDeploymentManager> logger)
         : base(deploymentStore, handlers, logger)
     {
+        _siteService = siteService;
     }
 
     public async ValueTask<IEnumerable<AIDeployment>> GetAllAsync(string providerName, string connectionName)
@@ -27,5 +33,88 @@ public sealed class DefaultAIDeploymentManager : NamedSourceCatalogManager<AIDep
         }
 
         return deployments;
+    }
+
+    public async ValueTask<IEnumerable<AIDeployment>> GetByTypeAsync(AIDeploymentType type)
+    {
+        var deployments = (await Catalog.GetAllAsync())
+            .Where(x => x.Type == type);
+
+        foreach (var deployment in deployments)
+        {
+            await LoadAsync(deployment);
+        }
+
+        return deployments;
+    }
+
+    public async ValueTask<AIDeployment> GetDefaultAsync(string providerName, string connectionName, AIDeploymentType type)
+    {
+        var deployments = await GetAllAsync(providerName, connectionName);
+
+        var candidates = deployments.Where(d => d.Type == type);
+
+        return candidates.FirstOrDefault(d => d.IsDefault)
+            ?? candidates.FirstOrDefault();
+    }
+
+    public async ValueTask<AIDeployment> ResolveAsync(AIDeploymentType type, string deploymentId = null, string providerName = null, string connectionName = null)
+    {
+        if (!string.IsNullOrEmpty(deploymentId))
+        {
+            var deployment = await FindByIdAsync(deploymentId);
+
+            if (deployment != null)
+            {
+                return deployment;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(providerName) && !string.IsNullOrEmpty(connectionName))
+        {
+            var deployment = await GetDefaultAsync(providerName, connectionName, type);
+
+            if (deployment != null)
+            {
+                return deployment;
+            }
+        }
+
+        var globalDefaultId = await GetGlobalDefaultIdAsync(type);
+
+        if (!string.IsNullOrEmpty(globalDefaultId))
+        {
+            return await FindByIdAsync(globalDefaultId);
+        }
+
+        return null;
+    }
+
+    public async ValueTask<IEnumerable<AIDeployment>> GetAllByTypeAsync(AIDeploymentType type, string providerName = null)
+    {
+        var allDeployments = await GetAllAsync();
+
+        var filtered = allDeployments.Where(d => d.Type == type);
+
+        if (!string.IsNullOrEmpty(providerName))
+        {
+            filtered = filtered.Where(d => string.Equals(d.ProviderName, providerName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return filtered;
+    }
+
+    private async ValueTask<string> GetGlobalDefaultIdAsync(AIDeploymentType type)
+    {
+        var settings = await _siteService.GetSettingsAsync<DefaultAIDeploymentSettings>();
+
+        return type switch
+        {
+            AIDeploymentType.Utility => settings.DefaultUtilityDeploymentId,
+            AIDeploymentType.Embedding => settings.DefaultEmbeddingDeploymentId,
+            AIDeploymentType.Image => settings.DefaultImageDeploymentId,
+            AIDeploymentType.SpeechToText => settings.DefaultSpeechToTextDeploymentId,
+            _ => null,
+        };
     }
 }

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/DefaultAIDeploymentStore.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/DefaultAIDeploymentStore.cs
@@ -14,9 +14,23 @@ public sealed class DefaultAIDeploymentStore : NamedSourceCatalog<AIDeployment>
 
     protected override void Saving(AIDeployment deployment, DictionaryDocument<AIDeployment> document)
     {
-        if (document.Records.Values.Any(x => x.ProviderName == deployment.ProviderName && x.ConnectionName == deployment.ConnectionName && x.Name.Equals(deployment.Name, StringComparison.OrdinalIgnoreCase) && x.ItemId != deployment.ItemId))
+        if (document.Records.Values.Any(x => x.ProviderName == deployment.ProviderName && x.Type == deployment.Type && x.ConnectionName == deployment.ConnectionName && x.Name.Equals(deployment.Name, StringComparison.OrdinalIgnoreCase) && x.ItemId != deployment.ItemId))
         {
             throw new InvalidOperationException("There is already another deployment with the same name.");
+        }
+
+        if (deployment.IsDefault)
+        {
+            var previousDefaults = document.Records.Values
+                .Where(x => x.IsDefault &&
+                    x.Type == deployment.Type &&
+                    x.ConnectionName.Equals(deployment.ConnectionName, StringComparison.OrdinalIgnoreCase) &&
+                    x.ItemId != deployment.ItemId);
+
+            foreach (var previous in previousDefaults)
+            {
+                previous.IsDefault = false;
+            }
         }
     }
 }

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/DeploymentAwareAICompletionClient.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/DeploymentAwareAICompletionClient.cs
@@ -10,6 +10,7 @@ namespace CrestApps.OrchardCore.AI.Core.Services;
 public abstract class DeploymentAwareAICompletionClient : NamedAICompletionClient
 {
     private readonly ICatalog<AIDeployment> _store;
+    private readonly IAIDeploymentManager _deploymentManager;
 
     public DeploymentAwareAICompletionClient(
         string name,
@@ -21,7 +22,8 @@ public abstract class DeploymentAwareAICompletionClient : NamedAICompletionClien
         DefaultAIOptions defaultOptions,
         IEnumerable<IAICompletionServiceHandler> handlers,
         ICatalog<AIDeployment> deploymentStore,
-        IAITemplateService aiTemplateService)
+        IAITemplateService aiTemplateService,
+        IAIDeploymentManager deploymentManager)
         : base(
             name,
             aIClientFactory,
@@ -31,16 +33,28 @@ public abstract class DeploymentAwareAICompletionClient : NamedAICompletionClien
             providerOptions,
             defaultOptions,
             handlers,
-            aiTemplateService)
+            aiTemplateService,
+            deploymentManager)
     {
         _store = deploymentStore;
+        _deploymentManager = deploymentManager;
     }
 
     protected override async Task<AIDeployment> GetDeploymentAsync(AICompletionContext content)
     {
-        if (!string.IsNullOrEmpty(content.DeploymentId))
+        if (!string.IsNullOrEmpty(content.ChatDeploymentId))
         {
-            return await _store.FindByIdAsync(content.DeploymentId);
+            if (_deploymentManager != null)
+            {
+                var deployment = await _deploymentManager.FindByIdAsync(content.ChatDeploymentId);
+
+                if (deployment != null)
+                {
+                    return deployment;
+                }
+            }
+
+            return await _store.FindByIdAsync(content.ChatDeploymentId);
         }
 
         return null;

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/NamedAICompletionClient.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/NamedAICompletionClient.cs
@@ -31,8 +31,9 @@ public abstract class NamedAICompletionClient : AICompletionServiceBase, IAIComp
         AIProviderOptions providerOptions,
         DefaultAIOptions defaultOptions,
         IEnumerable<IAICompletionServiceHandler> handlers,
-        IAITemplateService aiTemplateService)
-        : base(providerOptions, aiTemplateService)
+        IAITemplateService aiTemplateService,
+        IAIDeploymentManager deploymentManager)
+        : base(providerOptions, aiTemplateService, deploymentManager)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         Name = name;
@@ -97,6 +98,16 @@ public abstract class NamedAICompletionClient : AICompletionServiceBase, IAIComp
 
         var connectionName = GetDefaultConnectionName(provider, context.ConnectionName);
 
+        // Use the deployment resolver with fallback to legacy dictionary-based resolution.
+        var (deploymentName, resolvedConnectionName) = await ResolveDeploymentAsync(
+            AIDeploymentType.Chat,
+            provider,
+            ProviderName,
+            connectionName,
+            deploymentId: context.ChatDeploymentId);
+
+        connectionName = resolvedConnectionName;
+
         if (string.IsNullOrEmpty(connectionName))
         {
             Logger.LogWarning("Unable to chat. Unable to find a connection '{ConnectionName}' or the default connection", context.ConnectionName);
@@ -104,11 +115,9 @@ public abstract class NamedAICompletionClient : AICompletionServiceBase, IAIComp
             return null;
         }
 
-        var deploymentName = GetDefaultDeploymentName(provider, connectionName);
-
         if (string.IsNullOrEmpty(deploymentName))
         {
-            Logger.LogWarning("Unable to chat. Unable to find a deployment id '{DeploymentId}' or the default deployment", context.DeploymentId);
+            Logger.LogWarning("Unable to chat. Unable to find a deployment id '{DeploymentId}' or the default deployment", context.ChatDeploymentId);
 
             return null;
         }
@@ -147,6 +156,16 @@ public abstract class NamedAICompletionClient : AICompletionServiceBase, IAIComp
 
         var connectionName = GetDefaultConnectionName(provider, context.ConnectionName);
 
+        // Use the deployment resolver with fallback to legacy dictionary-based resolution.
+        var (deploymentName, resolvedConnectionName) = await ResolveDeploymentAsync(
+            AIDeploymentType.Chat,
+            provider,
+            ProviderName,
+            connectionName,
+            deploymentId: context.ChatDeploymentId);
+
+        connectionName = resolvedConnectionName;
+
         if (string.IsNullOrEmpty(connectionName))
         {
             Logger.LogWarning("Unable to chat. Unable to find a connection '{ConnectionName}' or the default connection", context.ConnectionName);
@@ -154,11 +173,9 @@ public abstract class NamedAICompletionClient : AICompletionServiceBase, IAIComp
             yield break;
         }
 
-        var deploymentName = GetDefaultDeploymentName(provider, connectionName);
-
         if (string.IsNullOrEmpty(deploymentName))
         {
-            Logger.LogWarning("Unable to chat. Unable to find a deployment id '{DeploymentId}' or the default deployment", context.DeploymentId);
+            Logger.LogWarning("Unable to chat. Unable to find a deployment id '{DeploymentId}' or the default deployment", context.ChatDeploymentId);
 
             yield break;
         }

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/PostSessionProcessingService.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/PostSessionProcessingService.cs
@@ -717,12 +717,14 @@ public sealed class PostSessionProcessingService
             return null;
         }
 
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
         var deploymentName = connection.GetUtilityDeploymentName(throwException: false);
 
         if (string.IsNullOrEmpty(deploymentName))
         {
             deploymentName = connection.GetChatDeploymentName(throwException: false);
         }
+#pragma warning restore CS0618
 
         if (string.IsNullOrEmpty(deploymentName))
         {

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/PreemptiveSearchQueryProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/PreemptiveSearchQueryProvider.cs
@@ -185,12 +185,14 @@ public sealed class PreemptiveSearchQueryProvider
         }
 
         // Prefer the utility deployment, fall back to the default deployment.
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
         var deploymentName = connection.GetUtilityDeploymentOrDefaultName(throwException: false);
 
         if (string.IsNullOrEmpty(deploymentName))
         {
             deploymentName = connection.GetChatDeploymentOrDefaultName(throwException: false);
         }
+#pragma warning restore CS0618
 
         if (string.IsNullOrEmpty(deploymentName))
         {

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Tools/GenerateChartTool.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Tools/GenerateChartTool.cs
@@ -100,12 +100,14 @@ public sealed class GenerateChartTool : AIFunction
             }
 
             // Prefer the utility deployment for chart generation, fall back to the default deployment.
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
             var deploymentName = connection.GetUtilityDeploymentOrDefaultName(throwException: false);
 
             if (string.IsNullOrEmpty(deploymentName))
             {
                 deploymentName = connection.GetChatDeploymentOrDefaultName(throwException: false);
             }
+#pragma warning restore CS0618
 
             if (string.IsNullOrEmpty(deploymentName))
             {

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Tools/GenerateImageTool.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Tools/GenerateImageTool.cs
@@ -99,7 +99,9 @@ public sealed class GenerateImageTool : AIFunction
                 return "Image generation is not available. No connection is configured.";
             }
 
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
             var deploymentName = connection.GetImagesDeploymentOrDefaultName(throwException: false);
+#pragma warning restore CS0618
 
             if (string.IsNullOrEmpty(deploymentName))
             {

--- a/src/Core/CrestApps.OrchardCore.OpenAI.Azure.Core/Services/AzureOpenAICompletionClient.cs
+++ b/src/Core/CrestApps.OrchardCore.OpenAI.Azure.Core/Services/AzureOpenAICompletionClient.cs
@@ -12,7 +12,6 @@ using CrestApps.OrchardCore.AI.Core;
 using CrestApps.OrchardCore.AI.Core.Models;
 using CrestApps.OrchardCore.AI.Core.Services;
 using CrestApps.OrchardCore.AI.Models;
-using CrestApps.OrchardCore.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenAI.Chat;
@@ -21,7 +20,6 @@ namespace CrestApps.OrchardCore.OpenAI.Azure.Core.Services;
 
 public sealed class AzureOpenAICompletionClient : AICompletionServiceBase, IAICompletionClient
 {
-    private readonly INamedCatalog<AIDeployment> _deploymentStore;
     private readonly IServiceProvider _serviceProvider;
     private readonly ILoggerFactory _loggerFactory;
     private readonly IEnumerable<IAICompletionServiceHandler> _completionServiceHandlers;
@@ -31,16 +29,15 @@ public sealed class AzureOpenAICompletionClient : AICompletionServiceBase, IAICo
     private AzureOpenAIClientOptions _clientOptions;
 
     public AzureOpenAICompletionClient(
-        INamedCatalog<AIDeployment> deploymentStore,
         IOptions<AIProviderOptions> providerOptions,
         IServiceProvider serviceProvider,
         ILoggerFactory loggerFactory,
         IEnumerable<IAICompletionServiceHandler> completionServiceHandlers,
         IOptions<DefaultAIOptions> defaultOptions,
-        IAITemplateService aiTemplateService)
-        : base(providerOptions.Value, aiTemplateService)
+        IAITemplateService aiTemplateService,
+        IAIDeploymentManager deploymentManager)
+        : base(providerOptions.Value, aiTemplateService, deploymentManager)
     {
-        _deploymentStore = deploymentStore;
         _serviceProvider = serviceProvider;
         _loggerFactory = loggerFactory;
         _completionServiceHandlers = completionServiceHandlers;
@@ -63,6 +60,16 @@ public sealed class AzureOpenAICompletionClient : AICompletionServiceBase, IAICo
 
         var connectionName = GetDefaultConnectionName(provider, context.ConnectionName);
 
+        // Use the deployment resolver with fallback to legacy dictionary-based resolution.
+        var (deploymentName, resolvedConnectionName) = await ResolveDeploymentAsync(
+            AIDeploymentType.Chat,
+            provider,
+            AzureOpenAIConstants.ProviderName,
+            connectionName,
+            deploymentId: context.ChatDeploymentId);
+
+        connectionName = resolvedConnectionName;
+
         if (string.IsNullOrEmpty(connectionName))
         {
             _logger.LogWarning("Unable to chat. Unable to find a connection '{ConnectionName}' or the default connection", context.ConnectionName);
@@ -72,16 +79,14 @@ public sealed class AzureOpenAICompletionClient : AICompletionServiceBase, IAICo
 
         if (!provider.Connections.TryGetValue(connectionName, out var connectionProperties))
         {
-            _logger.LogWarning("Unable to chat. Unable to find a connection '{ConnectionName}'", context.ConnectionName);
+            _logger.LogWarning("Unable to chat. Unable to find a connection '{ConnectionName}'", connectionName);
 
             return null;
         }
 
-        var deploymentName = GetDefaultDeploymentName(provider, connectionName);
-
         if (string.IsNullOrEmpty(deploymentName))
         {
-            _logger.LogWarning("Unable to chat. Unable to find a deployment id '{DeploymentId}' or the default deployment", context.DeploymentId);
+            _logger.LogWarning("Unable to chat. Unable to find a deployment id '{DeploymentId}' or the default deployment", context.ChatDeploymentId);
 
             return null;
         }
@@ -184,11 +189,33 @@ public sealed class AzureOpenAICompletionClient : AICompletionServiceBase, IAICo
         ArgumentNullException.ThrowIfNull(messages);
         ArgumentNullException.ThrowIfNull(context);
 
-        (var connection, var deploymentName) = await GetConnectionAsync(context, AzureOpenAIConstants.ProviderName);
+        if (!ProviderOptions.Providers.TryGetValue(AzureOpenAIConstants.ProviderName, out var provider))
+        {
+            throw new ArgumentException($"Provider '{AzureOpenAIConstants.ProviderName}' not found.");
+        }
 
-        if (connection is null)
+        var connectionName = GetDefaultConnectionName(provider, context.ConnectionName);
+
+        // Use the deployment resolver with fallback to legacy dictionary-based resolution.
+        var (deploymentName, resolvedConnectionName) = await ResolveDeploymentAsync(
+            AIDeploymentType.Chat,
+            provider,
+            AzureOpenAIConstants.ProviderName,
+            connectionName,
+            deploymentId: context.ChatDeploymentId);
+
+        connectionName = resolvedConnectionName;
+
+        if (string.IsNullOrEmpty(connectionName) || !provider.Connections.TryGetValue(connectionName, out var connection))
         {
             _logger.LogWarning("Unable to chat. Unable to find a connection '{ConnectionName}' or the default connection", context.ConnectionName);
+
+            yield break;
+        }
+
+        if (string.IsNullOrEmpty(deploymentName))
+        {
+            _logger.LogWarning("Unable to chat. Unable to find a deployment id '{DeploymentId}' or the default deployment", context.ChatDeploymentId);
 
             yield break;
         }
@@ -331,20 +358,12 @@ public sealed class AzureOpenAICompletionClient : AICompletionServiceBase, IAICo
             yield return new Microsoft.Extensions.AI.ChatResponseUpdate
             {
                 Contents = [new Microsoft.Extensions.AI.TextContent(
-                    "\n\n⚠️ The operation reached the maximum number of tool-call iterations and may be incomplete. " +
-                    "Please try again or break the task into smaller steps.")],
+                    """
+                    The operation reached the maximum number of tool-call iterations and may be incomplete. 
+                    Please try again or break the task into smaller steps.
+                    """)],
             };
         }
-    }
-
-    protected override async Task<AIDeployment> GetDeploymentAsync(AICompletionContext content)
-    {
-        if (!string.IsNullOrEmpty(content.DeploymentId))
-        {
-            return await _deploymentStore.FindByIdAsync(content.DeploymentId);
-        }
-
-        return null;
     }
 
     private async Task ProcessToolCallsAsync(List<ChatMessage> prompts, IEnumerable<ChatToolCall> toolCalls, IEnumerable<Microsoft.Extensions.AI.AIFunction> functions)
@@ -380,9 +399,11 @@ public sealed class AzureOpenAICompletionClient : AICompletionServiceBase, IAICo
                 // Detect truncation: "end of data" in the message indicates the model's output
                 // was cut off (hit the output token limit) rather than being structurally wrong.
                 var errorMessage = ex.Message.Contains("end of data", StringComparison.OrdinalIgnoreCase)
-                    ? "The function arguments were truncated because the response exceeded the output token limit. "
-                      + "Please significantly reduce the size of the arguments. For content creation, use much shorter text, "
-                      + "omit optional fields, or split the operation into multiple smaller calls."
+                    ? """
+                      The function arguments were truncated because the response exceeded the output token limit.
+                      Please significantly reduce the size of the arguments. For content creation, use much shorter text, 
+                      omit optional fields, or split the operation into multiple smaller calls. 
+                    """
                     : "Invalid JSON in function arguments. Please fix the JSON structure and try again.";
 
                 prompts.Add(new ToolChatMessage(toolCall.Id,
@@ -447,8 +468,6 @@ public sealed class AzureOpenAICompletionClient : AICompletionServiceBase, IAICo
 
         return azureClient;
     }
-
-
 
     private static async ValueTask<IReadOnlyList<Microsoft.Extensions.AI.AIFunction>> ConfigureOptionsAsync(ChatCompletionOptions chatOptions, AICompletionContext context, List<ChatMessage> prompts)
     {
@@ -552,32 +571,5 @@ public sealed class AzureOpenAICompletionClient : AICompletionServiceBase, IAICo
         }
 
         return prompts;
-    }
-
-    private async Task<(AIProviderConnectionEntry, string)> GetConnectionAsync(AICompletionContext context, string providerName)
-    {
-        string deploymentName = null;
-
-        if (ProviderOptions.Providers.TryGetValue(providerName, out var provider))
-        {
-            var connectionName = GetDefaultConnectionName(provider, context.ConnectionName);
-
-            deploymentName = GetDefaultDeploymentName(provider, connectionName);
-
-            var deployment = await GetDeploymentAsync(context);
-
-            if (deployment is not null)
-            {
-                connectionName = deployment.ConnectionName;
-                deploymentName = deployment.Name;
-            }
-
-            if (!string.IsNullOrEmpty(connectionName) && provider.Connections.TryGetValue(connectionName, out var connectionProperties))
-            {
-                return new(connectionProperties, deploymentName);
-            }
-        }
-
-        return new(null, deploymentName);
     }
 }

--- a/src/Core/CrestApps.OrchardCore.OpenAI.Core/Services/OpenAICompletionClient.cs
+++ b/src/Core/CrestApps.OrchardCore.OpenAI.Core/Services/OpenAICompletionClient.cs
@@ -25,7 +25,8 @@ public class OpenAICompletionClient : DeploymentAwareAICompletionClient
         IOptions<DefaultAIOptions> defaultOptions,
         INamedCatalog<AIDeployment> deploymentStore,
         IEnumerable<IOpenAIChatOptionsConfiguration> openAIChatOptionsConfigurations,
-        IAITemplateService aiTemplateService
+        IAITemplateService aiTemplateService,
+        IAIDeploymentManager deploymentManager
         ) : base(
             OpenAIConstants.ImplementationName,
             aIClientFactory,
@@ -36,7 +37,8 @@ public class OpenAICompletionClient : DeploymentAwareAICompletionClient
             defaultOptions.Value,
             handlers,
             deploymentStore,
-            aiTemplateService)
+            aiTemplateService,
+            deploymentManager)
     {
         _openAIChatOptionsConfigurations = openAIChatOptionsConfigurations;
     }
@@ -52,7 +54,8 @@ public class OpenAICompletionClient : DeploymentAwareAICompletionClient
         DefaultAIOptions defaultOptions,
         INamedCatalog<AIDeployment> deploymentStore,
         IEnumerable<IOpenAIChatOptionsConfiguration> openAIChatOptionsConfigurations,
-        IAITemplateService aiTemplateService
+        IAITemplateService aiTemplateService,
+        IAIDeploymentManager deploymentManager
         ) : base(
             implementationName,
             aIClientFactory,
@@ -63,7 +66,8 @@ public class OpenAICompletionClient : DeploymentAwareAICompletionClient
             defaultOptions,
             handlers,
             deploymentStore,
-            aiTemplateService)
+            aiTemplateService,
+            deploymentManager)
     {
         _openAIChatOptionsConfigurations = openAIChatOptionsConfigurations;
     }

--- a/src/Core/CrestApps.OrchardCore.Recipes.Core/Schemas/AIDeploymentRecipeStep.cs
+++ b/src/Core/CrestApps.OrchardCore.Recipes.Core/Schemas/AIDeploymentRecipeStep.cs
@@ -25,7 +25,9 @@ public sealed class AIDeploymentRecipeStep : IRecipeStep
             .Properties(
                 ("Name", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Deployment name as specified by the vendor.")),
                 ("ProviderName", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Provider name (e.g., OpenAI, DeepSeek).")),
-                ("ConnectionName", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Connection name used to configure the provider.")))
+                ("ConnectionName", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Connection name used to configure the provider.")),
+                ("Type", new JsonSchemaBuilder().Type(SchemaValueType.String).Enum("Chat", "Utility", "Embedding", "Image", "SpeechToText").Description("The deployment type. Defaults to Chat when not specified.")),
+                ("IsDefault", new JsonSchemaBuilder().Type(SchemaValueType.Boolean).Description("Whether this deployment is the default for its type and connection.")))
             .Required("Name")
             .AdditionalProperties(true);
 

--- a/src/Core/CrestApps.OrchardCore.Recipes.Core/Schemas/AIProfileRecipeStep.cs
+++ b/src/Core/CrestApps.OrchardCore.Recipes.Core/Schemas/AIProfileRecipeStep.cs
@@ -32,7 +32,9 @@ public sealed class AIProfileRecipeStep : IRecipeStep
                 ("TitleType", new JsonSchemaBuilder().Type(SchemaValueType.String).Enum("InitialPrompt", "Generated").Description("How the session title is generated.")),
                 ("PromptTemplate", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Liquid template for TemplatePrompt profiles.")),
                 ("ConnectionName", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Connection name for the AI provider.")),
-                ("DeploymentId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Deployment ID for the AI model.")),
+                ("ChatDeploymentId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Chat deployment ID for the AI model.")),
+                ("UtilityDeploymentId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Utility deployment ID for the AI model.")),
+                ("DeploymentId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Deprecated. Use ChatDeploymentId instead.")),
                 ("Properties", new JsonSchemaBuilder().Type(SchemaValueType.Object).AdditionalProperties(true).Description("Extended profile properties including AIProfileMetadata.")),
                 ("Settings", new JsonSchemaBuilder().Type(SchemaValueType.Object).AdditionalProperties(true).Description("Profile settings.")))
             .Required("Name")

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/chat-interactions.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/chat-interactions.md
@@ -22,7 +22,7 @@ This module provides ad-hoc AI chat interactions with configurable parameters, e
 - Session persistence — all chat messages are saved and can be resumed later
 - Configurable parameters — customize temperature, TopP, max tokens, frequency/presence penalties, and past messages count
 - Tool integration — select from available AI tools and MCP connections
-- Connection/deployment selection — choose specific connections and deployments for each interaction
+- Deployment selection — choose specific chat and utility deployments for each interaction (grouped by connection in the dropdown)
 - Orchestrator selection — choose which orchestrator runtime manages the session (e.g., Default, Copilot)
 - Image generation — generate images from text prompts using AI image generation models
 - Chart generation — generate chart specifications from prompts (for rendering as a chart)
@@ -32,8 +32,12 @@ This module provides ad-hoc AI chat interactions with configurable parameters, e
 
 1. Enable the `AI Chat Interactions` feature in Orchard Core admin
 2. Navigate to **Artificial Intelligence > Chat Interactions**
-3. Click **+ New Chat** and select an AI provider
+3. Click **+ New Chat** and select your chat and utility deployments
 4. Configure your chat settings and start chatting
+
+:::tip
+Deployment dropdowns are grouped by connection, making it easy to find the right model. If you don't select a deployment, the system uses the fallback chain: connection default → global default (configured in **Settings > Artificial Intelligence > Default Deployments**).
+:::
 
 ## Orchestration
 
@@ -65,11 +69,12 @@ Image and chart generation are handled by AI tools that the orchestrator can inv
 
 ### Configuration
 
-To enable image generation, configure the `ImagesDeploymentName` in your AI provider connection settings.
+To enable image generation, create an `AIDeployment` record with type `Image` for your image model (e.g., `dall-e-3`). You can set it as the default Image deployment globally, or select it explicitly on each chat interaction.
 
 **Option 1: Admin UI**
 
-Navigate to **Artificial Intelligence > Provider Connections**, edit your connection, and set the **Images deployment name** field (e.g., `dall-e-3`).
+1. Navigate to **Artificial Intelligence > Deployments** and create a new deployment with type **Image** (e.g., name `dall-e-3`, connection `openai-main`).
+2. Optionally, set it as the default Image deployment in **Settings > Artificial Intelligence > Default Deployments**.
 
 **Option 2: Configuration (appsettings.json)**
 
@@ -81,10 +86,23 @@ Navigate to **Artificial Intelligence > Provider Connections**, edit your connec
         "OpenAI": {
           "Connections": {
             "default": {
-              "ChatDeploymentName": "gpt-4o",
-              "UtilityDeploymentName": "gpt-4o-mini",
-              "EmbeddingDeploymentName": "",
-              "ImagesDeploymentName": "dall-e-3"
+              "Deployments": [
+                {
+                  "Name": "gpt-4o",
+                  "Type": "Chat",
+                  "IsDefault": true
+                },
+                {
+                  "Name": "gpt-4o-mini",
+                  "Type": "Utility",
+                  "IsDefault": true
+                },
+                {
+                  "Name": "dall-e-3",
+                  "Type": "Image",
+                  "IsDefault": true
+                }
+              ]
             }
           }
         }
@@ -93,3 +111,7 @@ Navigate to **Artificial Intelligence > Provider Connections**, edit your connec
   }
 }
 ```
+
+:::info
+The legacy format with `ChatDeploymentName`, `UtilityDeploymentName`, `EmbeddingDeploymentName`, and `ImagesDeploymentName` on the connection is still supported for backward compatibility but is deprecated. See the [migration guide](migration-typed-deployments) for details.
+:::

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/consuming-ai-services.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/consuming-ai-services.md
@@ -224,6 +224,21 @@ services.AddScoped<IOrchestrationContextBuilderHandler, MyOrchestrationHandler>(
 | Extend orchestration context building | `IOrchestrationContextBuilderHandler` |
 | Extend completion context building | `IAICompletionContextBuilderHandler` |
 
+## Deployment Resolution
+
+When an AI Profile, Chat Interaction, or other resource requests a deployment, the system resolves it using a typed fallback chain:
+
+1. **Explicit deployment** — The `ChatDeploymentId` or `UtilityDeploymentId` explicitly assigned on the profile/resource
+2. **Connection default for type** — The deployment marked `IsDefault: true` for that type on the associated connection
+3. **Global default** — The default deployment configured in **Settings → Artificial Intelligence → Default AI Deployment Settings** (e.g., `DefaultUtilityDeploymentId`, `DefaultEmbeddingDeploymentId`, `DefaultImageDeploymentId`)
+4. **null/error** — If no deployment is found at any level
+
+Each deployment is a first-class typed entity with a `Type` property (`Chat`, `Utility`, `Embedding`, `Image`, `SpeechToText`). This allows the system to automatically resolve the correct model based on the task being performed.
+
+:::tip
+When using `IAIClientFactory` directly, you still specify the `deploymentName` explicitly. The typed resolution chain applies to higher-level services that work with profiles and interactions.
+:::
+
 ## Implementing a Custom Orchestrator
 
 You can create a custom orchestrator by implementing `IOrchestrator`:

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/migration-typed-deployments.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/migration-typed-deployments.md
@@ -1,0 +1,277 @@
+---
+sidebar_label: "Migration: Typed Deployments"
+sidebar_position: 11
+title: Migrating to Typed AI Deployments
+description: Guide for migrating from connection-based deployment names to the new typed AIDeployment system.
+---
+
+# Migrating to Typed AI Deployments
+
+## What Changed
+
+Previously, AI model deployments were configured as string properties on `AIProviderConnection` — for example, `ChatDeploymentName`, `UtilityDeploymentName`, `EmbeddingDeploymentName`, and `ImagesDeploymentName`. This meant deployments were tightly coupled to their connection and had no independent identity.
+
+In the new architecture, **AIDeployment** is a first-class typed entity with:
+
+- **`Type`** — The deployment purpose: `Chat`, `Utility`, `Embedding`, `Image`, or `SpeechToText`
+- **`IsDefault`** — Whether this deployment is the default for its type within its connection
+- **Independent identity** — Each deployment has its own record and can be referenced by ID
+
+AI Profiles and Chat Interactions now reference deployments by ID (`ChatDeploymentId`, `UtilityDeploymentId`) rather than relying on a connection name to resolve deployment names.
+
+## Deployment Resolution Fallback
+
+When resolving a deployment for a given type, the system follows this fallback chain:
+
+1. **Explicit deployment** — The deployment ID set directly on the profile or interaction
+2. **Connection default** — The default deployment for the requested type on the connection
+3. **Global default** — The global default deployment configured in **Settings > Artificial Intelligence > Default Deployments**
+4. **null** — No deployment found
+
+---
+
+## Automatic Migration
+
+:::tip
+Most users don't need to do anything manually. The automatic migration handles the conversion on startup.
+:::
+
+On application startup, the data migration automatically:
+
+1. Scans all existing `AIProviderConnection` records for deployment name fields
+2. Creates typed `AIDeployment` records for each non-empty deployment name
+3. Sets the `IsDefault` flag on the first deployment of each type per connection
+4. Preserves all existing functionality — no downtime or data loss
+
+After migration, review the auto-created deployments at **Artificial Intelligence > Deployments** to verify they look correct.
+
+---
+
+## Manual Steps After Migration
+
+After the automatic migration runs:
+
+1. **Review deployments** — Navigate to **Artificial Intelligence > Deployments** and verify the auto-created records have the correct types and default flags.
+2. **Set global defaults** — Go to **Settings > Artificial Intelligence > Default Deployments** and configure global defaults for Utility, Embedding, and Image deployment types. These serve as fallbacks when a profile doesn't specify a deployment.
+3. **Update profiles (optional)** — Existing profiles continue to work. However, you can now set separate `ChatDeploymentId` and `UtilityDeploymentId` on each profile for more granular control.
+
+---
+
+## appsettings.json Migration
+
+### Old Format (still supported, deprecated)
+
+```json
+{
+  "OrchardCore": {
+    "CrestApps_AI": {
+      "Providers": {
+        "OpenAI": {
+          "Connections": {
+            "default": {
+              "ChatDeploymentName": "gpt-4o",
+              "UtilityDeploymentName": "gpt-4o-mini",
+              "EmbeddingDeploymentName": "text-embedding-3-small",
+              "ImagesDeploymentName": "dall-e-3"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### New Format (recommended)
+
+```json
+{
+  "OrchardCore": {
+    "CrestApps_AI": {
+      "Providers": {
+        "OpenAI": {
+          "Connections": {
+            "default": {
+              "Deployments": [
+                {
+                  "Name": "gpt-4o",
+                  "Type": "Chat",
+                  "IsDefault": true
+                },
+                {
+                  "Name": "gpt-4o-mini",
+                  "Type": "Utility",
+                  "IsDefault": true
+                },
+                {
+                  "Name": "text-embedding-3-small",
+                  "Type": "Embedding",
+                  "IsDefault": true
+                },
+                {
+                  "Name": "dall-e-3",
+                  "Type": "Image",
+                  "IsDefault": true
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::info
+Both formats are supported simultaneously. If both are present, the `Deployments` array takes precedence. We recommend migrating to the new format when convenient.
+:::
+
+---
+
+## Code Migration
+
+### Reading Deployment Names
+
+If your code referenced deployment names from the connection:
+
+```csharp
+// ❌ Old — deprecated
+var chatDeployment = connection.ChatDeploymentName;
+var embeddingDeployment = connection.EmbeddingDeploymentName;
+
+// ✅ New — use IAIDeploymentManager
+var chatDeployment = await deploymentManager.ResolveAsync(
+    AIDeploymentType.Chat, connectionName: connectionName);
+var embeddingDeployment = await deploymentManager.ResolveAsync(
+    AIDeploymentType.Embedding, connectionName: connectionName);
+```
+
+### AI Profile DeploymentId
+
+If your code referenced `DeploymentId` on AI Profiles:
+
+```csharp
+// ❌ Old
+var deploymentId = profile.DeploymentId;
+
+// ✅ New
+var chatDeploymentId = profile.ChatDeploymentId;
+var utilityDeploymentId = profile.UtilityDeploymentId;
+```
+
+### AICompletionContext
+
+If your code built or read `AICompletionContext`:
+
+```csharp
+// ❌ Old
+context.DeploymentId = "some-id";
+
+// ✅ New
+context.ChatDeploymentId = "some-id";
+```
+
+---
+
+## Recipe Migration
+
+### Old Recipe Format (still works)
+
+```json
+{
+  "steps": [
+    {
+      "name": "AIProfile",
+      "profiles": [
+        {
+          "Name": "MyProfile",
+          "ConnectionName": "default",
+          "DeploymentId": "some-deployment-id",
+          ...
+        }
+      ]
+    }
+  ]
+}
+```
+
+### New Recipe Format
+
+```json
+{
+  "steps": [
+    {
+      "name": "AIProfile",
+      "profiles": [
+        {
+          "Name": "MyProfile",
+          "ConnectionName": "default",
+          "ChatDeploymentId": "chat-deployment-id",
+          "UtilityDeploymentId": "utility-deployment-id",
+          ...
+        }
+      ]
+    }
+  ]
+}
+```
+
+### AI Deployment Recipes
+
+Create typed deployments via recipes:
+
+```json
+{
+  "steps": [
+    {
+      "name": "AIDeployment",
+      "deployments": [
+        {
+          "Name": "gpt-4o",
+          "ProviderName": "OpenAI",
+          "ConnectionName": "default",
+          "Type": "Chat",
+          "IsDefault": true
+        },
+        {
+          "Name": "gpt-4o-mini",
+          "ProviderName": "OpenAI",
+          "ConnectionName": "default",
+          "Type": "Utility",
+          "IsDefault": true
+        },
+        {
+          "Name": "dall-e-3",
+          "ProviderName": "OpenAI",
+          "ConnectionName": "default",
+          "Type": "Image",
+          "IsDefault": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Summary of Deprecated Properties
+
+| Deprecated Property | Replacement |
+|---|---|
+| `AIProviderConnection.ChatDeploymentName` | `AIDeployment` record with `Type = Chat` |
+| `AIProviderConnection.UtilityDeploymentName` | `AIDeployment` record with `Type = Utility` |
+| `AIProviderConnection.EmbeddingDeploymentName` | `AIDeployment` record with `Type = Embedding` |
+| `AIProviderConnection.ImagesDeploymentName` | `AIDeployment` record with `Type = Image` |
+| `AIProvider.DefaultChatDeploymentName` | `AIDeployment` with `IsDefault = true` |
+| `AIProvider.DefaultEmbeddingDeploymentName` | `AIDeployment` with `IsDefault = true` |
+| `AIProvider.DefaultUtilityDeploymentName` | `AIDeployment` with `IsDefault = true` |
+| `AIProvider.DefaultImagesDeploymentName` | `AIDeployment` with `IsDefault = true` |
+| `AIProfile.DeploymentId` | `AIProfile.ChatDeploymentId` |
+| `ChatInteraction.DeploymentId` | `ChatInteraction.ChatDeploymentId` |
+| `AICompletionContext.DeploymentId` | `AICompletionContext.ChatDeploymentId` |
+
+:::warning
+The deprecated properties still work for backward compatibility but will be removed in a future major release. Migrate to the new typed deployment system at your earliest convenience.
+:::

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/overview.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/overview.md
@@ -74,17 +74,15 @@ Below is an example configuration:
       "Providers": {
         "<!-- Provider name goes here (valid values: 'OpenAI', 'Azure', 'AzureAIInference', or 'Ollama') -->": {
           "DefaultConnectionName": "<!-- The default connection name to use from the Connections list -->",
-          "DefaultChatDeploymentName": "<!-- The default deployment name for chat completions -->",
-          "DefaultUtilityDeploymentName": "<!-- Optional: a lightweight model for auxiliary tasks like query rewriting and planning -->",
-          "DefaultEmbeddingDeploymentName": "<!-- The default embedding deployment name (optional, for embedding services) -->",
-          "DefaultImagesDeploymentName": "<!-- The default deployment name for image generation (optional, e.g., 'dall-e-3') -->",
           "Connections": {
             "<!-- Connection name goes here -->": {
-              "ChatDeploymentName": "<!-- The deployment name for this connection -->",
-              "UtilityDeploymentName": "<!-- Optional: a lightweight model for auxiliary tasks -->",
-              "EmbeddingDeploymentName": "<!-- The embedding deployment name (optional) -->",
-              "ImagesDeploymentName": "<!-- The image generation deployment name (optional, e.g., 'dall-e-3') -->"
-              // Provider-specific settings go here
+              // Provider-specific settings go here (e.g., ApiKey, Endpoint)
+              "Deployments": [
+                { "Name": "<!-- model name -->", "Type": "Chat", "IsDefault": true },
+                { "Name": "<!-- lightweight model name -->", "Type": "Utility", "IsDefault": true },
+                { "Name": "<!-- embedding model name -->", "Type": "Embedding", "IsDefault": true },
+                { "Name": "<!-- image model name -->", "Type": "Image", "IsDefault": true }
+              ]
             }
           }
         }
@@ -93,6 +91,31 @@ Below is an example configuration:
   }
 }
 ```
+
+:::warning Legacy Format (Deprecated)
+The following configuration format using `ChatDeploymentName`, `UtilityDeploymentName`, `EmbeddingDeploymentName`, and `ImagesDeploymentName` at both the provider and connection levels is **deprecated**. It is still supported and will be auto-migrated at runtime, but new configurations should use the `Deployments` array format shown above.
+
+```json
+{
+  "Providers": {
+    "OpenAI": {
+      "DefaultChatDeploymentName": "gpt-4o",
+      "DefaultUtilityDeploymentName": "gpt-4o-mini",
+      "DefaultEmbeddingDeploymentName": "text-embedding-3-large",
+      "DefaultImagesDeploymentName": "dall-e-3",
+      "Connections": {
+        "openai-cloud": {
+          "ChatDeploymentName": "gpt-4o",
+          "UtilityDeploymentName": "gpt-4o-mini",
+          "EmbeddingDeploymentName": "text-embedding-3-large",
+          "ImagesDeploymentName": "dall-e-3"
+        }
+      }
+    }
+  }
+}
+```
+:::
 
 #### Default Parameters
 
@@ -108,25 +131,59 @@ Below is an example configuration:
 | `EnableOpenTelemetry` | Enables OpenTelemetry tracing for AI requests. | `false` |
 | `EnableDistributedCaching` | Enables distributed caching for AI responses. | `true` |
 
-#### Deployment Name Settings
+#### Typed AI Deployments
 
-**Provider-level settings** (apply to all connections under a provider):
+Each deployment is a first-class entity with a **Type** and an optional **IsDefault** flag. Deployments are defined in the `Deployments` array on each connection.
 
-| Setting | Description | Required |
-|---------|-------------|----------|
-| `DefaultChatDeploymentName` | The default model for chat completions | Yes |
-| `DefaultUtilityDeploymentName` | The default lightweight model for auxiliary tasks (e.g., query rewriting, planning). Falls back to `DefaultChatDeploymentName` when not set. | No |
-| `DefaultEmbeddingDeploymentName` | The model for generating embeddings (for retrieval-augmented generation (RAG) / vector search) | No |
-| `DefaultImagesDeploymentName` | The model for image generation (e.g., `dall-e-3`). Required for image generation features. | No |
+| Property | Description | Required |
+|----------|-------------|----------|
+| `Name` | The model/deployment name (e.g., `gpt-4o`, `text-embedding-3-large`) | Yes |
+| `Type` | The deployment type. Valid values: `Chat`, `Utility`, `Embedding`, `Image`, `SpeechToText` | Yes |
+| `IsDefault` | Whether this is the default deployment for its type within the connection | No |
 
-**Connection-level settings** (specific to an individual connection):
+**Deployment Types:**
 
-| Setting | Description | Required |
-|---------|-------------|----------|
-| `ChatDeploymentName` | The model for chat completions for this connection | Yes |
-| `UtilityDeploymentName` | A lightweight model for auxiliary tasks such as query rewriting, planning, and chart generation. Falls back to `ChatDeploymentName` when not set. | No |
-| `EmbeddingDeploymentName` | The model for generating embeddings (for retrieval-augmented generation (RAG) / vector search) | No |
-| `ImagesDeploymentName` | The model for image generation (e.g., `dall-e-3`). Required for image generation features. | No |
+| Type | Purpose | Example Models |
+|------|---------|----------------|
+| `Chat` | Primary chat completions | `gpt-4o`, `gemini-pro`, `deepseek-chat` |
+| `Utility` | Lightweight auxiliary tasks (query rewriting, planning, chart generation). Falls back to `Chat` when not set. | `gpt-4o-mini`, `gemini-flash` |
+| `Embedding` | Generating embeddings for RAG / vector search | `text-embedding-3-large`, `text-embedding-3-small` |
+| `Image` | Image generation | `dall-e-3`, `dall-e-2` |
+| `SpeechToText` | Speech-to-text transcription | `whisper-1` |
+
+#### Deployment Resolution
+
+When an AI Profile or service requests a deployment, the system resolves it using the following fallback chain:
+
+1. **Explicit deployment** — The deployment explicitly assigned to the profile/resource
+2. **Connection default for type** — The deployment marked `IsDefault: true` for that type on the connection
+3. **Global default** — The default deployment configured in **Default AI Deployment Settings** (see below)
+4. **null/error** — No deployment found
+
+#### Default AI Deployment Settings
+
+A new settings page is available under **Settings → Artificial Intelligence → Default AI Deployment Settings**. This page allows administrators to configure global default deployments:
+
+| Setting | Description |
+|---------|-------------|
+| `DefaultUtilityDeploymentId` | The global default deployment for utility tasks |
+| `DefaultEmbeddingDeploymentId` | The global default deployment for embedding generation |
+| `DefaultImageDeploymentId` | The global default deployment for image generation |
+
+These global defaults act as the final fallback when no explicit or connection-level default is configured.
+
+:::tip
+Chat deployments do not need a global default because they are always explicitly set on AI Profiles or Chat Interactions.
+:::
+
+:::warning Deprecated Settings
+The following provider-level and connection-level settings are **deprecated** and will be auto-migrated:
+
+- `DefaultChatDeploymentName`, `DefaultUtilityDeploymentName`, `DefaultEmbeddingDeploymentName`, `DefaultImagesDeploymentName` (provider-level)
+- `ChatDeploymentName`, `UtilityDeploymentName`, `EmbeddingDeploymentName`, `ImagesDeploymentName` (connection-level)
+
+Use the `Deployments` array on connections and the **Default AI Deployment Settings** page instead.
+:::
 
 ---
 
@@ -159,9 +216,11 @@ Simply inject `IAIClientFactory` into your service and use the `CreateChatClient
 | **Feature Name** | AI Deployments |
 | **Feature ID** | `CrestApps.OrchardCore.AI.Deployments` |
 
-Manages AI model deployments.
+Manages typed AI model deployments.
 
-The **AI Deployments** feature extends the **AI Services** feature by enabling AI model deployment capabilities.
+The **AI Deployments** feature extends the **AI Services** feature by enabling AI model deployment capabilities. Each deployment is a first-class entity with a `Type` property (`Chat`, `Utility`, `Embedding`, `Image`, `SpeechToText`) and an `IsDefault` flag. Deployments are associated with a provider connection and can be managed through the admin UI under **Artificial Intelligence → Deployments**.
+
+UI dropdowns for deployment selection display deployments **grouped by connection**, making it easy to find the correct deployment without navigating a cascading connection → deployment hierarchy.
 
 ### AI Chat Services Feature
 
@@ -194,7 +253,7 @@ The **AI Chat WebAPI** feature extends the **AI Chat Services** feature by enabl
 
 Provides user interface to manage AI connections.
 
-The **AI Connection Management** feature enhances **AI Services** by providing a user interface to manage provider connections.
+The **AI Connection Management** feature enhances **AI Services** by providing a user interface to manage provider connections. Connections are **pure connection configurations** — they define how to reach a provider (endpoint, API key, authentication). Deployments (models) are managed separately as typed entities associated with each connection.
 
 ---
 
@@ -217,15 +276,15 @@ You need to use a paid plan for all of these even when using models that are fre
 :::
 
 - DeepSeek
-  - **Deployment name** (the model to use): e.g. `deepseek-chat`.
+  - **Model name**: e.g. `deepseek-chat`.
   - **Endpoint**: `https://api.deepseek.com/v1/`.
   - **API Key**: Generate one in [DeepSeek Platform](https://platform.deepseek.com).
 - Google Gemini
-  - **Deployment name**: e.g. `gemini-2.0-flash`.
+  - **Model name**: e.g. `gemini-2.0-flash`.
   - **Endpoint**: `https://generativelanguage.googleapis.com/v1beta/openai/`.
   - **API Key**: Generate one in [Google AI Studio](https://aistudio.google.com).
 - OpenAI
-  - **Deployment name**: e.g. `gpt-4o-mini`.
+  - **Model name**: e.g. `gpt-4o-mini`.
   - **Endpoint**: `https://api.openai.com/v1/`.
   - **API Key**: Generate one in [OpenAI Platform](https://platform.openai.com/account/api-keys).
 
@@ -247,9 +306,10 @@ You can add or update a connection using **recipes**. Below is a recipe for addi
           "Source": "OpenAI",
           "Name": "deepseek",
           "IsDefault": false,
-          "ChatDeploymentName": "deepseek-chat",
-          "UtilityDeploymentName": "deepseek-chat",
           "DisplayText": "DeepSeek",
+          "Deployments": [
+            { "Name": "deepseek-chat", "Type": "Chat", "IsDefault": true }
+          ],
           "Properties": {
             "OpenAIConnectionMetadata": {
               "Endpoint": "https://api.deepseek.com/v1",
@@ -263,7 +323,11 @@ You can add or update a connection using **recipes**. Below is a recipe for addi
 }
 ```  
 
-This recipe ensures that a **DeepSeek** connection is added or updated within the AI provider settings. Replace `<!-- DeepSeek API Key -->` with a valid API key to authenticate the connection.  
+This recipe ensures that a **DeepSeek** connection is added or updated within the AI provider settings, with a typed `Chat` deployment. Replace `<!-- DeepSeek API Key -->` with a valid API key to authenticate the connection.  
+
+:::warning Legacy Recipe Format
+The old recipe format using `ChatDeploymentName`, `UtilityDeploymentName`, etc. on the connection object is still supported but deprecated. Migrate to the `Deployments` array format shown above.
+:::
 
 If a connection with the same `Name` and `Source` already exists, the recipe updates its properties. Otherwise, it creates a new connection.
 

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/profile-templates.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/profile-templates.md
@@ -60,7 +60,8 @@ Navigate to **Artificial Intelligence → Profile Templates** in the admin dashb
    - **Is Listable** — Whether this template appears in the selection dropdown (default: true).
 3. Configure the **Profile Settings**:
    - **Profile Type** — The type of profile to create (`Chat`, `Utility`, or `TemplatePrompt`). Required.
-   - **Connection Name** — The AI provider connection to use (dropdown, optional).
+   - **Chat Deployment** — The AI deployment to use for chat completions (dropdown, grouped by connection, optional).
+   - **Utility Deployment** — The AI deployment to use for auxiliary tasks (dropdown, grouped by connection, optional).
    - **Orchestrator Name** — The orchestrator to use (dropdown, defaults to "default").
    - **Welcome Message** — An initial greeting shown to users.
    - **Title Type** — How the session title is generated.
@@ -126,7 +127,8 @@ Description: Template for customer support chatbots
 Category: Customer Service
 IsListable: true
 ProfileType: Chat
-ConnectionName: openai-main
+ChatDeploymentId: your-chat-deployment-id
+UtilityDeploymentId: your-utility-deployment-id
 WelcomeMessage: Hello! How can I help you today?
 TitleType: Generated
 Temperature: 0.7
@@ -154,7 +156,9 @@ The body after the front matter becomes the **System Message**.
 | `Category` | string | `null` | Category for grouping templates |
 | `IsListable` | bool | `true` | Whether this template appears in selection dropdowns |
 | `ProfileType` | string | `null` | Profile type: `Chat`, `Utility`, or `TemplatePrompt` |
-| `ConnectionName` | string | `null` | AI provider connection name |
+| `ConnectionName` | string | `null` | AI provider connection name (derived from deployment if not set) |
+| `ChatDeploymentId` | string | `null` | Deployment ID for chat completions |
+| `UtilityDeploymentId` | string | `null` | Deployment ID for auxiliary/utility tasks |
 | `WelcomeMessage` | string | `null` | Initial greeting shown to users |
 | `TitleType` | string | `null` | Session title type: `Generated`, `Fixed`, or `None` |
 | `OrchestratorName` | string | `null` | Name of the orchestrator to use |
@@ -362,6 +366,8 @@ Use the `AIProfileTemplate` step key to define templates in a recipe:
           "IsListable": true,
           "ProfileType": "Chat",
           "ConnectionName": "openai-main",
+          "ChatDeploymentId": "your-chat-deployment-id",
+          "UtilityDeploymentId": "your-utility-deployment-id",
           "SystemMessage": "You are a professional customer support agent.",
           "WelcomeMessage": "Hello! How can I help you today?",
           "TitleType": "Generated",
@@ -396,7 +402,9 @@ Use the `AIProfileTemplate` step key to define templates in a recipe:
 | `Category` | string | No | Grouping category |
 | `IsListable` | bool | No | Whether the template appears in dropdowns (default: `true`) |
 | `ProfileType` | string | No | `Chat`, `Utility`, or `TemplatePrompt` |
-| `ConnectionName` | string | No | AI provider connection name |
+| `ConnectionName` | string | No | AI provider connection name (derived from deployment if not set) |
+| `ChatDeploymentId` | string | No | Deployment ID for chat completions |
+| `UtilityDeploymentId` | string | No | Deployment ID for auxiliary/utility tasks |
 | `SystemMessage` | string | No | System prompt text |
 | `WelcomeMessage` | string | No | Initial greeting for chat profiles |
 | `TitleType` | string | No | `Generated`, `Fixed`, or `None` |
@@ -422,7 +430,9 @@ When a template is applied, the following fields are pre-filled on the new AI Pr
 | Template Field | AI Profile Field | Notes |
 |----------------|-----------------|-------|
 | `ProfileType` | `Type` | The profile type (Chat, Utility, TemplatePrompt) |
-| `ConnectionName` | `ConnectionName` | AI provider connection |
+| `ConnectionName` | `ConnectionName` | AI provider connection (derived from deployment if not set) |
+| `ChatDeploymentId` | `ChatDeploymentId` | Deployment for chat completions |
+| `UtilityDeploymentId` | `UtilityDeploymentId` | Deployment for auxiliary tasks |
 | `OrchestratorName` | `OrchestratorName` | The orchestrator to use |
 | `SystemMessage` | `AIProfileMetadata.SystemMessage` | Via profile metadata |
 | `WelcomeMessage` | `WelcomeMessage` | Only for Chat profiles |

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/profiles-code.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/profiles-code.md
@@ -139,8 +139,9 @@ You can create or update AI chat profiles via the Recipes module using the follo
           "Type": "Chat",
           "TitleType": "InitialPrompt",
           "PromptTemplate": null,
-          "ConnectionName":"<!-- Connection name for the deployment; leave blank for default. -->",
-          "DeploymentId":"<!-- Deployment ID for the deployment; leave blank for default. -->",
+          "ConnectionName":"<!-- Connection name; leave blank to derive from the selected deployment. -->",
+          "ChatDeploymentId":"<!-- Deployment ID for chat completions; leave blank for default. -->",
+          "UtilityDeploymentId":"<!-- Deployment ID for utility/auxiliary tasks; leave blank for default. -->",
           "Properties": {
             "AIProfileMetadata": {
               "SystemMessage": "You are an AI assistant that helps people find information.",
@@ -172,7 +173,9 @@ You can create or update AI deployments using the following recipe:
         {
           "Name": "<!-- Deployment name as specified by the vendor -->",
           "ProviderName": "<!-- Provider name (e.g., OpenAI, DeepSeek) -->",
-          "ConnectionName": "<!-- Connection name used to configure the provider -->"
+          "ConnectionName": "<!-- Connection name used to configure the provider -->",
+          "Type": "<!-- Deployment type: Chat, Utility, Embedding, Image, or SpeechToText -->",
+          "IsDefault": false
         }
       ]
     }

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/azure-ai-inference.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/azure-ai-inference.md
@@ -27,19 +27,15 @@ To configure the OpenAI connection, add the following settings to the `appsettin
       "Providers": {
         "AzureAIInference": {
           "DefaultConnectionName": "default",
-          "DefaultChatDeploymentName": "Phi-3-medium-4k-instruct",
-          "DefaultUtilityDeploymentName": "Phi-3-medium-4k-instruct",
-          "DefaultEmbeddingDeploymentName": "",
-          "DefaultImagesDeploymentName": "",
           "Connections": {
             "default": {
               "Endpoint": "https://<!-- Your Azure Resource Name -->.services.ai.azure.com/models",
               "AuthenticationType": "ApiKey",
               "ApiKey": "<!-- Your GitHub Access Token goes here -->",
-              "ChatDeploymentName": "Phi-3-medium-4k-instruct",
-              "UtilityDeploymentName": "Phi-3-medium-4k-instruct",
-              "EmbeddingDeploymentName": "",
-              "ImagesDeploymentName": ""
+              "Deployments": [
+                { "Name": "Phi-3-medium-4k-instruct", "Type": "Chat", "IsDefault": true },
+                { "Name": "Phi-3-medium-4k-instruct", "Type": "Utility", "IsDefault": true }
+              ]
             }
           }
         }
@@ -48,6 +44,26 @@ To configure the OpenAI connection, add the following settings to the `appsettin
   }
 }
 ```
+
+:::warning Legacy Format (Deprecated)
+The following format using `ChatDeploymentName`, `UtilityDeploymentName`, etc. is still supported but deprecated. Existing configurations will be auto-migrated at runtime.
+
+```json
+{
+  "Connections": {
+    "default": {
+      "Endpoint": "https://my-resource.services.ai.azure.com/models",
+      "AuthenticationType": "ApiKey",
+      "ApiKey": "...",
+      "ChatDeploymentName": "Phi-3-medium-4k-instruct",
+      "UtilityDeploymentName": "Phi-3-medium-4k-instruct",
+      "EmbeddingDeploymentName": "",
+      "ImagesDeploymentName": ""
+    }
+  }
+}
+```
+:::
 
 Authentication Type in the connection can be `Default`, `ManagedIdentity` or `ApiKey`. When using `ApiKey` authentication type, `ApiKey` is required.
 

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/azure-openai.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/azure-openai.md
@@ -27,19 +27,17 @@ Add the following section to your `appsettings.json` to configure Azure OpenAI:
       "Providers": {
         "Azure": {
           "DefaultConnectionName": "<!-- Default connection name -->",
-          "DefaultChatDeploymentName": "<!-- Default deployment name for chat completions -->",
-          "DefaultUtilityDeploymentName": "<!-- Optional: a lightweight model for auxiliary tasks -->",
-          "DefaultEmbeddingDeploymentName": "<!-- Optional: the default embedding deployment name -->",
-          "DefaultImagesDeploymentName": "<!-- Optional: the default image generation deployment name -->",
           "Connections": {
             "<!-- Unique connection name, ideally your Azure AccountName -->": {
               "Endpoint": "https://<!-- Your Azure Resource Name -->.openai.azure.com/",
               "AuthenticationType": "ApiKey",
               "ApiKey": "<!-- API Key for your Azure AI instance -->",
-              "ChatDeploymentName": "<!-- Deployment name for chat completions -->",
-              "UtilityDeploymentName": "<!-- Optional: a lightweight model for auxiliary tasks -->",
-              "EmbeddingDeploymentName": "<!-- Optional: the embedding deployment name -->",
-              "ImagesDeploymentName": "<!-- Optional: the image generation deployment name -->"
+              "Deployments": [
+                { "Name": "<!-- chat model deployment -->", "Type": "Chat", "IsDefault": true },
+                { "Name": "<!-- utility model deployment -->", "Type": "Utility", "IsDefault": true },
+                { "Name": "<!-- embedding model deployment -->", "Type": "Embedding", "IsDefault": true },
+                { "Name": "<!-- image model deployment -->", "Type": "Image", "IsDefault": true }
+              ]
             }
           }
         }
@@ -48,6 +46,26 @@ Add the following section to your `appsettings.json` to configure Azure OpenAI:
   }
 }
 ```
+
+:::warning Legacy Format (Deprecated)
+The following format using `ChatDeploymentName`, `UtilityDeploymentName`, `EmbeddingDeploymentName`, and `ImagesDeploymentName` at both provider and connection levels is still supported but deprecated. Existing configurations will be auto-migrated at runtime.
+
+```json
+{
+  "Connections": {
+    "my-azure-account": {
+      "Endpoint": "https://my-account.openai.azure.com/",
+      "AuthenticationType": "ApiKey",
+      "ApiKey": "...",
+      "ChatDeploymentName": "gpt-4o",
+      "UtilityDeploymentName": "gpt-4o-mini",
+      "EmbeddingDeploymentName": "text-embedding-ada-002",
+      "ImagesDeploymentName": "dall-e-3"
+    }
+  }
+}
+```
+:::
 
 Valid values for `AuthenticationType` are: `Default`, `ManagedIdentity`, or `ApiKey`. If using `ApiKey`, the `ApiKey` field is required.
 
@@ -84,7 +102,8 @@ Define an AI profile with the following step in your recipe:
           "TitleType": "InitialPrompt",
           "PromptTemplate": null,
           "ConnectionName": "<!-- Connection name (optional) -->",
-          "DeploymentId": "<!-- Deployment ID (optional) -->",
+          "ChatDeploymentId": "<!-- Chat Deployment ID (optional) -->",
+          "UtilityDeploymentId": "<!-- Utility Deployment ID (optional) -->",
           "Properties": {
             "AIProfileMetadata": {
               "SystemMessage": "You are an AI assistant that helps people find information.",
@@ -102,6 +121,10 @@ Define an AI profile with the following step in your recipe:
   ]
 }
 ```
+
+:::tip
+AI Profiles now use `ChatDeploymentId` and `UtilityDeploymentId` instead of the previous single `DeploymentId` field. This allows profiles to specify separate deployments for chat completions and auxiliary utility tasks.
+:::
 
 ## RAG / Data Sources
 

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/index.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/index.md
@@ -16,7 +16,7 @@ A provider is a module that implements the connection layer between CrestApps AI
 - **Authentication** — Managing API keys, tokens, or managed identity credentials
 - **Client creation** — Creating `IChatClient`, `IEmbeddingGenerator`, and `IImageGenerator` instances
 - **Connection configuration** — Defining endpoints, deployment names, and provider-specific settings
-- **Deployment management** — Supporting multiple models/deployments under a single connection
+- **Deployment management** — Supporting multiple typed models/deployments under a single connection, each with a `Type` (`Chat`, `Utility`, `Embedding`, `Image`, `SpeechToText`) and an `IsDefault` flag
 
 ## Built-in Providers
 
@@ -129,3 +129,36 @@ services.AddAIDeploymentProvider("CustomProvider", options =>
     options.Description = _localizer["Custom provider deployments."];
 });
 ```
+
+### Typed Deployments
+
+Deployments are now first-class typed entities. Each deployment has a `Type` property that indicates its purpose:
+
+| Type | Purpose |
+|------|---------|
+| `Chat` | Primary chat completions |
+| `Utility` | Lightweight auxiliary tasks (query rewriting, planning) |
+| `Embedding` | Vector embeddings for RAG / semantic search |
+| `Image` | Image generation |
+| `SpeechToText` | Speech-to-text transcription |
+
+When configuring connections via `appsettings.json`, deployments are defined as a `Deployments` array on each connection:
+
+```json
+{
+  "Connections": {
+    "my-connection": {
+      "ApiKey": "...",
+      "Deployments": [
+        { "Name": "gpt-4o", "Type": "Chat", "IsDefault": true },
+        { "Name": "gpt-4o-mini", "Type": "Utility", "IsDefault": true },
+        { "Name": "text-embedding-3-large", "Type": "Embedding", "IsDefault": true }
+      ]
+    }
+  }
+}
+```
+
+The `IsDefault` flag marks a deployment as the default for its type within that connection. The system resolves deployments using a fallback chain: explicit assignment → connection default for type → global default → null/error.
+
+Global defaults can be configured under **Settings → Artificial Intelligence → Default AI Deployment Settings**.

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/ollama.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/ollama.md
@@ -38,24 +38,39 @@ To configure the Ollama connection, add the following settings to the `appsettin
       "Providers": {
         "Ollama": {
           "DefaultConnectionName": "Default",
-          "DefaultChatDeploymentName": "deepseek-v2:16b",
-          "DefaultUtilityDeploymentName": "deepseek-v2:16b",
-          "DefaultEmbeddingDeploymentName": "",
-          "DefaultImagesDeploymentName": "",
           "Connections": {
             "Default": {
               "Endpoint": "<!-- Ollama host address -->",
-              "ChatDeploymentName": "deepseek-v2:16b",
-              "UtilityDeploymentName": "deepseek-v2:16b",
-              "EmbeddingDeploymentName": "",
-              "ImagesDeploymentName": ""
+              "Deployments": [
+                { "Name": "deepseek-v2:16b", "Type": "Chat", "IsDefault": true },
+                { "Name": "deepseek-v2:16b", "Type": "Utility", "IsDefault": true }
+              ]
             }
+          }
         }
       }
     }
   }
 }
 ```
+
+:::warning Legacy Format (Deprecated)
+The following format using `ChatDeploymentName`, `UtilityDeploymentName`, etc. is still supported but deprecated. Existing configurations will be auto-migrated at runtime.
+
+```json
+{
+  "Connections": {
+    "Default": {
+      "Endpoint": "...",
+      "ChatDeploymentName": "deepseek-v2:16b",
+      "UtilityDeploymentName": "deepseek-v2:16b",
+      "EmbeddingDeploymentName": "",
+      "ImagesDeploymentName": ""
+    }
+  }
+}
+```
+:::
 
 ### Aspire
 

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/openai.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/providers/openai.md
@@ -29,17 +29,15 @@ To configure a connection, add the following settings to the `appsettings.json` 
       "Providers": {
         "OpenAI": {
           "DefaultConnectionName": "openai-cloud",
-          "DefaultChatDeploymentName": "gpt-4o-mini",
-          "DefaultUtilityDeploymentName": "gpt-4o-mini",
-          "DefaultEmbeddingDeploymentName": "",
-          "DefaultImagesDeploymentName": "",
           "Connections": {
             "openai-cloud": {
               "ApiKey": "<!-- Your API Key Goes Here -->",
-              "ChatDeploymentName": "gpt-4o-mini",
-              "UtilityDeploymentName": "gpt-4o-mini",
-              "EmbeddingDeploymentName": "",
-              "ImagesDeploymentName": ""
+              "Deployments": [
+                { "Name": "gpt-4o", "Type": "Chat", "IsDefault": true },
+                { "Name": "gpt-4o-mini", "Type": "Utility", "IsDefault": true },
+                { "Name": "text-embedding-3-large", "Type": "Embedding", "IsDefault": true },
+                { "Name": "dall-e-3", "Type": "Image", "IsDefault": true }
+              ]
             }
           }
         }
@@ -49,11 +47,29 @@ To configure a connection, add the following settings to the `appsettings.json` 
 }
 ```
 
+:::warning Legacy Format (Deprecated)
+The following format using `ChatDeploymentName`, `UtilityDeploymentName`, etc. is still supported but deprecated. Existing configurations will be auto-migrated at runtime.
+
+```json
+{
+  "Connections": {
+    "openai-cloud": {
+      "ApiKey": "...",
+      "ChatDeploymentName": "gpt-4o",
+      "UtilityDeploymentName": "gpt-4o-mini",
+      "EmbeddingDeploymentName": "text-embedding-3-large",
+      "ImagesDeploymentName": "dall-e-3"
+    }
+  }
+}
+```
+:::
+
 ---
 
 ### Using AI Deployments  
 
-If the **AI Deployments** feature is enabled, you can create multiple deployments under the same connection. This allows different AI profiles to utilize different models while sharing the same connection.  
+If the **AI Deployments** feature is enabled, you can create multiple typed deployments under the same connection. Each deployment has a `Type` (`Chat`, `Utility`, `Embedding`, `Image`, `SpeechToText`) and an optional `IsDefault` flag. This allows different AI profiles to utilize different models while sharing the same connection. UI dropdowns display deployments grouped by connection for easy selection.
 
 ### Configuring Other AI Providers  
 
@@ -90,18 +106,13 @@ To configure DeepSeek, add the following settings:
       "Providers": {
         "OpenAI": {
           "DefaultConnectionName": "deepseek",
-          "DefaultChatDeploymentName": "deepseek-chat",
-          "DefaultUtilityDeploymentName": "",
-          "DefaultEmbeddingDeploymentName": "",
-          "DefaultImagesDeploymentName": "",
           "Connections": {
             "deepseek": {
               "Endpoint": "https://api.deepseek.com/v1",
               "ApiKey": "<!-- Your API Key Goes Here -->",
-              "ChatDeploymentName": "deepseek-chat",
-              "UtilityDeploymentName": "",
-              "EmbeddingDeploymentName": "",
-              "ImagesDeploymentName": ""
+              "Deployments": [
+                { "Name": "deepseek-chat", "Type": "Chat", "IsDefault": true }
+              ]
             }
           }
         }
@@ -111,7 +122,7 @@ To configure DeepSeek, add the following settings:
 }
 ```
 
-> The `DefaultConnectionName` and `DefaultChatDeploymentName` under the `OpenAI` node are required only if you want to set the `deepseek` connection as the default OpenAI connection when AI profiles use the default setting.  
+> The `DefaultConnectionName` under the `OpenAI` node is required only if you want to set the `deepseek` connection as the default OpenAI connection when AI profiles use the default setting.  
 
 #### Configuration via AI Connection Management  
 
@@ -127,8 +138,10 @@ If you are using the **AI Connection Management** feature, you can configure Dee
           "Source": "OpenAI",
           "Name": "deepseek",
           "IsDefault": false,
-          "ChatDeploymentName": "deepseek-chat",
           "DisplayText": "DeepSeek",
+          "Deployments": [
+            { "Name": "deepseek-chat", "Type": "Chat", "IsDefault": true }
+          ],
           "Properties": {
             "OpenAIConnectionMetadata": {
               "Endpoint": "https://api.deepseek.com/v1",
@@ -155,18 +168,13 @@ To connect to **Google Gemini**, **Together AI**, **vLLM**, or any other support
       "Providers": {
         "OpenAI": {
           "DefaultConnectionName": "google-gemini",
-          "DefaultChatDeploymentName": "gemini-pro",
-          "DefaultUtilityDeploymentName": "",
-          "DefaultEmbeddingDeploymentName": "",
-          "DefaultImagesDeploymentName": "",
           "Connections": {
             "google-gemini": {
               "Endpoint": "https://generativelanguage.googleapis.com/v1",
               "ApiKey": "<!-- Your Google Gemini API Key -->",
-              "ChatDeploymentName": "gemini-pro",
-              "UtilityDeploymentName": "",
-              "EmbeddingDeploymentName": "",
-              "ImagesDeploymentName": ""
+              "Deployments": [
+                { "Name": "gemini-pro", "Type": "Chat", "IsDefault": true }
+              ]
             }
           }
         }
@@ -182,7 +190,7 @@ You can replace `Endpoint` with the appropriate URL for each provider.
 
 #### Configuring Multiple Models
 
-If you need access to multiple DeepSeek models, you can execute the following recipe to add standard deployments:
+If you need access to multiple DeepSeek models, you can execute the following recipe to add typed deployments:
 
 ```json
 {
@@ -192,11 +200,14 @@ If you need access to multiple DeepSeek models, you can execute the following re
       "deployments": [
         {
           "Name": "deepseek-chat",
+          "Type": "Chat",
+          "IsDefault": true,
           "ProviderName": "OpenAI",
           "ConnectionName": "deepseek"
         },
         {
           "Name": "deepseek-reasoner",
+          "Type": "Chat",
           "ProviderName": "OpenAI",
           "ConnectionName": "deepseek"
         }
@@ -206,6 +217,6 @@ If you need access to multiple DeepSeek models, you can execute the following re
 }
 ```
 
-This configuration allows you to access multiple models provided by DeepSeek, such as `deepseek-chat` and `deepseek-reasoner`.
+This configuration allows you to access multiple models provided by DeepSeek, such as `deepseek-chat` (set as the default Chat deployment) and `deepseek-reasoner`.
 
 By following these steps, you can seamlessly integrate DeepSeek into your AI chat feature, either as a default provider or alongside other AI models.

--- a/src/CrestApps.OrchardCore.Documentations/docs/changelog/v2.0.0.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/changelog/v2.0.0.md
@@ -131,6 +131,7 @@ A new suite of modules for multi-channel communication:
 - **AI Tool Registration** — New fluent API for registering AI tools with `.AddAITool<T>()`, supporting categories, purposes, and selectable/system tool modes.
 - **AI Profile Types** — Added `Utility` and `TemplatePrompt` profile types in addition to `Chat`.
 - **AI Deployments** — New feature for managing AI model deployments.
+- **Typed AI Deployments** — AI deployments are now first-class typed entities. Each deployment has a `Type` property (`Chat`, `Utility`, `Embedding`, `Image`, `SpeechToText`) and an `IsDefault` flag. Connections are pure connections — deployment name fields (`ChatDeploymentName`, `EmbeddingDeploymentName`, `UtilityDeploymentName`, `ImagesDeploymentName`) on `AIProviderConnection` are deprecated. The `IAIDeploymentManager` service resolves deployments by type with fallback chain (explicit → connection default → global default). New settings page under **Settings > Artificial Intelligence > Default Deployments** to configure global defaults. AI Profiles and Chat Interactions now use `ChatDeploymentId` and `UtilityDeploymentId` instead of `DeploymentId`. Deployment dropdowns show all deployments grouped by connection. Existing connection deployment names are automatically migrated to typed `AIDeployment` records on startup. Both old format (deployment names on connection) and new format (`Deployments` array) are supported in `appsettings.json`. See the [migration guide](../ai/migration-typed-deployments.md) for details.
 - **AI Connection Management** — UI for managing provider connections from the admin dashboard.
 - **AI Chat WebAPI** — RESTful API endpoints for interacting with AI chat.
 - **Workflow Integration** — AI Completion tasks for Orchard Core Workflows.
@@ -292,6 +293,35 @@ Fixed `OpenXmlIngestionDocumentReader.GetCellValue` to correctly handle Excel ce
 ---
 
 ## Breaking Changes
+
+### Typed AI Deployments
+
+AI deployments are now first-class typed entities. Each deployment has a `Type` property (`Chat`, `Utility`, `Embedding`, `Image`, `SpeechToText`) and an `IsDefault` flag.
+
+**Key changes:**
+- **Connections are pure connections** — deployment name fields (`ChatDeploymentName`, `EmbeddingDeploymentName`, `UtilityDeploymentName`, `ImagesDeploymentName`) on `AIProviderConnection` are deprecated
+- **Typed deployment resolution** — `IAIDeploymentManager` resolves deployments by type with fallback chain (explicit → connection default → global default)
+- **Global default deployments** — new settings page under **Settings > Artificial Intelligence > Default Deployments** to configure global defaults for Utility, Embedding, and Image deployments
+- **AI Profiles** — `DeploymentId` renamed to `ChatDeploymentId`, new `UtilityDeploymentId` field added
+- **Chat Interactions** — same changes as AI Profiles
+- **Deployment dropdowns** — now show all deployments grouped by connection for easier selection
+- **Automatic migration** — existing connection deployment names are automatically migrated to typed `AIDeployment` records on startup
+- **appsettings.json** — both old format (deployment names on connection) and new format (`Deployments` array) are supported
+
+**Breaking changes:**
+- `AIProviderConnection.ChatDeploymentName` → deprecated (use typed `AIDeployment` records instead)
+- `AIProviderConnection.EmbeddingDeploymentName` → deprecated
+- `AIProviderConnection.UtilityDeploymentName` → deprecated
+- `AIProviderConnection.ImagesDeploymentName` → deprecated
+- `AIProvider.DefaultChatDeploymentName` → deprecated
+- `AIProvider.DefaultEmbeddingDeploymentName` → deprecated
+- `AIProvider.DefaultUtilityDeploymentName` → deprecated
+- `AIProvider.DefaultImagesDeploymentName` → deprecated
+- `AIProfile.DeploymentId` → renamed to `ChatDeploymentId` (old JSON property still deserialized for backward compat)
+- `ChatInteraction.DeploymentId` → renamed to `ChatDeploymentId`
+- `AICompletionContext.DeploymentId` → renamed to `ChatDeploymentId`
+
+For detailed migration instructions, see the [Migrating to Typed AI Deployments](../ai/migration-typed-deployments.md) guide.
 
 ### Changed: Navigation Paths
 
@@ -621,3 +651,13 @@ New modules are not enabled by default. Enable them via **Tools → Features** i
 ### Conversion Metrics
 
 - **Independent of Session Metrics**: The "Enable Conversion Metrics" setting and its associated goals configuration are now always visible and operate independently of the "Enable Session Metrics" toggle. Conversion goals can be defined and evaluated without enabling session metrics.
+
+### Typed AI Deployments
+
+- **First-Class Typed Deployments**: `AIDeployment` is now a typed entity with a `Type` property (`Chat`, `Utility`, `Embedding`, `Image`, `SpeechToText`) and an `IsDefault` boolean. This replaces the old pattern of storing deployment names directly on provider connections.
+- **Pure Connections**: `AIProviderConnection` no longer carries deployment name fields (`ChatDeploymentName`, `UtilityDeploymentName`, `EmbeddingDeploymentName`, `ImagesDeploymentName`). Connections are now pure connection configurations. These fields are deprecated and auto-migrated to the new `Deployments` array format.
+- **Default AI Deployment Settings**: A new settings page under **Settings → Artificial Intelligence → Default AI Deployment Settings** allows configuring global defaults: `DefaultUtilityDeploymentId`, `DefaultEmbeddingDeploymentId`, `DefaultImageDeploymentId`.
+- **Deployment Resolution Fallback**: The system resolves deployments using a fallback chain: explicit assignment → connection default for type → global default → null/error.
+- **AI Profile & Chat Interaction Fields**: `ChatDeploymentId` and `UtilityDeploymentId` replace the single `DeploymentId` field on AI Profiles and Chat Interactions.
+- **Grouped Deployment UI**: UI dropdowns now show deployments grouped by connection instead of the previous cascading connection → deployment selection.
+- **Configuration Format**: `appsettings.json` now uses a `Deployments` array on each connection. Provider-level `DefaultChatDeploymentName`, `DefaultUtilityDeploymentName`, `DefaultEmbeddingDeploymentName`, `DefaultImagesDeploymentName` are deprecated.

--- a/src/CrestApps.OrchardCore.Documentations/sidebars.js
+++ b/src/CrestApps.OrchardCore.Documentations/sidebars.js
@@ -23,6 +23,7 @@ const sidebars = {
         'ai/copilot',
         'ai/agent',
         'ai/prompt-templates',
+        'ai/migration-typed-deployments',
         {
           type: 'category',
           label: 'AI Providers',

--- a/src/Modules/CrestApps.OrchardCore.AI.Agent/Profiles/ViewAIProfileTool.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Agent/Profiles/ViewAIProfileTool.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using CrestApps.OrchardCore.AI.Core.Extensions;
 using CrestApps.OrchardCore.AI.Models;
@@ -88,7 +88,7 @@ public sealed class ViewAIProfileTool : AIFunction
             ["type"] = profile.Type.ToString(),
             ["source"] = profile.Source,
             ["connectionName"] = profile.ConnectionName,
-            ["deploymentId"] = profile.DeploymentId,
+            ["chatDeploymentId"] = profile.ChatDeploymentId,
             ["welcomeMessage"] = profile.WelcomeMessage,
             ["promptSubject"] = profile.PromptSubject,
             ["createdUtc"] = profile.CreatedUtc.ToString("o"),

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Controllers/AdminController.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Controllers/AdminController.cs
@@ -271,7 +271,7 @@ public sealed class AdminController : Controller
 
         var clonedInteraction = await _interactionManager.NewAsync(interaction.Source, interaction.Properties);
         clonedInteraction.Title = GetNextTitle(interaction.Title);
-        clonedInteraction.DeploymentId = interaction.DeploymentId;
+        clonedInteraction.ChatDeploymentId = interaction.ChatDeploymentId;
         clonedInteraction.ConnectionName = interaction.ConnectionName;
         clonedInteraction.SystemMessage = interaction.SystemMessage;
         clonedInteraction.Temperature = interaction.Temperature;

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Drivers/ChatInteractionConnectionDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Drivers/ChatInteractionConnectionDisplayDriver.cs
@@ -13,19 +13,16 @@ public sealed class ChatInteractionConnectionDisplayDriver : DisplayDriver<ChatI
 {
     private readonly IAIDeploymentManager _deploymentManager;
     private readonly AIOptions _aiOptions;
-    private readonly AIProviderOptions _providerOptions;
 
     internal readonly IStringLocalizer S;
 
     public ChatInteractionConnectionDisplayDriver(
         IAIDeploymentManager deploymentManager,
         IOptions<AIOptions> aiOptions,
-        IOptions<AIProviderOptions> providerOptions,
         IStringLocalizer<ChatInteractionConnectionDisplayDriver> stringLocalizer)
     {
         _deploymentManager = deploymentManager;
         _aiOptions = aiOptions.Value;
-        _providerOptions = providerOptions.Value;
         S = stringLocalizer;
     }
 
@@ -38,58 +35,14 @@ public sealed class ChatInteractionConnectionDisplayDriver : DisplayDriver<ChatI
                 return;
             }
 
-            model.ProviderName = profileSource.ProviderName;
-            model.DeploymentId = interaction.DeploymentId;
+            model.ChatDeploymentId = interaction.ChatDeploymentId;
+            model.UtilityDeploymentId = interaction.UtilityDeploymentId;
 
-            if (profileSource is not null && _providerOptions.Providers.TryGetValue(profileSource.ProviderName, out var provider))
-            {
-                if (provider.Connections.Count == 1)
-                {
-                    // If there's only one connection, use it automatically
-                    var connection = provider.Connections.First();
-                    model.ConnectionName = connection.Key;
-                }
-                else
-                {
-                    model.ConnectionName = interaction.ConnectionName;
-                }
+            model.ChatDeployments = BuildGroupedDeploymentItems(
+                await _deploymentManager.GetByTypeAsync(AIDeploymentType.Chat));
 
-                model.ConnectionNames = provider.Connections.Select(x => new SelectListItem(
-                    x.Value.TryGetValue("ConnectionNameAlias", out var alias) ? alias.ToString() : x.Key,
-                    x.Key)).ToArray();
-            }
-            else
-            {
-                model.ConnectionNames = [];
-            }
-
-            // Load deployments based on connection name
-            if (!string.IsNullOrEmpty(interaction.DeploymentId))
-            {
-                var deployment = await _deploymentManager.FindByIdAsync(interaction.DeploymentId);
-
-                if (deployment is not null)
-                {
-                    model.Deployments = (await _deploymentManager.GetAllAsync(profileSource.ProviderName, deployment.ConnectionName))
-                        .Select(x => new SelectListItem(x.Name, x.ItemId));
-                }
-            }
-
-            if (model.Deployments is null || !model.Deployments.Any())
-            {
-                var connectionName = interaction.ConnectionName;
-
-                if (string.IsNullOrEmpty(connectionName) && _providerOptions.Providers.TryGetValue(profileSource.ProviderName, out var prov))
-                {
-                    connectionName = prov.DefaultConnectionName;
-                }
-
-                if (!string.IsNullOrEmpty(connectionName))
-                {
-                    model.Deployments = (await _deploymentManager.GetAllAsync(profileSource.ProviderName, connectionName))
-                        .Select(x => new SelectListItem(x.Name, x.ItemId));
-                }
-            }
+            model.UtilityDeployments = BuildGroupedDeploymentItems(
+                await _deploymentManager.GetByTypeAsync(AIDeploymentType.Utility));
 
         }).Location("Parameters:3#Settings;1");
 
@@ -107,9 +60,30 @@ public sealed class ChatInteractionConnectionDisplayDriver : DisplayDriver<ChatI
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-        interaction.ConnectionName = model.ConnectionName;
-        interaction.DeploymentId = model.DeploymentId;
+        interaction.ChatDeploymentId = model.ChatDeploymentId;
+        interaction.UtilityDeploymentId = model.UtilityDeploymentId;
 
         return Edit(interaction, context);
+    }
+
+    private static IEnumerable<SelectListItem> BuildGroupedDeploymentItems(IEnumerable<AIDeployment> deployments)
+    {
+        var groups = new Dictionary<string, SelectListGroup>(StringComparer.OrdinalIgnoreCase);
+
+        return deployments
+            .OrderBy(d => d.ConnectionNameAlias ?? d.ConnectionName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(d =>
+            {
+                var groupKey = d.ConnectionNameAlias ?? d.ConnectionName;
+
+                if (!groups.TryGetValue(groupKey, out var group))
+                {
+                    group = new SelectListGroup { Name = groupKey };
+                    groups[groupKey] = group;
+                }
+
+                return new SelectListItem(d.Name, d.ItemId) { Group = group };
+            });
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Drivers/ChatInteractionDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Drivers/ChatInteractionDisplayDriver.cs
@@ -93,7 +93,7 @@ public sealed class ChatInteractionDisplayDriver : DisplayDriver<ChatInteraction
         {
             model.ItemId = interaction.ItemId;
             model.Title = interaction.Title;
-            model.DeploymentId = interaction.DeploymentId;
+            model.ChatDeploymentId = interaction.ChatDeploymentId;
             model.ConnectionName = interaction.ConnectionName;
             model.SystemMessage = interaction.SystemMessage;
             model.Temperature = interaction.Temperature;

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Handlers/ChatInteractionCompletionContextBuilderHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Handlers/ChatInteractionCompletionContextBuilderHandler.cs
@@ -22,7 +22,7 @@ internal sealed class ChatInteractionCompletionContextBuilderHandler : IAIComple
         }
 
         context.Context.ConnectionName = interaction.ConnectionName;
-        context.Context.DeploymentId = interaction.DeploymentId;
+        context.Context.ChatDeploymentId = interaction.ChatDeploymentId;
         context.Context.SystemMessage = await ResolveSystemMessageAsync(interaction);
         context.Context.Temperature = interaction.Temperature;
         context.Context.TopP = interaction.TopP;

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Hubs/ChatInteractionHub.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Hubs/ChatInteractionHub.cs
@@ -90,7 +90,7 @@ public class ChatInteractionHub : Hub<IChatInteractionHubClient>
                 interaction.ItemId,
                 interaction.Title,
                 interaction.ConnectionName,
-                interaction.DeploymentId,
+                DeploymentId = interaction.ChatDeploymentId,
                 Messages = prompts.Select(message => new AIChatResponseMessageDetailed
                 {
                     Id = message.ItemId,
@@ -149,7 +149,7 @@ public class ChatInteractionHub : Hub<IChatInteractionHubClient>
             interaction.Title = GetString(settings, "title") ?? "Untitled";
             interaction.OrchestratorName = GetString(settings, "orchestratorName");
             interaction.ConnectionName = GetString(settings, "connectionName");
-            interaction.DeploymentId = GetString(settings, "deploymentId");
+            interaction.ChatDeploymentId = GetString(settings, "deploymentId");
             interaction.SystemMessage = GetString(settings, "systemMessage");
             interaction.Temperature = GetFloat(settings, "temperature");
             interaction.TopP = GetFloat(settings, "topP");

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/ViewModels/EditChatInteractionConnectionViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/ViewModels/EditChatInteractionConnectionViewModel.cs
@@ -5,16 +5,13 @@ namespace CrestApps.OrchardCore.AI.Chat.Interactions.ViewModels;
 
 public class EditChatInteractionConnectionViewModel
 {
-    public string ConnectionName { get; set; }
+    public string ChatDeploymentId { get; set; }
 
-    public string DeploymentId { get; set; }
-
-    [BindNever]
-    public string ProviderName { get; set; }
+    public string UtilityDeploymentId { get; set; }
 
     [BindNever]
-    public IList<SelectListItem> ConnectionNames { get; set; }
+    public IEnumerable<SelectListItem> ChatDeployments { get; set; }
 
     [BindNever]
-    public IEnumerable<SelectListItem> Deployments { get; set; }
+    public IEnumerable<SelectListItem> UtilityDeployments { get; set; }
 }

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/ViewModels/EditChatInteractionViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/ViewModels/EditChatInteractionViewModel.cs
@@ -6,7 +6,7 @@ public class EditChatInteractionViewModel
 
     public string Title { get; set; }
 
-    public string DeploymentId { get; set; }
+    public string ChatDeploymentId { get; set; }
 
     public string ConnectionName { get; set; }
 

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Views/ChatInteractionConnection.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Views/ChatInteractionConnection.Edit.cshtml
@@ -1,94 +1,31 @@
 @using CrestApps.OrchardCore.AI.Chat.Interactions.ViewModels
-@using CrestApps.OrchardCore.AI.Core
 @using CrestApps.OrchardCore.AI.Core.Orchestration
 @using OrchardCore
 
 @model EditChatInteractionConnectionViewModel
 
-@if (Model.ConnectionNames?.Count > 1)
-{
-    <div class="mb-3 orchestrator-dependent orchestrator-dependent-@(DefaultOrchestrator.OrchestratorName)">
-        <label asp-for="ConnectionName" class="form-label">
-            @T["Connection"]
-            <span class="text-muted" data-bs-toggle="tooltip" title="@T["The connection to use for this chat interaction. If not selected, the default connection will be used."]">
-                <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
-            </span>
-        </label>
-        <select asp-for="ConnectionName" asp-items="Model.ConnectionNames" class="form-select">
-            <option value="">@T["Default connection"]</option>
-        </select>
-        <span asp-validation-for="ConnectionName" class="text-danger"></span>
-    </div>
-}
-else
-{
-    <input type="hidden" asp-for="ConnectionName" />
-}
-
 <div class="mb-3 orchestrator-dependent orchestrator-dependent-@(DefaultOrchestrator.OrchestratorName)">
-    <label asp-for="DeploymentId" class="form-label">
-        @T["Deployment"]
-        <span class="text-muted" data-bs-toggle="tooltip" title="@T["The AI model deployment to use for this chat interaction. If not selected, the default deployment will be used."]">
+    <label asp-for="ChatDeploymentId" class="form-label">
+        @T["Chat Model"]
+        <span class="text-muted" data-bs-toggle="tooltip" title="@T["Select the deployment to use for chat completions."]">
             <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
         </span>
     </label>
-    <select asp-for="DeploymentId" class="form-select">
-        <option value="">@T["Default deployment"]</option>
-        @if (Model.Deployments != null)
-        {
-            foreach (var deployment in Model.Deployments)
-            {
-                <option value="@deployment.Value">@deployment.Text</option>
-            }
-        }
+    <select asp-for="ChatDeploymentId" asp-items="Model.ChatDeployments" class="form-select">
+        <option value="">@T["Default"]</option>
     </select>
-    <span asp-validation-for="DeploymentId" class="text-danger"></span>
+    <span asp-validation-for="ChatDeploymentId" class="text-danger"></span>
 </div>
 
-<script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
-
-        const connectionNameElement = document.getElementById('@Html.IdFor(x => x.ConnectionName)');
-        const deploymentsElement = document.getElementById('@Html.IdFor(x => x.DeploymentId)');
-        const providerName = '@(Model.ProviderName)';
-
-        if (connectionNameElement) {
-            connectionNameElement.addEventListener('change', async (e) => {
-                const selectedConnection = e.target.value;
-
-                // Remove only options that have a value
-                [...deploymentsElement.options].forEach(option => {
-                    if (option.value) {
-                        option.remove();
-                    }
-                });
-
-                if (!selectedConnection) {
-                    deploymentsElement.value = '';
-                    return;
-                }
-
-                var url = '@(Url.RouteUrl(AIConstants.RouteNames.GetDeploymentsByConnectionRouteName))';
-                try {
-                    const response = await fetch(`${url}?providerName=${encodeURIComponent(providerName)}&connection=${encodeURIComponent(selectedConnection)}`);
-
-                    if (!response.ok) {
-                        throw new Error('Failed to fetch deployments');
-                    }
-
-                    const deployments = await response.json();
-
-                    // Populate new options
-                    deployments.forEach(deployment => {
-                        let option = document.createElement('option');
-                        option.value = deployment.id;
-                        option.textContent = deployment.name;
-                        deploymentsElement.appendChild(option);
-                    });
-                } catch (error) {
-                    console.error('Error fetching deployments:', error);
-                }
-            });
-        }
-    });
-</script>
+<div class="mb-3 orchestrator-dependent orchestrator-dependent-@(DefaultOrchestrator.OrchestratorName)">
+    <label asp-for="UtilityDeploymentId" class="form-label">
+        @T["Utility Model (Optional)"]
+        <span class="text-muted" data-bs-toggle="tooltip" title="@T["Select a lightweight model for auxiliary tasks. Falls back to the global default if not set."]">
+            <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+        </span>
+    </label>
+    <select asp-for="UtilityDeploymentId" asp-items="Model.UtilityDeployments" class="form-select">
+        <option value="">@T["Default"]</option>
+    </select>
+    <span asp-validation-for="UtilityDeploymentId" class="text-danger"></span>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/AIChatAdminWidgetSettings.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/AIChatAdminWidgetSettings.Edit.cshtml
@@ -8,7 +8,7 @@
     <label asp-for="ProfileId" class="@Orchard.GetLabelClasses()">@T["AI Profile"]</label>
     <div class="@Orchard.GetEndClasses()">
         <select asp-for="ProfileId" asp-items="Model.Profiles" class="form-select">
-            <option value="">@T["-- Select a profile --"]</option>
+            <option value="">@T["No profile (Disabled)"]</option>
         </select>
         <span asp-validation-for="ProfileId" class="text-danger"></span>
         <span class="hint">@T["Select the AI profile to use for the admin widget. Users with the appropriate permission can chat with this profile from any admin page."]</span>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources/Drivers/DataSourceIndexProfileDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources/Drivers/DataSourceIndexProfileDisplayDriver.cs
@@ -51,7 +51,9 @@ public sealed class DataSourceIndexProfileDisplayDriver : DisplayDriver<IndexPro
             {
                 foreach (var (connectionName, connection) in provider.Connections)
                 {
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
                     var embeddingDeploymentName = connection.GetEmbeddingDeploymentOrDefaultName(false);
+#pragma warning restore CS0618
 
                     if (string.IsNullOrEmpty(embeddingDeploymentName))
                     {
@@ -64,9 +66,11 @@ public sealed class DataSourceIndexProfileDisplayDriver : DisplayDriver<IndexPro
                         ? $"{alias} ({providerName})"
                         : $"{connectionName} ({providerName})";
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     var isSelected = metadata.EmbeddingProviderName == providerName &&
                                 metadata.EmbeddingDeploymentName == embeddingDeploymentName &&
                                 metadata.EmbeddingConnectionName == connectionName;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     if (isSelected)
                     {
@@ -80,8 +84,10 @@ public sealed class DataSourceIndexProfileDisplayDriver : DisplayDriver<IndexPro
             model.EmbeddingConnections = embeddingConnections;
 
             // Make read-only once the index has been created.
+#pragma warning disable CS0618 // Type or member is obsolete
             model.IsLocked = !string.IsNullOrEmpty(metadata.EmbeddingProviderName) &&
                              !string.IsNullOrEmpty(indexProfile.IndexFullName);
+#pragma warning restore CS0618 // Type or member is obsolete
         }).Location("Content:3");
     }
 
@@ -99,6 +105,7 @@ public sealed class DataSourceIndexProfileDisplayDriver : DisplayDriver<IndexPro
         var metadata = indexProfile.As<DataSourceIndexProfileMetadata>();
 
         // Don't allow changes if already locked.
+#pragma warning disable CS0618 // Type or member is obsolete
         if (!string.IsNullOrEmpty(metadata.EmbeddingProviderName) &&
             !string.IsNullOrEmpty(indexProfile.IndexFullName))
         {
@@ -120,6 +127,7 @@ public sealed class DataSourceIndexProfileDisplayDriver : DisplayDriver<IndexPro
                 isSet = true;
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (!isSet)
         {

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources/Handlers/DataSourcePreemptiveRagOrchestrationHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources/Handlers/DataSourcePreemptiveRagOrchestrationHandler.cs
@@ -5,10 +5,12 @@ using CrestApps.OrchardCore.AI.Core.Services;
 using CrestApps.OrchardCore.AI.Models;
 using CrestApps.OrchardCore.Services;
 using Cysharp.Text;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OrchardCore.Entities;
 using OrchardCore.Indexing;
+using OrchardCore.Indexing.Models;
 using OrchardCore.Settings;
 
 namespace CrestApps.OrchardCore.AI.DataSources.Handlers;
@@ -24,6 +26,7 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
     private readonly IIndexProfileStore _indexProfileStore;
     private readonly IAIClientFactory _aiClientFactory;
     private readonly IAITemplateService _templateService;
+    private readonly IAIDeploymentManager _deploymentManager;
     private readonly ISiteService _siteService;
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger _logger;
@@ -33,6 +36,7 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
         IIndexProfileStore indexProfileStore,
         IAIClientFactory aiClientFactory,
         IAITemplateService templateService,
+        IAIDeploymentManager deploymentManager,
         ISiteService siteService,
         IServiceProvider serviceProvider,
         ILogger<DataSourcePreemptiveRagHandler> logger)
@@ -41,6 +45,7 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
         _indexProfileStore = indexProfileStore;
         _aiClientFactory = aiClientFactory;
         _templateService = templateService;
+        _deploymentManager = deploymentManager;
         _siteService = siteService;
         _serviceProvider = serviceProvider;
         _logger = logger;
@@ -100,6 +105,29 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
         // Get embedding configuration.
         var profileMetadata = masterProfile.As<DataSourceIndexProfileMetadata>();
 
+        // Try the new deployment resolver first.
+        var embeddingDeployment = await _deploymentManager.ResolveAsync(
+            AIDeploymentType.Embedding,
+            deploymentId: profileMetadata.EmbeddingDeploymentId);
+
+        if (embeddingDeployment != null)
+        {
+            var embeddingGenerator = await _aiClientFactory.CreateEmbeddingGeneratorAsync(
+                embeddingDeployment.ProviderName,
+                embeddingDeployment.ConnectionName,
+                embeddingDeployment.Name);
+
+            if (embeddingGenerator == null)
+            {
+                return;
+            }
+
+            await SearchAndInjectContextAsync(context, ragMetadata, masterProfile, contentManager, embeddingGenerator);
+            return;
+        }
+
+        // Fall back to legacy explicit metadata properties for backward compatibility.
+#pragma warning disable CS0618 // Type or member is obsolete
         if (string.IsNullOrEmpty(profileMetadata.EmbeddingProviderName) ||
             string.IsNullOrEmpty(profileMetadata.EmbeddingConnectionName) ||
             string.IsNullOrEmpty(profileMetadata.EmbeddingDeploymentName))
@@ -107,15 +135,29 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
             return;
         }
 
-        var embeddingGenerator = await _aiClientFactory.CreateEmbeddingGeneratorAsync(
+        var legacyEmbeddingGenerator = await _aiClientFactory.CreateEmbeddingGeneratorAsync(
             profileMetadata.EmbeddingProviderName,
             profileMetadata.EmbeddingConnectionName,
             profileMetadata.EmbeddingDeploymentName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
-        if (embeddingGenerator == null)
+        if (legacyEmbeddingGenerator == null)
         {
             return;
         }
+
+        await SearchAndInjectContextAsync(context, ragMetadata, masterProfile, contentManager, legacyEmbeddingGenerator);
+    }
+
+    private async Task SearchAndInjectContextAsync(
+        PreemptiveRagContext context,
+        AIDataSourceRagMetadata ragMetadata,
+        IndexProfile masterProfile,
+        IDataSourceContentManager contentManager,
+        IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator)
+    {
+        var orchestrationContext = context.OrchestrationContext;
+        var dataSourceId = orchestrationContext.CompletionContext.DataSourceId;
 
         // Generate embeddings for all search queries.
         var embeddings = await embeddingGenerator.GenerateAsync(context.Queries);

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources/Tools/DataSourceSearchTool.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources/Tools/DataSourceSearchTool.cs
@@ -126,6 +126,7 @@ public sealed class DataSourceSearchTool : AIFunction
 
             var profileMetadata = masterIndexProfile.As<DataSourceIndexProfileMetadata>();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (string.IsNullOrEmpty(profileMetadata.EmbeddingProviderName) ||
                 string.IsNullOrEmpty(profileMetadata.EmbeddingConnectionName) ||
                 string.IsNullOrEmpty(profileMetadata.EmbeddingDeploymentName))
@@ -138,6 +139,7 @@ public sealed class DataSourceSearchTool : AIFunction
                 profileMetadata.EmbeddingProviderName,
                 profileMetadata.EmbeddingConnectionName,
                 profileMetadata.EmbeddingDeploymentName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (embeddingGenerator == null)
             {

--- a/src/Modules/CrestApps.OrchardCore.AI.Documents/Drivers/ChatInteractionIndexProfileDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Documents/Drivers/ChatInteractionIndexProfileDisplayDriver.cs
@@ -48,7 +48,9 @@ public sealed class ChatInteractionIndexProfileDisplayDriver : DisplayDriver<Ind
                 foreach (var (connectionName, connection) in provider.Connections)
                 {
                     // Check if this connection has embedding deployments configured
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
                     var embeddingDeploymentName = connection.GetEmbeddingDeploymentOrDefaultName(false);
+#pragma warning restore CS0618
 
                     if (string.IsNullOrEmpty(embeddingDeploymentName))
                     {

--- a/src/Modules/CrestApps.OrchardCore.AI.Documents/Services/DefaultAIDocumentProcessingService.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Documents/Services/DefaultAIDocumentProcessingService.cs
@@ -22,6 +22,7 @@ public sealed class DefaultAIDocumentProcessingService : IAIDocumentProcessingSe
     private readonly IOptions<ChatDocumentsOptions> _extractorOptions;
     private readonly IAIClientFactory _aiClientFactory;
     private readonly IOptions<AIProviderOptions> _providerOptions;
+    private readonly IAIDeploymentManager _deploymentManager;
     private readonly IClock _clock;
     private readonly ILogger _logger;
 
@@ -30,6 +31,7 @@ public sealed class DefaultAIDocumentProcessingService : IAIDocumentProcessingSe
         IOptions<ChatDocumentsOptions> extractorOptions,
         IAIClientFactory aiClientFactory,
         IOptions<AIProviderOptions> providerOptions,
+        IAIDeploymentManager deploymentManager,
         IClock clock,
         ILogger<DefaultAIDocumentProcessingService> logger)
     {
@@ -37,14 +39,38 @@ public sealed class DefaultAIDocumentProcessingService : IAIDocumentProcessingSe
         _extractorOptions = extractorOptions;
         _aiClientFactory = aiClientFactory;
         _providerOptions = providerOptions;
+        _deploymentManager = deploymentManager;
         _clock = clock;
         _logger = logger;
     }
 
     public async Task<IEmbeddingGenerator<string, Embedding<float>>> CreateEmbeddingGeneratorAsync(string providerName, string connectionName)
     {
+        var embeddingDeployment = await _deploymentManager.ResolveAsync(
+            AIDeploymentType.Embedding,
+            providerName: providerName,
+            connectionName: connectionName);
+
+        if (embeddingDeployment != null)
+        {
+            var generator = await _aiClientFactory.CreateEmbeddingGeneratorAsync(
+                embeddingDeployment.ProviderName,
+                embeddingDeployment.ConnectionName,
+                embeddingDeployment.Name);
+
+            if (generator == null)
+            {
+                _logger.LogWarning("Failed to create embedding generator for provider {Provider}, connection {Connection}, deployment {Deployment}. Documents will be stored without embeddings.",
+                    embeddingDeployment.ProviderName, embeddingDeployment.ConnectionName, embeddingDeployment.Name);
+            }
+
+            return generator;
+        }
+
+        // Fall back to legacy provider options lookup for backward compatibility.
         string deploymentName = null;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         if (!string.IsNullOrEmpty(providerName) && _providerOptions.Value.Providers.TryGetValue(providerName, out var provider))
         {
             if (string.IsNullOrEmpty(connectionName))
@@ -54,9 +80,12 @@ public sealed class DefaultAIDocumentProcessingService : IAIDocumentProcessingSe
 
             if (!string.IsNullOrEmpty(connectionName) && provider.Connections.TryGetValue(connectionName, out var connection))
             {
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
                 deploymentName = connection.GetEmbeddingDeploymentOrDefaultName(false);
+#pragma warning restore CS0618
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (string.IsNullOrEmpty(deploymentName))
         {
@@ -64,15 +93,15 @@ public sealed class DefaultAIDocumentProcessingService : IAIDocumentProcessingSe
             return null;
         }
 
-        var generator = await _aiClientFactory.CreateEmbeddingGeneratorAsync(providerName, connectionName, deploymentName);
+        var legacyGenerator = await _aiClientFactory.CreateEmbeddingGeneratorAsync(providerName, connectionName, deploymentName);
 
-        if (generator == null)
+        if (legacyGenerator == null)
         {
             _logger.LogWarning("Failed to create embedding generator for provider {Provider}, connection {Connection}, deployment {Deployment}. Documents will be stored without embeddings.",
                 providerName, connectionName, deploymentName);
         }
 
-        return generator;
+        return legacyGenerator;
     }
 
     public async Task<DocumentProcessingResult> ProcessFileAsync(

--- a/src/Modules/CrestApps.OrchardCore.AI.Documents/Tools/SearchDocumentsTool.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Documents/Tools/SearchDocumentsTool.cs
@@ -151,7 +151,9 @@ public sealed class SearchDocumentsTool : AIFunction
                 if (!string.IsNullOrEmpty(connectionName) &&
                     provider.Connections.TryGetValue(connectionName, out var connection))
                 {
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
                     deploymentName = connection.GetEmbeddingDeploymentOrDefaultName(false);
+#pragma warning restore CS0618
                 }
             }
 

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Services/DefaultMcpCapabilityResolver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Services/DefaultMcpCapabilityResolver.cs
@@ -410,7 +410,9 @@ internal sealed class DefaultMcpCapabilityResolver : IMcpCapabilityResolver
             return null;
         }
 
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
         var deploymentName = connection.GetEmbeddingDeploymentOrDefaultName(throwException: false);
+#pragma warning restore CS0618
 
         if (string.IsNullOrEmpty(deploymentName))
         {

--- a/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIDeploymentDeploymentSource.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIDeploymentDeploymentSource.cs
@@ -39,6 +39,8 @@ internal sealed class AIDeploymentDeploymentSource : DeploymentSourceBase<AIDepl
                 { "ProviderName" , deployment.Source },
                 { "ConnectionName", deployment.ConnectionName },
                 { "ConnectionNameAlias", deployment.ConnectionNameAlias },
+                { "Type", deployment.Type.ToString() },
+                { "IsDefault", deployment.IsDefault },
                 { "Author", deployment.Author },
                 { "OwnerId", deployment.OwnerId },
                 { "CreatedUtc" , deployment.CreatedUtc },

--- a/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIProfileDeploymentSource.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIProfileDeploymentSource.cs
@@ -41,7 +41,7 @@ internal sealed class AIProfileDeploymentSource : DeploymentSourceBase<AIProfile
                 { "WelcomeMessage", profile.WelcomeMessage },
                 { "Type", profile.Type.ToString() },
                 { "PromptTemplate", profile.PromptTemplate },
-                { "DeploymentId", profile.DeploymentId },
+                { "ChatDeploymentId", profile.ChatDeploymentId },
                 { "CreatedUtc", profile.CreatedUtc },
                 { "OwnerId", profile.OwnerId },
                 { "Author", profile.Author },

--- a/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIProviderConnectionDeploymentSource.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIProviderConnectionDeploymentSource.cs
@@ -46,10 +46,12 @@ internal sealed class AIProviderConnectionDeploymentSource : DeploymentSourceBas
                 { "ItemId", connection.ItemId },
                 { "Source", connection.Source },
                 { "Name", connection.Name },
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
                 { "ChatDeploymentName", connection.ChatDeploymentName },
                 { "EmbeddingDeploymentName", connection.EmbeddingDeploymentName },
                 { "ImagesDeploymentName", connection.ImagesDeploymentName },
                 { "UtilityDeploymentName", connection.UtilityDeploymentName },
+#pragma warning restore CS0618
                 { "IsDefault", connection.IsDefault },
                 { "DisplayText", connection.DisplayText },
                 { "CreatedUtc", connection.CreatedUtc },

--- a/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIDeploymentDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIDeploymentDisplayDriver.cs
@@ -44,7 +44,13 @@ internal sealed class AIDeploymentDisplayDriver : DisplayDriver<AIDeployment>
         {
             model.Name = deployment.Name;
             model.ConnectionName = deployment.ConnectionName;
+            model.Type = deployment.Type;
+            model.IsDefault = deployment.IsDefault;
             model.IsNew = context.IsNew;
+
+            model.Types = Enum.GetValues<AIDeploymentType>()
+                .Select(t => new SelectListItem(t.ToString(), t.ToString()))
+                .ToList();
 
             if (_providerOptions.Providers.TryGetValue(deployment.ProviderName, out var providerOptions))
             {
@@ -76,6 +82,9 @@ internal sealed class AIDeploymentDisplayDriver : DisplayDriver<AIDeployment>
             deployment.Name = name;
         }
 
+        deployment.Type = model.Type;
+        deployment.IsDefault = model.IsDefault;
+
         if (!_providerOptions.Providers.TryGetValue(deployment.ProviderName, out var provider))
         {
             context.Updater.ModelState.AddModelError(Prefix, nameof(model.ConnectionName), S["There are no configured connection for the provider: {0}.", deployment.ProviderName]);
@@ -103,12 +112,13 @@ internal sealed class AIDeploymentDisplayDriver : DisplayDriver<AIDeployment>
         var anotherExists = (await _deploymentsCatalog.GetAllAsync())
             .Any(d => d.ProviderName == deployment.ProviderName &&
             d.ConnectionName == deployment.ConnectionName &&
+            d.Type == deployment.Type &&
             d.Name.Equals(deployment.Name, StringComparison.OrdinalIgnoreCase)
             && d.ItemId != deployment.ItemId);
 
         if (anotherExists)
         {
-            context.Updater.ModelState.AddModelError(Prefix, nameof(model.ConnectionName), S["The selected connection already has an existing deployment with the specified name."]);
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.ConnectionName), S["The selected connection already has an existing deployment with the specified name and type."]);
         }
 
         return Edit(deployment, context);

--- a/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIProfileDeploymentDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIProfileDeploymentDisplayDriver.cs
@@ -13,19 +13,16 @@ internal sealed class AIProfileDeploymentDisplayDriver : DisplayDriver<AIProfile
 {
     private readonly IAIDeploymentManager _deploymentManager;
     private readonly AIOptions _aiOptions;
-    private readonly AIProviderOptions _providerOptions;
 
     internal readonly IStringLocalizer S;
 
     public AIProfileDeploymentDisplayDriver(
         IAIDeploymentManager deploymentManager,
         IOptions<AIOptions> aiOptions,
-        IOptions<AIProviderOptions> providerOptions,
         IStringLocalizer<AIProfileDisplayDriver> stringLocalizer)
     {
         _deploymentManager = deploymentManager;
         _aiOptions = aiOptions.Value;
-        _providerOptions = providerOptions.Value;
         S = stringLocalizer;
     }
 
@@ -38,42 +35,20 @@ internal sealed class AIProfileDeploymentDisplayDriver : DisplayDriver<AIProfile
                 return;
             }
 
-            model.ConnectionName = profile.ConnectionName;
-            model.DeploymentId = profile.DeploymentId;
-            model.ProviderName = profileSource.ProviderName;
+            model.ChatDeploymentId = profile.ChatDeploymentId;
+            model.UtilityDeploymentId = profile.UtilityDeploymentId;
 
-            if (!string.IsNullOrEmpty(profile.DeploymentId))
-            {
-                var deployment = await _deploymentManager.FindByIdAsync(profile.DeploymentId);
+            model.ChatDeployments = BuildGroupedDeploymentItems(
+                await _deploymentManager.GetByTypeAsync(AIDeploymentType.Chat));
 
-                if (deployment is not null)
-                {
-                    model.Deployments = (await _deploymentManager.GetAllAsync(profileSource.ProviderName, deployment.ConnectionName))
-                    .Select(x => new SelectListItem(x.Name, x.ItemId));
-                }
-            }
-
-            if (model.Deployments is null || !model.Deployments.Any())
-            {
-                var connectionName = profile.ConnectionName;
-
-                if (string.IsNullOrEmpty(connectionName) && _providerOptions.Providers.TryGetValue(profileSource.ProviderName, out var provider))
-                {
-                    connectionName = provider.DefaultConnectionName;
-                }
-
-                if (!string.IsNullOrEmpty(connectionName))
-                {
-                    model.Deployments = (await _deploymentManager.GetAllAsync(profileSource.ProviderName, connectionName))
-                    .Select(x => new SelectListItem(x.Name, x.ItemId));
-                }
-            }
+            model.UtilityDeployments = BuildGroupedDeploymentItems(
+                await _deploymentManager.GetByTypeAsync(AIDeploymentType.Utility));
         }).Location("Content:4");
     }
 
     public override async Task<IDisplayResult> UpdateAsync(AIProfile profile, UpdateEditorContext context)
     {
-        if (!_aiOptions.ProfileSources.TryGetValue(profile.Source, out var _))
+        if (!_aiOptions.ProfileSources.TryGetValue(profile.Source, out _))
         {
             return null;
         }
@@ -82,9 +57,30 @@ internal sealed class AIProfileDeploymentDisplayDriver : DisplayDriver<AIProfile
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-        profile.DeploymentId = model.DeploymentId;
-        profile.ConnectionName = model.ConnectionName;
+        profile.ChatDeploymentId = model.ChatDeploymentId;
+        profile.UtilityDeploymentId = model.UtilityDeploymentId;
 
         return Edit(profile, context);
+    }
+
+    private static IEnumerable<SelectListItem> BuildGroupedDeploymentItems(IEnumerable<AIDeployment> deployments)
+    {
+        var groups = new Dictionary<string, SelectListGroup>(StringComparer.OrdinalIgnoreCase);
+
+        return deployments
+            .OrderBy(d => d.ConnectionNameAlias ?? d.ConnectionName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(d =>
+            {
+                var groupKey = d.ConnectionNameAlias ?? d.ConnectionName;
+
+                if (!groups.TryGetValue(groupKey, out var group))
+                {
+                    group = new SelectListGroup { Name = groupKey };
+                    groups[groupKey] = group;
+                }
+
+                return new SelectListItem(d.Name, d.ItemId) { Group = group };
+            });
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIProviderConnectionDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Drivers/AIProviderConnectionDisplayDriver.cs
@@ -44,10 +44,6 @@ internal sealed class AIProviderConnectionDisplayDriver : DisplayDriver<AIProvid
         {
             model.DisplayText = connection.DisplayText;
             model.Name = connection.Name;
-            model.ChatDeploymentName = connection.ChatDeploymentName;
-            model.EmbeddingDeploymentName = connection.EmbeddingDeploymentName;
-            model.ImagesDeploymentName = connection.ImagesDeploymentName;
-            model.UtilityDeploymentName = connection.UtilityDeploymentName;
             model.IsDefault = connection.IsDefault;
             model.IsNew = context.IsNew;
 
@@ -79,16 +75,7 @@ internal sealed class AIProviderConnectionDisplayDriver : DisplayDriver<AIProvid
             context.Updater.ModelState.AddModelError(Prefix, nameof(model.DisplayText), S["The Title is required."]);
         }
 
-        if (string.IsNullOrWhiteSpace(model.ChatDeploymentName))
-        {
-            context.Updater.ModelState.AddModelError(Prefix, nameof(model.ChatDeploymentName), S["Default deployment name is required."]);
-        }
-
         connection.DisplayText = model.DisplayText;
-        connection.ChatDeploymentName = model.ChatDeploymentName;
-        connection.EmbeddingDeploymentName = model.EmbeddingDeploymentName;
-        connection.ImagesDeploymentName = model.ImagesDeploymentName;
-        connection.UtilityDeploymentName = model.UtilityDeploymentName;
         connection.IsDefault = model.IsDefault;
 
         _shellReleaseManager.RequestRelease();

--- a/src/Modules/CrestApps.OrchardCore.AI/Drivers/DefaultAIDeploymentSettingsDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Drivers/DefaultAIDeploymentSettingsDisplayDriver.cs
@@ -1,0 +1,97 @@
+using CrestApps.OrchardCore.AI.Core;
+using CrestApps.OrchardCore.AI.Core.Models;
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.AI.ViewModels;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using OrchardCore.DisplayManagement.Entities;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Settings;
+
+namespace CrestApps.OrchardCore.AI.Drivers;
+
+public sealed class DefaultAIDeploymentSettingsDisplayDriver : SiteDisplayDriver<DefaultAIDeploymentSettings>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IAIDeploymentManager _deploymentManager;
+
+    protected override string SettingsGroupId => AIConstants.AISettingsGroupId;
+
+    public DefaultAIDeploymentSettingsDisplayDriver(
+        IHttpContextAccessor httpContextAccessor,
+        IAuthorizationService authorizationService,
+        IAIDeploymentManager deploymentManager)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _authorizationService = authorizationService;
+        _deploymentManager = deploymentManager;
+    }
+
+    public override IDisplayResult Edit(ISite site, DefaultAIDeploymentSettings settings, BuildEditorContext context)
+    {
+        return Initialize<DefaultAIDeploymentSettingsViewModel>("DefaultAIDeploymentSettings_Edit", async model =>
+        {
+            model.DefaultUtilityDeploymentId = settings.DefaultUtilityDeploymentId;
+            model.DefaultEmbeddingDeploymentId = settings.DefaultEmbeddingDeploymentId;
+            model.DefaultImageDeploymentId = settings.DefaultImageDeploymentId;
+            model.DefaultSpeechToTextDeploymentId = settings.DefaultSpeechToTextDeploymentId;
+
+            model.UtilityDeployments = BuildGroupedDeploymentItems(
+                await _deploymentManager.GetByTypeAsync(AIDeploymentType.Utility));
+
+            model.EmbeddingDeployments = BuildGroupedDeploymentItems(
+                await _deploymentManager.GetByTypeAsync(AIDeploymentType.Embedding));
+
+            model.ImageDeployments = BuildGroupedDeploymentItems(
+                await _deploymentManager.GetByTypeAsync(AIDeploymentType.Image));
+
+            model.SpeechToTextDeployments = BuildGroupedDeploymentItems(
+                await _deploymentManager.GetByTypeAsync(AIDeploymentType.SpeechToText));
+        }).Location("Content:4%Default Deployments;1")
+        .OnGroup(SettingsGroupId)
+        .RenderWhen(() => _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, AIPermissions.ManageAIProfiles));
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(ISite site, DefaultAIDeploymentSettings settings, UpdateEditorContext context)
+    {
+        if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, AIPermissions.ManageAIProfiles))
+        {
+            return null;
+        }
+
+        var model = new DefaultAIDeploymentSettingsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        settings.DefaultUtilityDeploymentId = model.DefaultUtilityDeploymentId;
+        settings.DefaultEmbeddingDeploymentId = model.DefaultEmbeddingDeploymentId;
+        settings.DefaultImageDeploymentId = model.DefaultImageDeploymentId;
+        settings.DefaultSpeechToTextDeploymentId = model.DefaultSpeechToTextDeploymentId;
+
+        return Edit(site, settings, context);
+    }
+
+    private static IEnumerable<SelectListItem> BuildGroupedDeploymentItems(IEnumerable<AIDeployment> deployments)
+    {
+        var groups = new Dictionary<string, SelectListGroup>(StringComparer.OrdinalIgnoreCase);
+
+        return deployments
+            .OrderBy(d => d.ConnectionNameAlias ?? d.ConnectionName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(d =>
+            {
+                var groupKey = d.ConnectionNameAlias ?? d.ConnectionName;
+
+                if (!groups.TryGetValue(groupKey, out var group))
+                {
+                    group = new SelectListGroup { Name = groupKey };
+                    groups[groupKey] = group;
+                }
+
+                return new SelectListItem(d.Name, d.ItemId) { Group = group };
+            });
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Handlers/AIProfileCompletionContextBuilderHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Handlers/AIProfileCompletionContextBuilderHandler.cs
@@ -23,7 +23,7 @@ internal sealed class AIProfileCompletionContextBuilderHandler : IAICompletionCo
         }
 
         context.Context.ConnectionName = profile.ConnectionName;
-        context.Context.DeploymentId = profile.DeploymentId;
+        context.Context.ChatDeploymentId = profile.ChatDeploymentId;
 
         if (profile.TryGet<AIProfileMetadata>(out var metadata))
         {

--- a/src/Modules/CrestApps.OrchardCore.AI/Indexes/AIProfileIndexProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Indexes/AIProfileIndexProvider.cs
@@ -27,7 +27,7 @@ internal sealed class AIProfileIndexProvider : IndexProvider<AIProfile>
                     Source = profile.Source,
                     Type = profile.Type.ToString(),
                     ConnectionName = profile.ConnectionName,
-                    DeploymentId = profile.DeploymentId,
+                    DeploymentId = profile.ChatDeploymentId,
                     OrchestratorName = profile.OrchestratorName,
                     OwnerId = profile.OwnerId,
                     Author = profile.Author,

--- a/src/Modules/CrestApps.OrchardCore.AI/Migrations/AIDeploymentTypeMigrations.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Migrations/AIDeploymentTypeMigrations.cs
@@ -1,0 +1,84 @@
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.Models;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore;
+using OrchardCore.Data.Migration;
+using OrchardCore.Documents;
+using OrchardCore.Environment.Shell.Scope;
+
+namespace CrestApps.OrchardCore.AI.Migrations;
+
+internal sealed class AIDeploymentTypeMigrations : DataMigration
+{
+#pragma warning disable CA1822 // Member does not access instance data — called by convention from DataMigration base class
+    public Task<int> CreateAsync()
+#pragma warning restore CA1822
+    {
+        ShellScope.AddDeferredTask(async scope =>
+        {
+            var connectionDocManager = scope.ServiceProvider.GetRequiredService<IDocumentManager<DictionaryDocument<AIProviderConnection>>>();
+            var deploymentDocManager = scope.ServiceProvider.GetRequiredService<IDocumentManager<DictionaryDocument<AIDeployment>>>();
+
+            var connectionDoc = await connectionDocManager.GetOrCreateMutableAsync();
+            var deploymentDoc = await deploymentDocManager.GetOrCreateMutableAsync();
+
+            var needsSave = false;
+
+            foreach (var connection in connectionDoc.Records.Values)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                needsSave |= TryCreateDeployment(deploymentDoc, connection, connection.ChatDeploymentName, AIDeploymentType.Chat);
+                needsSave |= TryCreateDeployment(deploymentDoc, connection, connection.EmbeddingDeploymentName, AIDeploymentType.Embedding);
+                needsSave |= TryCreateDeployment(deploymentDoc, connection, connection.ImagesDeploymentName, AIDeploymentType.Image);
+                needsSave |= TryCreateDeployment(deploymentDoc, connection, connection.UtilityDeploymentName, AIDeploymentType.Utility);
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            if (needsSave)
+            {
+                await deploymentDocManager.UpdateAsync(deploymentDoc);
+            }
+        });
+
+        return Task.FromResult(1);
+    }
+
+    private static bool TryCreateDeployment(
+        DictionaryDocument<AIDeployment> deploymentDoc,
+        AIProviderConnection connection,
+        string deploymentName,
+        AIDeploymentType type)
+    {
+        if (string.IsNullOrWhiteSpace(deploymentName))
+        {
+            return false;
+        }
+
+        var exists = deploymentDoc.Records.Values.Any(d =>
+            d.ProviderName == connection.ProviderName &&
+            string.Equals(d.ConnectionName, connection.ItemId, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(d.Name, deploymentName, StringComparison.OrdinalIgnoreCase));
+
+        if (exists)
+        {
+            return false;
+        }
+
+        var deployment = new AIDeployment
+        {
+            ItemId = IdGenerator.GenerateId(),
+            Name = deploymentName,
+            ProviderName = connection.ProviderName,
+            ConnectionName = connection.ItemId,
+            ConnectionNameAlias = connection.Name,
+            Type = type,
+            IsDefault = true,
+            CreatedUtc = connection.CreatedUtc,
+            Author = connection.Author,
+            OwnerId = connection.OwnerId,
+        };
+
+        deploymentDoc.Records[deployment.ItemId] = deployment;
+        return true;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Recipes/AIDeploymentStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Recipes/AIDeploymentStep.cs
@@ -102,6 +102,21 @@ internal sealed class AIDeploymentStep : NamedRecipeStepHandler
                 }
             }
 
+            var typeValue = token[nameof(AIDeployment.Type)]?.GetValue<string>();
+
+            if (!string.IsNullOrEmpty(typeValue) && Enum.TryParse<AIDeploymentType>(typeValue, ignoreCase: true, out var deploymentType))
+            {
+                deployment.Type = deploymentType;
+            }
+            else
+            {
+                // Default to Chat for backward compatibility with recipes
+                // that do not include the Type property.
+                deployment.Type = AIDeploymentType.Chat;
+            }
+
+            deployment.IsDefault = token[nameof(AIDeployment.IsDefault)]?.GetValue<bool>() ?? false;
+
             var validationResult = await _manager.ValidateAsync(deployment);
 
             if (!validationResult.Succeeded)

--- a/src/Modules/CrestApps.OrchardCore.AI/Services/AIProviderOptionsConfiguration.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Services/AIProviderOptionsConfiguration.cs
@@ -100,6 +100,7 @@ internal sealed class AIProviderOptionsConfiguration : IConfigureOptions<AIProvi
                     provider.DefaultConnectionName = connections.FirstOrDefault().Key;
                 }
 
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
                 var defaultDeploymentName = providerNode["ChatDeploymentName"]?.GetValue<string>()
                     ?? providerNode["DefaultChatDeploymentName"]?.GetValue<string>()
                     ?? providerNode["DefaultDeploymentName"]?.GetValue<string>();
@@ -136,6 +137,7 @@ internal sealed class AIProviderOptionsConfiguration : IConfigureOptions<AIProvi
                 {
                     provider.DefaultUtilityDeploymentName = defaultUtilityDeploymentName;
                 }
+#pragma warning restore CS0618
 
                 options.Providers.Add(providerName, provider);
             }

--- a/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
@@ -162,7 +162,9 @@ public sealed class DeploymentsStartup : StartupBase
             .AddAIDeploymentServices()
             .AddPermissionProvider<AIDeploymentPermissionProvider>()
             .AddDisplayDriver<AIDeployment, AIDeploymentDisplayDriver>()
-            .AddNavigationProvider<AIDeploymentAdminMenu>();
+            .AddNavigationProvider<AIDeploymentAdminMenu>()
+            .AddDataMigration<AIDeploymentTypeMigrations>()
+            .AddSiteDisplayDriver<DefaultAIDeploymentSettingsDisplayDriver>();
     }
 
     public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/AIProviderConnectionFieldsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/AIProviderConnectionFieldsViewModel.cs
@@ -10,12 +10,16 @@ public class AIProviderConnectionFieldsViewModel
 
     public bool IsDefault { get; set; }
 
+    [Obsolete("Deployment names are now managed through AIDeployment entities. Retained for backward compatibility.")]
     public string ChatDeploymentName { get; set; }
 
+    [Obsolete("Deployment names are now managed through AIDeployment entities. Retained for backward compatibility.")]
     public string EmbeddingDeploymentName { get; set; }
 
+    [Obsolete("Deployment names are now managed through AIDeployment entities. Retained for backward compatibility.")]
     public string ImagesDeploymentName { get; set; }
 
+    [Obsolete("Deployment names are now managed through AIDeployment entities. Retained for backward compatibility.")]
     public string UtilityDeploymentName { get; set; }
 
     [BindNever]

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/DefaultAIDeploymentSettingsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/DefaultAIDeploymentSettingsViewModel.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CrestApps.OrchardCore.AI.ViewModels;
+
+public class DefaultAIDeploymentSettingsViewModel
+{
+    public string DefaultUtilityDeploymentId { get; set; }
+
+    public string DefaultEmbeddingDeploymentId { get; set; }
+
+    public string DefaultImageDeploymentId { get; set; }
+
+    public string DefaultSpeechToTextDeploymentId { get; set; }
+
+    [BindNever]
+    public IEnumerable<SelectListItem> UtilityDeployments { get; set; }
+
+    [BindNever]
+    public IEnumerable<SelectListItem> EmbeddingDeployments { get; set; }
+
+    [BindNever]
+    public IEnumerable<SelectListItem> ImageDeployments { get; set; }
+
+    [BindNever]
+    public IEnumerable<SelectListItem> SpeechToTextDeployments { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/EditDeploymentViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/EditDeploymentViewModel.cs
@@ -1,3 +1,4 @@
+using CrestApps.OrchardCore.AI.Models;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
@@ -9,9 +10,16 @@ public class EditDeploymentViewModel
 
     public string ConnectionName { get; set; }
 
+    public AIDeploymentType Type { get; set; }
+
+    public bool IsDefault { get; set; }
+
     [BindNever]
     public bool IsNew { get; set; }
 
     [BindNever]
     public IList<SelectListItem> Connections { get; set; }
+
+    [BindNever]
+    public IList<SelectListItem> Types { get; set; }
 }

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/EditProfileDeploymentViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/EditProfileDeploymentViewModel.cs
@@ -3,13 +3,15 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace CrestApps.OrchardCore.AI.ViewModels;
 
-public class EditProfileDeploymentViewModel : EditConnectionProfileViewModel
+public class EditProfileDeploymentViewModel
 {
-    public string DeploymentId { get; set; }
+    public string ChatDeploymentId { get; set; }
+
+    public string UtilityDeploymentId { get; set; }
 
     [BindNever]
-    public string ProviderName { get; set; }
+    public IEnumerable<SelectListItem> ChatDeployments { get; set; }
 
     [BindNever]
-    public IEnumerable<SelectListItem> Deployments { get; set; }
+    public IEnumerable<SelectListItem> UtilityDeployments { get; set; }
 }

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/AIDeploymentFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/AIDeploymentFields.Edit.cshtml
@@ -29,10 +29,29 @@
 </div>
 
 <div class="@Orchard.GetWrapperClasses()">
+    <label asp-for="Type" class="@Orchard.GetLabelClasses()">@T["Type"]</label>
+    <div class="@Orchard.GetEndClasses()">
+        <select asp-for="Type" asp-items="Model.Types" class="form-select"></select>
+        <span asp-validation-for="Type" class="text-danger"></span>
+        <span class="hint">@T["The capability type of this deployment."]</span>
+    </div>
+</div>
+
+<div class="@Orchard.GetWrapperClasses()">
     <label asp-for="ConnectionName" class="@Orchard.GetLabelClasses()">@T["Connection Name"]</label>
     <div class="@Orchard.GetEndClasses()">
         <select asp-for="ConnectionName" asp-items="Model.Connections" class="form-select"></select>
         <span asp-validation-for="ConnectionName" class="text-danger"></span>
         <span class="hint">@T["Connection name to use for this deployment."]</span>
+    </div>
+</div>
+
+<div class="@Orchard.GetWrapperClasses()">
+    <div class="@Orchard.GetEndClasses(true)">
+        <div class="form-check">
+            <input type="checkbox" class="form-check-input" asp-for="IsDefault">
+            <label class="form-check-label" asp-for="IsDefault">@T["Is default"]</label>
+            <span class="hint dashed">@T["When enabled, this deployment is the default for its type within its connection."]</span>
+        </div>
     </div>
 </div>

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/AIProfileDeployment.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/AIProfileDeployment.Edit.cshtml
@@ -1,71 +1,26 @@
-@using CrestApps.OrchardCore.AI.Core
 @using CrestApps.OrchardCore.AI.ViewModels
 @using OrchardCore
 
 @model EditProfileDeploymentViewModel
 
 <div class="@Orchard.GetWrapperClasses("orchestrator-dependent orchestrator-dependent-default")">
-    <label asp-for="DeploymentId" class="@Orchard.GetLabelClasses()">@T["Deployment"]</label>
+    <label asp-for="ChatDeploymentId" class="@Orchard.GetLabelClasses()">@T["Chat Model"]</label>
     <div class="@Orchard.GetEndClasses()">
-        <select asp-for="DeploymentId" class="form-select">
-            <option value="">@T["Default deployment"]</option>
-            @if (Model.Deployments != null)
-            {
-                foreach (var deployment in Model.Deployments)
-                {
-                    <option value="@deployment.Value">@deployment.Text</option>
-                }
-            }
+        <select asp-for="ChatDeploymentId" asp-items="Model.ChatDeployments" class="form-select">
+            <option value="">@T["Default"]</option>
         </select>
-        <span asp-validation-for="DeploymentId" class="text-danger"></span>
-        <span class="hint">@T["The deployment to use for this profile."]</span>
+        <span asp-validation-for="ChatDeploymentId" class="text-danger"></span>
+        <span class="hint">@T["Select the deployment to use for chat completions."]</span>
     </div>
 </div>
 
-<script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
-
-        const connectionNameElement = document.getElementById('@Html.IdFor(x => x.ConnectionName)');
-        const deploymentsElement = document.getElementById('@Html.IdFor(x => x.DeploymentId)');
-        const providerName = '@(Model.ProviderName)';
-
-        connectionNameElement.addEventListener('change', async (e) => {
-            const selectedConnection = e.target.value;
-
-            // Remove only options that have a value
-            [...deploymentsElement.options].forEach(option => {
-                if (option.value) {
-                    option.remove();
-                }
-            });
-
-            if (!selectedConnection) {
-
-                deploymentsElement.value = '';
-
-                return;
-            }
-
-            var url = '@(Url.RouteUrl(AIConstants.RouteNames.GetDeploymentsByConnectionRouteName))';
-            try {
-                const response = await fetch(`${url}?providerName=${encodeURIComponent(providerName)}&connection=${encodeURIComponent(selectedConnection)}`);
-
-                if (!response.ok) {
-                    throw new Error('Failed to fetch deployments');
-                }
-
-                const deployments = await response.json();
-
-                // Populate new options
-                deployments.forEach(deployment => {
-                    let option = document.createElement('option');
-                    option.value = deployment.id;
-                    option.textContent = deployment.name;
-                    deploymentsElement.appendChild(option);
-                });
-            } catch (error) {
-                console.error('Error fetching deployments:', error);
-            }
-        });
-    });
-</script>
+<div class="@Orchard.GetWrapperClasses("orchestrator-dependent orchestrator-dependent-default")">
+    <label asp-for="UtilityDeploymentId" class="@Orchard.GetLabelClasses()">@T["Utility Model (Optional)"]</label>
+    <div class="@Orchard.GetEndClasses()">
+        <select asp-for="UtilityDeploymentId" asp-items="Model.UtilityDeployments" class="form-select">
+            <option value="">@T["Default"]</option>
+        </select>
+        <span asp-validation-for="UtilityDeploymentId" class="text-danger"></span>
+        <span class="hint">@T["Select a lightweight model for auxiliary tasks. Falls back to the global default if not set."]</span>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/AIProviderConnectionFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/AIProviderConnectionFields.Edit.cshtml
@@ -29,42 +29,6 @@
 </div>
 
 <div class="@Orchard.GetWrapperClasses()">
-    <label asp-for="ChatDeploymentName" class="@Orchard.GetLabelClasses()">@T["Chat deployment name"]</label>
-    <div class="@Orchard.GetEndClasses()">
-        <input type="text" asp-for="ChatDeploymentName" class="form-control" />
-        <span asp-validation-for="ChatDeploymentName" class="text-danger"></span>
-        <span class="hint">@T["The deployment or model name used by the provider for this connection."]</span>
-    </div>
-</div>
-
-<div class="@Orchard.GetWrapperClasses()">
-    <label asp-for="EmbeddingDeploymentName" class="@Orchard.GetLabelClasses()">@T["Embedding deployment name"]</label>
-    <div class="@Orchard.GetEndClasses()">
-        <input type="text" asp-for="EmbeddingDeploymentName" class="form-control" />
-        <span asp-validation-for="EmbeddingDeploymentName" class="text-danger"></span>
-        <span class="hint">@T["The embedding deployment or model name used by the provider for this connection."]</span>
-    </div>
-</div>
-
-<div class="@Orchard.GetWrapperClasses()">
-    <label asp-for="ImagesDeploymentName" class="@Orchard.GetLabelClasses()">@T["Images deployment name"]</label>
-    <div class="@Orchard.GetEndClasses()">
-        <input type="text" asp-for="ImagesDeploymentName" class="form-control" />
-        <span asp-validation-for="ImagesDeploymentName" class="text-danger"></span>
-        <span class="hint">@T["The image generation deployment or model name used by the provider for this connection."]</span>
-    </div>
-</div>
-
-<div class="@Orchard.GetWrapperClasses()">
-    <label asp-for="UtilityDeploymentName" class="@Orchard.GetLabelClasses()">@T["Utility deployment name"]</label>
-    <div class="@Orchard.GetEndClasses()">
-        <input type="text" asp-for="UtilityDeploymentName" class="form-control" />
-        <span asp-validation-for="UtilityDeploymentName" class="text-danger"></span>
-        <span class="hint">@T["Optional lightweight model used for auxiliary tasks such as query rewriting, intent detection, and chart generation. When empty, the chat deployment name is used as a fallback."]</span>
-    </div>
-</div>
-
-<div class="@Orchard.GetWrapperClasses()">
     <div class="@Orchard.GetEndClasses(true)">
         <div class="form-check">
             <input type="checkbox" class="form-check-input" asp-for="IsDefault">

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/DefaultAIDeploymentSettings.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/DefaultAIDeploymentSettings.Edit.cshtml
@@ -1,0 +1,44 @@
+@using CrestApps.OrchardCore.AI.ViewModels
+@using OrchardCore
+
+@model DefaultAIDeploymentSettingsViewModel
+
+<div class="@Orchard.GetWrapperClasses()">
+    <label asp-for="DefaultUtilityDeploymentId" class="@Orchard.GetLabelClasses()">@T["Default Utility Deployment"]</label>
+    <div class="@Orchard.GetEndClasses()">
+        <select asp-for="DefaultUtilityDeploymentId" asp-items="Model.UtilityDeployments" class="form-select">
+            <option value="">@T["None"]</option>
+        </select>
+        <span class="hint">@T["The default lightweight model used for auxiliary tasks like planning and intent detection."]</span>
+    </div>
+</div>
+
+<div class="@Orchard.GetWrapperClasses()">
+    <label asp-for="DefaultEmbeddingDeploymentId" class="@Orchard.GetLabelClasses()">@T["Default Embedding Deployment"]</label>
+    <div class="@Orchard.GetEndClasses()">
+        <select asp-for="DefaultEmbeddingDeploymentId" asp-items="Model.EmbeddingDeployments" class="form-select">
+            <option value="">@T["None"]</option>
+        </select>
+        <span class="hint">@T["The default model used for embedding generation in document indexing and vector search."]</span>
+    </div>
+</div>
+
+<div class="@Orchard.GetWrapperClasses()">
+    <label asp-for="DefaultImageDeploymentId" class="@Orchard.GetLabelClasses()">@T["Default Image Deployment"]</label>
+    <div class="@Orchard.GetEndClasses()">
+        <select asp-for="DefaultImageDeploymentId" asp-items="Model.ImageDeployments" class="form-select">
+            <option value="">@T["None"]</option>
+        </select>
+        <span class="hint">@T["The default model used for image generation."]</span>
+    </div>
+</div>
+
+<div class="@Orchard.GetWrapperClasses()">
+    <label asp-for="DefaultSpeechToTextDeploymentId" class="@Orchard.GetLabelClasses()">@T["Default Speech-to-Text Deployment"]</label>
+    <div class="@Orchard.GetEndClasses()">
+        <select asp-for="DefaultSpeechToTextDeploymentId" asp-items="Model.SpeechToTextDeployments" class="form-select">
+            <option value="">@T["None"]</option>
+        </select>
+        <span class="hint">@T["The default model used for speech-to-text transcription."]</span>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/Items/AIDeployment.DefaultTags.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/Items/AIDeployment.DefaultTags.SummaryAdmin.cshtml
@@ -3,6 +3,17 @@
 
 @model ShapeViewModel<AIDeployment>
 
+<span class="badge ta-badge bg-info-subtle font-weight-normal" data-bs-toggle="tooltip" title="@T["Type"]">
+    <i class="text-secondary" aria-hidden="true"></i>@Model.Value.Type
+</span>
+
+@if (Model.Value.IsDefault)
+{
+    <span class="badge ta-badge bg-success-subtle font-weight-normal" data-bs-toggle="tooltip" title="@T["Default"]">
+        <i class="text-secondary" aria-hidden="true"></i>@T["Default"]
+    </span>
+}
+
 <span class="badge ta-badge bg-warning-subtle font-weight-normal" data-bs-toggle="tooltip" title="@T["Provider"]">
     <i class="text-secondary" aria-hidden="true"></i>@Model.Value.ProviderName
 </span>

--- a/src/Modules/CrestApps.OrchardCore.AI/Workflows/Models/AICompletionWithConfigTask.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Workflows/Models/AICompletionWithConfigTask.cs
@@ -147,7 +147,9 @@ public sealed class AICompletionWithConfigTask : TaskActivity<AICompletionWithCo
         try
         {
 
+#pragma warning disable CS0618 // Obsolete deployment name fields retained for backward compatibility
             var client = await _aIClientFactory.CreateChatClientAsync(ProviderName, ConnectionName ?? provider.DefaultConnectionName, DeploymentName ?? provider.DefaultChatDeploymentName);
+#pragma warning restore CS0618
 
             var chatOptions = new ChatOptions
             {

--- a/src/Modules/CrestApps.OrchardCore.AzureAIInference/Services/AzureAIInferenceCompletionClient.cs
+++ b/src/Modules/CrestApps.OrchardCore.AzureAIInference/Services/AzureAIInferenceCompletionClient.cs
@@ -21,7 +21,8 @@ public sealed class AzureAIInferenceCompletionClient : DeploymentAwareAICompleti
         IServiceProvider serviceProvider,
         IOptions<DefaultAIOptions> defaultOptions,
         INamedCatalog<AIDeployment> deploymentStore,
-        IAITemplateService aiTemplateService
+        IAITemplateService aiTemplateService,
+        IAIDeploymentManager deploymentManager
         ) : base(
             AzureAIInferenceConstants.ImplementationName,
             aIClientFactory,
@@ -32,7 +33,8 @@ public sealed class AzureAIInferenceCompletionClient : DeploymentAwareAICompleti
             defaultOptions.Value,
             handlers,
             deploymentStore,
-            aiTemplateService)
+            aiTemplateService,
+            deploymentManager)
     {
     }
 

--- a/src/Modules/CrestApps.OrchardCore.Ollama/Services/OllamaAIChatCompletionClient.cs
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/Services/OllamaAIChatCompletionClient.cs
@@ -19,7 +19,8 @@ internal sealed class OllamaAIChatCompletionClient : NamedAICompletionClient
            IOptions<AIProviderOptions> providerOptions,
            IEnumerable<IAICompletionServiceHandler> handlers,
            IOptions<DefaultAIOptions> defaultOptions,
-           IAITemplateService aiTemplateService
+           IAITemplateService aiTemplateService,
+           IAIDeploymentManager deploymentManager
            ) : base(
                OllamaConstants.ImplementationName,
                aIClientFactory, distributedCache,
@@ -28,7 +29,8 @@ internal sealed class OllamaAIChatCompletionClient : NamedAICompletionClient
                providerOptions.Value,
                defaultOptions.Value,
                handlers,
-               aiTemplateService)
+               aiTemplateService,
+               deploymentManager)
     {
     }
 

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Sms/Handlers/SmsOmnichannelEventHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Sms/Handlers/SmsOmnichannelEventHandler.cs
@@ -163,7 +163,7 @@ internal sealed class SmsOmnichannelEventHandler : IOmnichannelEventHandler
             var context = new AICompletionContext
             {
                 ConnectionName = campaign.ConnectionName,
-                DeploymentId = campaign.DeploymentName,
+                ChatDeploymentId = campaign.DeploymentName,
                 Temperature = campaign.Temperature,
                 TopP = campaign.TopP,
                 FrequencyPenalty = campaign.FrequencyPenalty,

--- a/src/Modules/CrestApps.OrchardCore.OpenAI.Azure/Migrations/AzureOpenAIDataSourceMetadataMigrations.cs
+++ b/src/Modules/CrestApps.OrchardCore.OpenAI.Azure/Migrations/AzureOpenAIDataSourceMetadataMigrations.cs
@@ -474,16 +474,20 @@ internal sealed class AzureOpenAIDataSourceMetadataMigrations : DataMigration
 
             foreach (var (connectionName, connection) in provider.Connections)
             {
+#pragma warning disable CS0618 // Obsolete deployment name methods retained for backward compatibility
                 var embeddingDeploymentName = connection.GetEmbeddingDeploymentOrDefaultName(false);
+#pragma warning restore CS0618
 
                 if (!string.IsNullOrEmpty(embeddingDeploymentName))
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     return new DataSourceIndexProfileMetadata
                     {
                         EmbeddingProviderName = providerName,
                         EmbeddingConnectionName = connectionName,
                         EmbeddingDeploymentName = embeddingDeploymentName,
                     };
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
         }

--- a/tests/CrestApps.OrchardCore.Tests/Core/Orchestration/DefaultOrchestratorResolverTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Core/Orchestration/DefaultOrchestratorResolverTests.cs
@@ -3,10 +3,12 @@ using CrestApps.AI.Prompting.Services;
 using CrestApps.OrchardCore.AI;
 using CrestApps.OrchardCore.AI.Core;
 using CrestApps.OrchardCore.AI.Core.Orchestration;
+using CrestApps.OrchardCore.AI.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
 
 namespace CrestApps.OrchardCore.Tests.Core.Orchestration;
 
@@ -121,6 +123,7 @@ public sealed class DefaultOrchestratorResolverTests
         services.AddSingleton<IAICompletionService, NullCompletionService>();
         services.AddSingleton<IAIClientFactory, NullAIClientFactory>();
         services.AddSingleton<IAITemplateService, NullAITemplateService>();
+        services.AddSingleton(Mock.Of<IAIDeploymentManager>());
         services.AddSingleton<IToolRegistry, NullToolRegistry>();
         services.AddSingleton<ITextTokenizer, LuceneTextTokenizer>();
         services.AddLogging(builder => builder.ClearProviders());
@@ -140,4 +143,5 @@ public sealed class DefaultOrchestratorResolverTests
         public Task<string> MergeAsync(IEnumerable<string> ids, IDictionary<string, object> arguments = null, string separator = "\n\n")
             => Task.FromResult<string>(null);
     }
+
 }

--- a/tests/CrestApps.OrchardCore.Tests/Core/Orchestration/DefaultOrchestratorTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Core/Orchestration/DefaultOrchestratorTests.cs
@@ -7,6 +7,7 @@ using CrestApps.OrchardCore.AI.Models;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
 
 namespace CrestApps.OrchardCore.Tests.Core.Orchestration;
 
@@ -328,6 +329,7 @@ public sealed class DefaultOrchestratorTests
             completionService ?? new FakeCompletionService("default response"),
             new FakeAIClientFactory(),
             new FakeAITemplateService(),
+            Mock.Of<IAIDeploymentManager>(),
             Options.Create(new AIProviderOptions()),
             toolRegistry ?? new FakeToolRegistry([]),
             new LuceneTextTokenizer(),
@@ -359,7 +361,7 @@ public sealed class DefaultOrchestratorTests
             CompletionContext = new AICompletionContext
             {
                 ConnectionName = "test",
-                DeploymentId = "test-deployment",
+                ChatDeploymentId = "test-deployment",
                 ToolNames = ["tool0", "tool1", "tool2"],
             },
             SourceName = "TestClient",
@@ -492,4 +494,5 @@ public sealed class DefaultOrchestratorTests
         public Task<string> MergeAsync(IEnumerable<string> ids, IDictionary<string, object> arguments = null, string separator = "\n\n")
             => Task.FromResult<string>(null);
     }
+
 }

--- a/tests/CrestApps.OrchardCore.Tests/Core/Services/DefaultAIDeploymentManagerTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Core/Services/DefaultAIDeploymentManagerTests.cs
@@ -1,0 +1,231 @@
+using CrestApps.OrchardCore.AI;
+using CrestApps.OrchardCore.AI.Core.Models;
+using CrestApps.OrchardCore.AI.Core.Services;
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OrchardCore.Settings;
+
+namespace CrestApps.OrchardCore.Tests.Core.Services;
+
+public sealed class DefaultAIDeploymentManagerTests
+{
+    private readonly Mock<INamedSourceCatalog<AIDeployment>> _storeMock;
+    private readonly Mock<ISiteService> _siteServiceMock;
+    private readonly Mock<ISite> _siteMock;
+    private readonly DefaultAIDeploymentSettings _settings;
+    private readonly DefaultAIDeploymentManager _manager;
+
+    public DefaultAIDeploymentManagerTests()
+    {
+        _storeMock = new Mock<INamedSourceCatalog<AIDeployment>>();
+        _siteServiceMock = new Mock<ISiteService>();
+        _siteMock = new Mock<ISite>();
+        _settings = new DefaultAIDeploymentSettings();
+
+        _siteMock.Setup(s => s.As<DefaultAIDeploymentSettings>())
+            .Returns(_settings);
+
+        _siteServiceMock.Setup(s => s.GetSiteSettingsAsync())
+            .ReturnsAsync(_siteMock.Object);
+
+        _manager = new DefaultAIDeploymentManager(
+            _storeMock.Object,
+            [],
+            _siteServiceMock.Object,
+            NullLogger<DefaultAIDeploymentManager>.Instance);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_WithValidId_ReturnsDeployment()
+    {
+        var deployment = CreateDeployment("dep-1", "gpt-4", AIDeploymentType.Chat);
+
+        _storeMock.Setup(m => m.FindByIdAsync("dep-1"))
+            .ReturnsAsync(deployment);
+
+        var result = await _manager.FindByIdAsync("dep-1");
+
+        Assert.NotNull(result);
+        Assert.Equal("dep-1", result.ItemId);
+        Assert.Equal("gpt-4", result.Name);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task FindByIdAsync_WithNullOrEmptyId_ReturnsNull(string id)
+    {
+        _storeMock.Setup(m => m.FindByIdAsync(It.IsAny<string>()))
+            .ReturnsAsync((AIDeployment)null);
+
+        var result = await _manager.FindByIdAsync(id);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_WithInvalidId_ReturnsNull()
+    {
+        _storeMock.Setup(m => m.FindByIdAsync("nonexistent"))
+            .ReturnsAsync((AIDeployment)null);
+
+        var result = await _manager.FindByIdAsync("nonexistent");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetDefaultAsync_WithType_ReturnsDefaultDeployment()
+    {
+        var deployments = new[]
+        {
+            CreateDeployment("dep-1", "gpt-4", AIDeploymentType.Chat, isDefault: false, connectionName: "conn-1"),
+            CreateDeployment("dep-2", "gpt-4o", AIDeploymentType.Chat, isDefault: true, connectionName: "conn-1"),
+            CreateDeployment("dep-3", "ada-002", AIDeploymentType.Embedding, isDefault: true, connectionName: "conn-1"),
+        };
+
+        _storeMock.Setup(m => m.GetAllAsync())
+            .ReturnsAsync(deployments);
+
+        var result = await _manager.GetDefaultAsync("openai", "conn-1", AIDeploymentType.Chat);
+
+        Assert.NotNull(result);
+        Assert.Equal("dep-2", result.ItemId);
+        Assert.True(result.IsDefault);
+    }
+
+    [Fact]
+    public async Task GetDefaultAsync_WithNoDefault_ReturnsNull()
+    {
+        var deployments = new[]
+        {
+            CreateDeployment("dep-1", "gpt-4", AIDeploymentType.Chat, isDefault: true, connectionName: "conn-1"),
+        };
+
+        _storeMock.Setup(m => m.GetAllAsync())
+            .ReturnsAsync(deployments);
+
+        var result = await _manager.GetDefaultAsync("openai", "conn-1", AIDeploymentType.Embedding);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithExplicitDeploymentId_ReturnsThatDeployment()
+    {
+        var deployment = CreateDeployment("dep-explicit", "gpt-4", AIDeploymentType.Chat);
+
+        _storeMock.Setup(m => m.FindByIdAsync("dep-explicit"))
+            .ReturnsAsync(deployment);
+
+        var connectionDeployments = new[]
+        {
+            CreateDeployment("dep-conn", "gpt-4o", AIDeploymentType.Chat, isDefault: true, connectionName: "conn-1"),
+        };
+
+        _storeMock.Setup(m => m.GetAllAsync())
+            .ReturnsAsync(connectionDeployments);
+
+        var result = await _manager.ResolveAsync(
+            AIDeploymentType.Chat,
+            deploymentId: "dep-explicit",
+            providerName: "openai",
+            connectionName: "conn-1");
+
+        Assert.NotNull(result);
+        Assert.Equal("dep-explicit", result.ItemId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithNoExplicit_FallsBackToConnectionDefault()
+    {
+        var deployments = new[]
+        {
+            CreateDeployment("dep-conn-default", "gpt-4o", AIDeploymentType.Utility, isDefault: true, connectionName: "conn-1"),
+        };
+
+        _storeMock.Setup(m => m.GetAllAsync())
+            .ReturnsAsync(deployments);
+
+        var result = await _manager.ResolveAsync(
+            AIDeploymentType.Utility,
+            providerName: "openai",
+            connectionName: "conn-1");
+
+        Assert.NotNull(result);
+        Assert.Equal("dep-conn-default", result.ItemId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithNoConnectionDefault_FallsBackToGlobalDefault()
+    {
+        _settings.DefaultUtilityDeploymentId = "dep-global";
+
+        var globalDeployment = CreateDeployment("dep-global", "gpt-4-turbo", AIDeploymentType.Utility);
+
+        _storeMock.Setup(m => m.FindByIdAsync("dep-global"))
+            .ReturnsAsync(globalDeployment);
+
+        _storeMock.Setup(m => m.GetAllAsync())
+            .ReturnsAsync([]);
+
+        var result = await _manager.ResolveAsync(AIDeploymentType.Utility);
+
+        Assert.NotNull(result);
+        Assert.Equal("dep-global", result.ItemId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithNoFallbacks_ReturnsNull()
+    {
+        _storeMock.Setup(m => m.GetAllAsync())
+            .ReturnsAsync([]);
+
+        var result = await _manager.ResolveAsync(AIDeploymentType.Chat);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetAllByTypeAsync_ReturnsOnlyMatchingType()
+    {
+        var allDeployments = new[]
+        {
+            CreateDeployment("dep-chat-1", "gpt-4", AIDeploymentType.Chat, providerName: "openai"),
+            CreateDeployment("dep-chat-2", "gpt-4o", AIDeploymentType.Chat, providerName: "azure"),
+            CreateDeployment("dep-embed-1", "ada-002", AIDeploymentType.Embedding, providerName: "openai"),
+            CreateDeployment("dep-img-1", "dall-e-3", AIDeploymentType.Image, providerName: "openai"),
+        };
+
+        _storeMock.Setup(m => m.GetAllAsync())
+            .ReturnsAsync(allDeployments);
+
+        var result = (await _manager.GetAllByTypeAsync(AIDeploymentType.Chat)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, d => Assert.Equal(AIDeploymentType.Chat, d.Type));
+        Assert.Contains(result, d => d.ItemId == "dep-chat-1");
+        Assert.Contains(result, d => d.ItemId == "dep-chat-2");
+    }
+
+    private static AIDeployment CreateDeployment(
+        string itemId,
+        string name,
+        AIDeploymentType type,
+        bool isDefault = false,
+        string providerName = "openai",
+        string connectionName = "default")
+    {
+        return new AIDeployment
+        {
+            ItemId = itemId,
+            Name = name,
+            Type = type,
+            IsDefault = isDefault,
+            ProviderName = providerName,
+            ConnectionName = connectionName,
+        };
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/OpenAI/Azure/AzureOpenAIDataSourceMetadataMigrationsTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/OpenAI/Azure/AzureOpenAIDataSourceMetadataMigrationsTests.cs
@@ -14,6 +14,8 @@ using Microsoft.Extensions.Options;
 using Moq;
 
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 
 namespace CrestApps.OrchardCore.Tests.OpenAI.Azure;
 


### PR DESCRIPTION
This pull request introduces a significant refactor to how AI deployment identifiers and types are managed across the codebase, moving from legacy string-based deployment names to a new, strongly-typed model using `AIDeploymentType` and explicit deployment IDs for each type. The changes improve clarity, extensibility, and pave the way for better multi-deployment support. Backward compatibility is maintained for existing serialized data and APIs.

Key changes are grouped below:

**1. Strongly-Typed Deployment Model and API Enhancements**

* Introduced the `AIDeploymentType` enum to represent deployment types (Chat, Utility, Embedding, Image, SpeechToText), and updated `AIDeployment` to include `Type` and `IsDefault` properties. This enables explicit typing and default designation for deployments. [[1]](diffhunk://#diff-99e30c2b3ee0872c348deb2161bd0dce68d18122f8adb1cb27cafeb69b993f15R1-R10) [[2]](diffhunk://#diff-db33cec3f64e28bd2a4d8b43d3d25f1bb03d607ac408f5c9793edeb4670f0f90R30-R41) [[3]](diffhunk://#diff-db33cec3f64e28bd2a4d8b43d3d25f1bb03d607ac408f5c9793edeb4670f0f90R57-R58)
* Extended the `IAIDeploymentManager` interface with new methods for querying and resolving deployments by type and default status, supporting advanced resolution and dropdown population scenarios.

**2. Model and Serialization Refactoring**

* Refactored models (`AIProfile`, `AICompletionContext`, `ChatInteraction`) to use `ChatDeploymentId` and `UtilityDeploymentId` instead of the generic `DeploymentId`, with backward compatibility via `[Obsolete]` properties and JSON serialization hooks. [[1]](diffhunk://#diff-5cd055174ac41325dbfd059094c1b013f5d5020632033e5a9b397adbc5cdaee7L30-R54) [[2]](diffhunk://#diff-5cd055174ac41325dbfd059094c1b013f5d5020632033e5a9b397adbc5cdaee7L95-R118) [[3]](diffhunk://#diff-5a1817428d3e67f12d461848b79f128cb652f758a6173defc6a5a520884fcd28L33-R52) [[4]](diffhunk://#diff-9566505f7d61fccc5378e75662a92566e03639258bf5884c57b8666cb00b7a25L32-R56)
* Updated JSON converters and cloning methods to handle new properties and preserve compatibility with legacy fields. [[1]](diffhunk://#diff-ba95092edee73bb6ad0b64cd72f46af53250e5ca52b32311add221cd36d7f815R26) [[2]](diffhunk://#diff-ba95092edee73bb6ad0b64cd72f46af53250e5ca52b32311add221cd36d7f815R35) [[3]](diffhunk://#diff-ba95092edee73bb6ad0b64cd72f46af53250e5ca52b32311add221cd36d7f815R61-R66) [[4]](diffhunk://#diff-02b806305ec57441aecc9865b4cac67801c48b7a64d3d4bf74c0985ced5d9128R51-R56)

**3. Deprecation of Legacy Deployment Name Properties**

* Marked legacy deployment name properties and related dictionary extension methods as `[Obsolete]`, guiding developers to use the new deployment resolver and strongly-typed APIs. [[1]](diffhunk://#diff-02b806305ec57441aecc9865b4cac67801c48b7a64d3d4bf74c0985ced5d9128R15-R24) [[2]](diffhunk://#diff-5b7c0106d63bae01475a85920b8db5a3c7ee9c181622f367a1f972b656b4f676R16-R25) [[3]](diffhunk://#diff-2f9dcf483d0c7d75fbfe453fe144405f6b91cb7a54cc9f9daee946903f73169eR28-R65)

**4. Validation and Handler Updates**

* Improved validation to ensure only valid `AIDeploymentType` values are accepted, and updated handlers to populate new deployment fields from incoming data. [[1]](diffhunk://#diff-17a9460ff1c97fdfe171018f22b5c7043c92190b872ef204cecb82cd25148533R47-R51) [[2]](diffhunk://#diff-17a9460ff1c97fdfe171018f22b5c7043c92190b872ef204cecb82cd25148533R126-R139)

**5. Codebase Consistency and Usage Updates**

* Updated code throughout the codebase to use the new `ChatDeploymentId` property instead of the obsolete `DeploymentId`.

These changes modernize the deployment management system, making it more robust and future-proof while ensuring a smooth transition from the previous model.