### PR TITLE
Add Agent to Agent (A2A) Protocol Support

### DIFF
--- a/CrestApps.OrchardCore.slnx
+++ b/CrestApps.OrchardCore.slnx
@@ -46,6 +46,7 @@
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.Documents/CrestApps.OrchardCore.AI.Documents.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.Mcp.Resources.Ftp/CrestApps.OrchardCore.AI.Mcp.Resources.Ftp.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.Mcp.Resources.Sftp/CrestApps.OrchardCore.AI.Mcp.Resources.Sftp.csproj" />
+    <Project Path="src/Modules/CrestApps.OrchardCore.AI.A2A/CrestApps.OrchardCore.AI.A2A.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.Mcp/CrestApps.OrchardCore.AI.Mcp.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.Prompting/CrestApps.OrchardCore.AI.Prompting.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI/CrestApps.OrchardCore.AI.csproj" />
@@ -75,6 +76,7 @@
   <Folder Name="/Startup/">
     <Project Path="src/Startup/CrestApps.Aspire.AppHost/CrestApps.Aspire.AppHost.csproj" />
     <Project Path="src/Startup/CrestApps.OrchardCore.Cms.Web/CrestApps.OrchardCore.Cms.Web.csproj" />
+    <Project Path="src/Startup/CrestApps.OrchardCore.Samples.A2AClient/CrestApps.OrchardCore.Samples.A2AClient.csproj" />
     <Project Path="src/Startup/CrestApps.OrchardCore.Samples.McpClient/CrestApps.OrchardCore.Samples.McpClient.csproj" />
   </Folder>
   <Folder Name="/Targets/">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,8 @@
     <PackageVersion Include="ZString" Version="2.6.0" />
     <PackageVersion Include="YesSql.Abstractions" Version="5.4.7" />
     <PackageVersion Include="YesSql.Core" Version="5.4.7" />
+    <PackageVersion Include="A2A" Version="0.3.4-preview" />
+    <PackageVersion Include="A2A.AspNetCore" Version="0.3.4-preview" />
     <PackageVersion Include="ModelContextProtocol" Version="1.0.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.0.0" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.0.0" />

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AICompletionContext.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/AICompletionContext.cs
@@ -32,6 +32,8 @@ public class AICompletionContext
 
     public string[] McpConnectionIds { get; set; }
 
+    public string[] A2AConnectionIds { get; set; }
+
     public string DataSourceId { get; set; }
 
     public string ChatDeploymentId { get; set; }

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/ChatInteraction.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/ChatInteraction.cs
@@ -125,6 +125,11 @@ public sealed class ChatInteraction : CatalogItem, ISourceAwareModel
     public IList<string> McpConnectionIds { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets the list of A2A connection IDs to use.
+    /// </summary>
+    public IList<string> A2AConnectionIds { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets the collection of attached documents for "chat against own data" functionality.
     /// Only applicable when Source is AzureOpenAIOwnData.
     /// </summary>

--- a/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/ToolRegistryEntry.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.AI.Abstractions/Models/ToolRegistryEntry.cs
@@ -73,4 +73,9 @@ public enum ToolRegistryEntrySource
     /// An AI agent profile exposed as a tool for multi-agent orchestration.
     /// </summary>
     Agent,
+
+    /// <summary>
+    /// A remote agent accessible via the Agent-to-Agent (A2A) protocol.
+    /// </summary>
+    A2AAgent,
 }

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/a2a/client.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/a2a/client.md
@@ -1,0 +1,95 @@
+---
+sidebar_label: A2A Client (Agent Connections)
+sidebar_position: 2
+title: A2A Client Integration
+description: Connect to remote A2A hosts to discover and use external AI agents.
+---
+
+# A2A Client Integration
+
+| | |
+| --- | --- |
+| **Feature Name** | Agent to Agent Protocol (A2A) |
+| **Feature ID** | `CrestApps.OrchardCore.AI.A2A` |
+
+The A2A Client feature allows your Orchard Core application to connect to external A2A hosts, enabling AI models to discover and communicate with remote AI agents.
+
+---
+
+## Managing Agent Connections
+
+### Add a Connection
+
+1. Navigate to **Artificial Intelligence** → **Agent to Agent Hosts**.
+2. Click the **Add Connection** button.
+3. Enter the following details:
+   - **Display Text**: A descriptive name for the connection (e.g., "Production Agent Hub").
+   - **Endpoint**: The base URL of the A2A host (e.g., `https://agents.example.com`). The agent card is automatically resolved at `/.well-known/agent-card.json`.
+   - **Authentication**: Select the appropriate authentication method for the remote host.
+4. Save the connection.
+
+Each connection represents a single A2A host that may expose multiple agents through its agent card.
+
+### Authentication Types
+
+The A2A client supports the same authentication types available for MCP SSE connections:
+
+| Type | Description |
+|------|-------------|
+| **Anonymous** | No authentication (default). |
+| **API Key** | Sends an API key via a configurable HTTP header with an optional prefix. |
+| **Basic Authentication** | Standard HTTP Basic authentication with username and password. |
+| **OAuth 2.0 Client Credentials** | Acquires a Bearer token using the client credentials grant. |
+| **OAuth 2.0 + Private Key JWT** | Uses a PEM-encoded private key to sign a JWT client assertion. |
+| **OAuth 2.0 + Mutual TLS (mTLS)** | Authenticates using a client certificate (PFX/PKCS#12). |
+| **Custom Headers** | Sends arbitrary HTTP headers defined as a JSON object. |
+
+Sensitive fields (API keys, passwords, secrets, private keys, certificates) are encrypted at rest using ASP.NET Core Data Protection.
+
+---
+
+## Assigning Agent Connections to AI Profiles
+
+Once connections are created, you can assign them to specific AI profiles, templates, or chat interactions:
+
+### On AI Profiles
+
+1. Navigate to the AI profile editor.
+2. Go to the **Capabilities** tab.
+3. Under **Agent Connections**, check the connections you want this profile to use.
+4. Save the profile.
+
+### On AI Profile Templates (Profile Sources)
+
+1. Navigate to the AI profile template editor.
+2. Go to the **Capabilities** tab.
+3. Under **Agent Connections**, check the connections you want templates using this source to include.
+4. Save the template.
+
+### On Chat Interactions
+
+1. Navigate to the chat interaction editor.
+2. Go to the **Parameters** tab under **Capabilities**.
+3. Under **Agent Connections**, check the connections to include for this interaction.
+4. Save the interaction.
+
+---
+
+## How Agent Connections Work
+
+When an AI profile has agent connections configured:
+
+1. **Discovery**: The system fetches the agent card from each connected A2A host (cached for 15 minutes).
+2. **Tool Registration**: Each agent skill from the agent card is registered as an AI tool available to the model.
+3. **Invocation**: When the AI model decides to use a remote agent, the `A2AAgentProxyTool` sends the message to the remote agent via the A2A protocol.
+4. **Response**: The remote agent's response is returned to the AI model as tool output.
+
+This means remote agents appear as callable tools to the AI model, just like local tools or MCP tools.
+
+---
+
+## Permissions
+
+| Permission | Description |
+|-----------|-------------|
+| Manage A2A Connections | Required to create, edit, and delete A2A connections |

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/a2a/host.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/a2a/host.md
@@ -1,0 +1,95 @@
+---
+sidebar_label: A2A Host
+sidebar_position: 3
+title: A2A Host
+description: Expose Orchard Core Agent AI Profiles to external clients via the Agent-to-Agent protocol.
+---
+
+# A2A Host
+
+| | |
+| --- | --- |
+| **Feature Name** | Agent to Agent Protocol (A2A) Host |
+| **Feature ID** | `CrestApps.OrchardCore.AI.A2A.Host` |
+
+The A2A Host feature exposes all AI Profiles of type **Agent** as discoverable agents via the Agent-to-Agent protocol. External A2A clients can discover available agents and send messages to them.
+
+---
+
+## Agent Exposure Modes
+
+The A2A Host supports two modes for how agents are exposed:
+
+### Multi-Agent Mode (Default)
+
+Each Agent AI Profile is exposed as its own independent agent card. The `/.well-known/agent-card.json` endpoint returns a **JSON array** of agent cards. Each card has its own `url` property pointing to `/a2a?agent={agentName}`.
+
+### Skill Mode
+
+When `ExposeAgentsAsSkill` is enabled, a single combined agent card is returned. All Agent AI Profiles are listed as **skills** within that card. Messages are routed using the `agentName` metadata field.
+
+---
+
+## Endpoints
+
+When the A2A Host feature is enabled, the following endpoints become available:
+
+| Endpoint | Description |
+|----------|-------------|
+| `/.well-known/agent-card.json` | Returns agent card(s) for discovery (array in multi-agent mode, single object in skill mode) |
+| `/a2a` | The A2A JSON-RPC endpoint for sending messages to agents |
+| `/a2a?agent={name}` | Routes to a specific agent in multi-agent mode |
+
+### Sending Messages
+
+Messages sent to `/a2a` are routed to the appropriate agent based on:
+
+1. **Query parameter routing** (multi-agent mode): The `?agent={name}` query parameter specifies the target agent.
+2. **Metadata routing**: If the message includes `agentName` in its metadata, it routes to that specific agent.
+3. **Default routing**: If no agent is specified, the message is routed to the first available agent.
+
+---
+
+## Authentication
+
+The A2A Host supports the same authentication patterns as the MCP Server:
+
+| Authentication Type | Description |
+|---|---|
+| **None** | No authentication required. Suitable for development environments. |
+| **API Key** | Clients must provide an API key for access. |
+| **OpenId** | Clients authenticate using OpenID Connect tokens. Enable the OrchardCore OpenIddict server feature for automatic integration. |
+
+### Configuration
+
+Authentication is configured via shell configuration (e.g., `appsettings.json`):
+
+```json
+{
+  "OrchardCore": {
+    "CrestApps_AI": {
+      "A2AHost": {
+        "AuthenticationType": "None",
+        "ApiKey": "your-api-key-here",
+        "RequireAccessPermission": false,
+        "ExposeAgentsAsSkill": false
+      }
+    }
+  }
+}
+```
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `AuthenticationType` | `None` \| `ApiKey` \| `OpenId` | `OpenId` | The authentication method for the A2A endpoint |
+| `ApiKey` | `string` | | The API key value (required when using `ApiKey` authentication) |
+| `RequireAccessPermission` | `bool` | `true` | When `true`, authenticated users must also have the `AccessA2AHost` permission |
+| `ExposeAgentsAsSkill` | `bool` | `false` | When `true`, all agents are combined into a single card with skills instead of individual cards |
+
+---
+
+## Permissions
+
+| Permission | Description |
+|-----------|-------------|
+| Access A2A Host | Required when `RequireAccessPermission` is enabled in host options |

--- a/src/CrestApps.OrchardCore.Documentations/docs/ai/a2a/index.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/ai/a2a/index.md
@@ -1,0 +1,46 @@
+---
+sidebar_label: Overview
+sidebar_position: 1
+title: Agent-to-Agent Protocol (A2A)
+description: Overview of A2A client and host support for inter-agent communication using the Agent-to-Agent protocol.
+---
+
+# Agent-to-Agent Protocol (A2A)
+
+The [Agent-to-Agent (A2A) protocol](https://github.com/a2aproject/A2A) is an open standard that enables seamless communication between AI agents. It allows agents to discover, communicate with, and delegate tasks to other agents, regardless of their underlying implementation or hosting environment.
+
+## Features Overview
+
+CrestApps provides both **client** (Agent Connections) and **host** A2A support:
+
+| Feature | Feature ID | Description |
+|---------|-----------|-------------|
+| [A2A Client (Agent Connections)](client) | `CrestApps.OrchardCore.AI.A2A` | Connect to remote A2A hosts and use their agents |
+| [A2A Host](host) | `CrestApps.OrchardCore.AI.A2A.Host` | Expose Agent AI Profiles via the A2A protocol |
+
+## How It Works
+
+The A2A protocol uses JSON-RPC 2.0 over HTTP for agent communication. Agents expose their capabilities through **agent cards** served at a well-known endpoint (`/.well-known/agent-card.json`). Client agents discover available agents through these cards and send messages using the A2A message format.
+
+### Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Agent Card** | A JSON document describing an agent's capabilities, skills, and metadata |
+| **Skills** | Specific capabilities an agent can perform (e.g., "translate text", "summarize document") |
+| **Task** | A unit of work sent to an agent, tracked through its lifecycle |
+| **Message** | A communication between agents containing text parts and metadata |
+
+## AI Functions
+
+When the A2A client feature is enabled, the following system AI functions become available to all AI profiles:
+
+| Function | Description |
+|----------|-------------|
+| `listAvailableAgents` | Lists all available agents (local and remote) with their names, descriptions, and capabilities |
+| `findAgentForTask` | Uses keyword matching to find the most relevant agent for a given task description |
+| `findToolsForTask` | Uses keyword matching to find the most relevant AI tools for a given task description |
+
+## Agent Card Caching
+
+To optimize performance, agent cards fetched from remote A2A hosts are cached for **15 minutes** per connection. The cache is automatically invalidated when a connection is updated or deleted, ensuring fresh data is loaded on the next request.

--- a/src/CrestApps.OrchardCore.Documentations/docs/changelog/v2.0.0.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/changelog/v2.0.0.md
@@ -111,6 +111,20 @@ Modules for RAG (Retrieval-Augmented Generation) and knowledge base indexing:
 | FTP Resources | `CrestApps.OrchardCore.AI.Mcp.Resources.Ftp` |
 | SFTP Resources | `CrestApps.OrchardCore.AI.Mcp.Resources.Sftp` |
 
+### Agent-to-Agent (A2A) Protocol
+
+A new module implementing the [A2A protocol](https://github.com/a2aproject/a2a-dotnet) for multi-agent interoperability:
+
+| Feature | Feature ID | Description |
+|---------|------------|-------------|
+| [A2A Client](../ai/a2a/client.md) | `CrestApps.OrchardCore.AI.A2A` | Connect to external A2A hosts and use their agents as AI tools in orchestration. |
+| [A2A Host](../ai/a2a/host.md) | `CrestApps.OrchardCore.AI.A2A.Host` | Expose Agent-type AI Profiles as discoverable A2A agents at `/.well-known/agent-card.json`. |
+
+- **A2A Host** — Exposes all Agent-type AI Profiles as A2A agents. Each agent gets its own agent card with skills derived from the profile description and configured tools. Supports streaming (`TaskArtifactUpdateEvent` SSE) and non-streaming responses. Configurable authentication: **OpenId Connect** (default, integrates with OrchardCore's OpenIddict feature), **API Key**, or **None**. Agent cards include `SecuritySchemes` so clients know how to authenticate. An `ExposeAgentsAsSkill` option consolidates all agents into a single card with multiple skills.
+- **A2A Client** — Add connections to external A2A hosts from the admin UI (**Artificial Intelligence → Agent to Agent Hosts**). Connections support the same authentication types as MCP client connections (Anonymous, API Key, Basic, OAuth 2.0, etc.). Agent cards are cached for 15 minutes per connection with signal-based invalidation on update/delete. Select A2A connections on AI Profiles, Templates, and Chat Interactions under the **Capabilities** tab. Connected agents are automatically registered as AI tools via `A2AAgentProxyTool` and can be invoked by the orchestrator.
+- **AI Discovery Functions** — Three new built-in AI tools: `list_available_agents` (returns agent cards from all connections and local agents), `find_agent_for_task` (semantic + keyword search for the best agent), and `find_tools_for_task` (semantic + keyword search for relevant AI tools). These help the AI model discover and select the right agent or tool for a given task.
+- **Sample A2A Client** — A standalone Razor Pages application at `CrestApps.OrchardCore.Samples.A2AClient` for testing A2A agents. Lists agent cards, supports streaming and non-streaming message sending, and integrates with .NET Aspire.
+
 ### Omnichannel Communications
 
 A new suite of modules for multi-channel communication:

--- a/src/CrestApps.OrchardCore.Documentations/docs/samples/a2a-client.md
+++ b/src/CrestApps.OrchardCore.Documentations/docs/samples/a2a-client.md
@@ -1,0 +1,51 @@
+---
+sidebar_label: A2A Client Sample
+sidebar_position: 2
+title: A2A Client Sample
+description: Sample ASP.NET Core Razor Pages app that connects to the A2A host hosted by CrestApps Orchard Core.
+---
+
+This sample project is a small ASP.NET Core Razor Pages app that connects to the A2A host served by `CrestApps.OrchardCore.Cms.Web` when running with Aspire. It provides a simple UI to explore A2A capabilities:
+
+- **Home** – Prerequisites and setup instructions.
+- **Agents** – List all available agents from the A2A host and send messages to them.
+
+## Run with Aspire
+
+The easiest way to run this sample is using the **Aspire AppHost** project:
+
+1. Make sure [Docker Desktop](https://www.docker.com/products/docker-desktop) is installed and running locally.
+2. Set `CrestApps.Aspire.AppHost` as your startup project.
+3. Run the project. The Aspire dashboard will open in your browser.
+4. From the Aspire dashboard, click on the endpoint for the resource you want to access:
+   - **orchardcore** — Opens the Orchard Core CMS application (on port 5001).
+   - **a2aclientsample** — Opens the A2A Client sample UI (on port 5003).
+
+:::note
+
+The Aspire AppHost orchestrates several services including **Ollama** (AI model host), **Elasticsearch**, **Redis**, and both the Orchard Core app and the sample clients. All service dependencies and environment variables are configured automatically.
+
+:::
+
+## A2A Host Feature Requirement
+
+If the A2A Host feature is not enabled, requests to `/.well-known/agent-card.json` will return `404`. Enable the A2A Host feature in the default tenant:
+
+- Feature ID: `CrestApps.OrchardCore.AI.A2A.Host`
+- Admin UI: **Tools → Features**
+
+After enabling the feature, refresh the sample UI to see available agents.
+
+## Configuration
+
+The A2A endpoint is configured via `A2A:Endpoint`. Aspire sets it automatically, but you can override it in `appsettings.json`:
+
+```json
+{
+  "A2A": {
+    "Endpoint": "https://localhost:5001"
+  }
+}
+```
+
+The agent card is automatically discovered at `/.well-known/agent-card.json` relative to the endpoint.

--- a/src/CrestApps.OrchardCore.Documentations/sidebars.js
+++ b/src/CrestApps.OrchardCore.Documentations/sidebars.js
@@ -66,6 +66,15 @@ const sidebars = {
             'ai/mcp/sftp',
           ],
         },
+        {
+          type: 'category',
+          label: 'Agent-to-Agent Protocol (A2A)',
+          items: [
+            'ai/a2a/index',
+            'ai/a2a/client',
+            'ai/a2a/host',
+          ],
+        },
       ],
     },
     {
@@ -97,6 +106,7 @@ const sidebars = {
       items: [
         'samples/index',
         'samples/mcp-client',
+        'samples/a2a-client',
       ],
     },
     {

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/A2AConstants.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/A2AConstants.cs
@@ -1,0 +1,13 @@
+namespace CrestApps.OrchardCore.AI.A2A;
+
+public static class A2AConstants
+{
+    public const string DataProtectionPurpose = "A2AClientConnection";
+
+    public static class Feature
+    {
+        public const string Area = "CrestApps.OrchardCore.AI.A2A";
+
+        public const string Host = "CrestApps.OrchardCore.AI.A2A.Host";
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/A2AJsonOptions.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/A2AJsonOptions.cs
@@ -1,0 +1,12 @@
+using System.Text.Json;
+
+namespace CrestApps.OrchardCore.AI.A2A;
+
+internal static class A2AJsonOptions
+{
+    public static readonly JsonSerializerOptions Default = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/A2APermissions.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/A2APermissions.cs
@@ -1,0 +1,8 @@
+using OrchardCore.Security.Permissions;
+
+namespace CrestApps.OrchardCore.AI.A2A;
+
+public static class A2APermissions
+{
+    public static readonly Permission ManageA2AConnections = new("ManageA2AConnections", "Manage Agent-to-Agent Connections");
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Controllers/ConnectionsController.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Controllers/ConnectionsController.cs
@@ -1,0 +1,304 @@
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.Core.Models;
+using CrestApps.OrchardCore.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Navigation;
+using OrchardCore.Routing;
+
+namespace CrestApps.OrchardCore.AI.A2A.Controllers;
+
+public sealed class ConnectionsController : Controller
+{
+    private const string _optionsSearch = "Options.Search";
+
+    private readonly ICatalogManager<A2AConnection> _manager;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IUpdateModelAccessor _updateModelAccessor;
+    private readonly IDisplayManager<A2AConnection> _displayDriver;
+    private readonly INotifier _notifier;
+
+    internal readonly IHtmlLocalizer H;
+    internal readonly IStringLocalizer S;
+
+    public ConnectionsController(
+        ICatalogManager<A2AConnection> manager,
+        IAuthorizationService authorizationService,
+        IUpdateModelAccessor updateModelAccessor,
+        IDisplayManager<A2AConnection> instanceDisplayManager,
+        INotifier notifier,
+        IHtmlLocalizer<ConnectionsController> htmlLocalizer,
+        IStringLocalizer<ConnectionsController> stringLocalizer)
+    {
+        _manager = manager;
+        _authorizationService = authorizationService;
+        _updateModelAccessor = updateModelAccessor;
+        _displayDriver = instanceDisplayManager;
+        _notifier = notifier;
+        H = htmlLocalizer;
+        S = stringLocalizer;
+    }
+
+    [Admin("ai/a2a/connections", "AIA2AConnectionsIndex")]
+    public async Task<IActionResult> Index(
+        CatalogEntryOptions options,
+        PagerParameters pagerParameters,
+        [FromServices] IOptions<PagerOptions> pagerOptions,
+        [FromServices] IShapeFactory shapeFactory)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, A2APermissions.ManageA2AConnections))
+        {
+            return Forbid();
+        }
+
+        var pager = new Pager(pagerParameters, pagerOptions.Value.GetPageSize());
+
+        var result = await _manager.PageAsync(pager.Page, pager.PageSize, new QueryContext
+        {
+            Sorted = true,
+            Name = options.Search,
+        });
+
+        var routeData = new RouteData();
+
+        if (!string.IsNullOrEmpty(options.Search))
+        {
+            routeData.Values.TryAdd(_optionsSearch, options.Search);
+        }
+
+        var viewModel = new ListCatalogEntryViewModel<CatalogEntryViewModel<A2AConnection>>
+        {
+            Models = [],
+            Options = options,
+            Pager = await shapeFactory.PagerAsync(pager, result.Count, routeData),
+        };
+
+        foreach (var model in result.Entries)
+        {
+            viewModel.Models.Add(new CatalogEntryViewModel<A2AConnection>
+            {
+                Model = model,
+                Shape = await _displayDriver.BuildDisplayAsync(model, _updateModelAccessor.ModelUpdater, "SummaryAdmin")
+            });
+        }
+
+        viewModel.Options.BulkActions =
+        [
+            new SelectListItem(S["Delete"], nameof(CatalogEntryAction.Remove)),
+        ];
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Index))]
+    [FormValueRequired("submit.Filter")]
+    [Admin("ai/a2a/connections", "AIA2AConnectionsIndex")]
+    public async Task<ActionResult> IndexFilterPost(ListCatalogEntryViewModel model)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, A2APermissions.ManageA2AConnections))
+        {
+            return Forbid();
+        }
+
+        return RedirectToAction(nameof(Index), new RouteValueDictionary
+        {
+            { _optionsSearch, model.Options?.Search },
+        });
+    }
+
+    [Admin("ai/a2a/connection/create", "AIA2AConnectionCreate")]
+    public async Task<ActionResult> Create()
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, A2APermissions.ManageA2AConnections))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.NewAsync();
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = S["A2A Host Connection"].Value,
+            Editor = await _displayDriver.BuildEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Create))]
+    [Admin("ai/a2a/connection/create", "AIA2AConnectionCreate")]
+    public async Task<ActionResult> CreatePost()
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, A2APermissions.ManageA2AConnections))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.NewAsync();
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = model.DisplayText,
+            Editor = await _displayDriver.UpdateEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        if (ModelState.IsValid)
+        {
+            await _manager.CreateAsync(model);
+            await _notifier.SuccessAsync(H["A new connection has been created successfully."]);
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        return View(viewModel);
+    }
+
+    [Admin("ai/a2a/connection/edit/{id}", "AIA2AConnectionEdit")]
+    public async Task<ActionResult> Edit(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, A2APermissions.ManageA2AConnections))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = model.DisplayText,
+            Editor = await _displayDriver.BuildEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Edit))]
+    [Admin("ai/a2a/connection/edit/{id}", "AIA2AConnectionEdit")]
+    public async Task<ActionResult> EditPost(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, A2APermissions.ManageA2AConnections))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = model.DisplayText,
+            Editor = await _displayDriver.UpdateEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        if (ModelState.IsValid)
+        {
+            await _manager.UpdateAsync(model);
+
+            await _notifier.SuccessAsync(H["The connection has been updated successfully."]);
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [Admin("ai/a2a/connection/delete/{id}", "AIA2AConnectionDelete")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, A2APermissions.ManageA2AConnections))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        if (await _manager.DeleteAsync(model))
+        {
+            await _notifier.SuccessAsync(H["The connection has been deleted successfully."]);
+        }
+        else
+        {
+            await _notifier.ErrorAsync(H["Unable to remove the connection."]);
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Index))]
+    [FormValueRequired("submit.BulkAction")]
+    [Admin("ai/a2a/connections", "AIA2AConnectionsIndex")]
+    public async Task<ActionResult> IndexPost(CatalogEntryOptions options, IEnumerable<string> itemIds)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, A2APermissions.ManageA2AConnections))
+        {
+            return Forbid();
+        }
+
+        if (itemIds?.Count() > 0)
+        {
+            switch (options.BulkAction)
+            {
+                case CatalogEntryAction.None:
+                    break;
+                case CatalogEntryAction.Remove:
+                    var counter = 0;
+                    foreach (var id in itemIds)
+                    {
+                        var instance = await _manager.FindByIdAsync(id);
+
+                        if (instance == null)
+                        {
+                            continue;
+                        }
+
+                        if (await _manager.DeleteAsync(instance))
+                        {
+                            counter++;
+                        }
+                    }
+                    if (counter == 0)
+                    {
+                        await _notifier.WarningAsync(H["No connections were removed."]);
+                    }
+                    else
+                    {
+                        await _notifier.SuccessAsync(H.Plural(counter, "1 connection has been removed successfully.", "{0} connections have been removed successfully."));
+                    }
+                    break;
+                default:
+                    return BadRequest();
+            }
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/CrestApps.OrchardCore.AI.A2A.csproj
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/CrestApps.OrchardCore.AI.A2A.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <RootNamespace>$(MSBuildProjectName)</RootNamespace>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+    <Title>CrestApps OrchardCore AI A2A Module</Title>
+    <Description>
+      $(CrestAppsDescription)
+
+      Provides Agent-to-Agent (A2A) protocol support including hosting AI agents for external discovery and connecting to remote A2A agent hosts.
+    </Description>
+    <PackageTags>$(PackageTags) OrchardCoreCMS AI A2A Agent AgentToAgent</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OrchardCore.Module.Targets" />
+    <PackageReference Include="OrchardCore.DisplayManagement" />
+    <PackageReference Include="OrchardCore.ResourceManagement" />
+    <PackageReference Include="OrchardCore.Admin.Abstractions" />
+    <PackageReference Include="OrchardCore.Navigation.Core" />
+    <PackageReference Include="A2A" />
+    <PackageReference Include="A2A.AspNetCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Abstractions\CrestApps.OrchardCore.Abstractions\CrestApps.OrchardCore.Abstractions.csproj" />
+    <ProjectReference Include="..\..\Core\CrestApps.OrchardCore.AI.Core\CrestApps.OrchardCore.AI.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CrestApps.OrchardCore.AI\CrestApps.OrchardCore.AI.csproj" PrivateAssets="none" />
+    <ProjectReference Include="..\CrestApps.OrchardCore.Resources\CrestApps.OrchardCore.Resources.csproj" PrivateAssets="none" />
+  </ItemGroup>
+
+</Project>

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Drivers/A2AConnectionDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Drivers/A2AConnectionDisplayDriver.cs
@@ -1,0 +1,373 @@
+using System.Text.Json;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.A2A.ViewModels;
+using CrestApps.OrchardCore.Core;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Entities;
+using OrchardCore.Mvc.ModelBinding;
+
+namespace CrestApps.OrchardCore.AI.A2A.Drivers;
+
+internal sealed class A2AConnectionDisplayDriver : DisplayDriver<A2AConnection>
+{
+    private readonly IDataProtectionProvider _dataProtectionProvider;
+
+    internal readonly IStringLocalizer S;
+
+    public A2AConnectionDisplayDriver(
+        IDataProtectionProvider dataProtectionProvider,
+        IStringLocalizer<A2AConnectionDisplayDriver> stringLocalizer)
+    {
+        _dataProtectionProvider = dataProtectionProvider;
+        S = stringLocalizer;
+    }
+
+    public override Task<IDisplayResult> DisplayAsync(A2AConnection connection, BuildDisplayContext context)
+    {
+        return CombineAsync(
+            View("A2AConnection_Fields_SummaryAdmin", connection).Location("Content:1"),
+            View("A2AConnection_Buttons_SummaryAdmin", connection).Location("Actions:5"),
+            View("A2AConnection_DefaultMeta_SummaryAdmin", connection).Location("Meta:5")
+        );
+    }
+
+    public override IDisplayResult Edit(A2AConnection connection, BuildEditorContext context)
+    {
+        return Initialize<A2AConnectionFieldsViewModel>("A2AConnectionFields_Edit", model =>
+        {
+            model.DisplayText = connection.DisplayText;
+            model.Endpoint = connection.Endpoint;
+
+            var metadata = connection.As<A2AConnectionMetadata>();
+            model.AuthenticationType = metadata.AuthenticationType;
+
+            if (metadata.AuthenticationType == A2AClientAuthenticationType.Anonymous &&
+                metadata.AdditionalHeaders is { Count: > 0 })
+            {
+                model.AuthenticationType = A2AClientAuthenticationType.CustomHeaders;
+            }
+
+            model.ApiKeyHeaderName = metadata.ApiKeyHeaderName;
+            model.ApiKeyPrefix = metadata.ApiKeyPrefix;
+            model.HasApiKey = !string.IsNullOrEmpty(metadata.ApiKey);
+
+            model.BasicUsername = metadata.BasicUsername;
+            model.HasBasicPassword = !string.IsNullOrEmpty(metadata.BasicPassword);
+
+            model.OAuth2TokenEndpoint = metadata.OAuth2TokenEndpoint;
+            model.OAuth2ClientId = metadata.OAuth2ClientId;
+            model.OAuth2Scopes = metadata.OAuth2Scopes;
+            model.HasOAuth2ClientSecret = !string.IsNullOrEmpty(metadata.OAuth2ClientSecret);
+
+            model.OAuth2KeyId = metadata.OAuth2KeyId;
+            model.HasOAuth2PrivateKey = !string.IsNullOrEmpty(metadata.OAuth2PrivateKey);
+
+            model.HasOAuth2ClientCertificate = !string.IsNullOrEmpty(metadata.OAuth2ClientCertificate);
+            model.HasOAuth2ClientCertificatePassword = !string.IsNullOrEmpty(metadata.OAuth2ClientCertificatePassword);
+
+            if (metadata.AdditionalHeaders is not null)
+            {
+                model.AdditionalHeaders = JsonSerializer.Serialize(metadata.AdditionalHeaders, JSOptions.Indented);
+            }
+
+            model.Schema =
+            """
+            {
+              "$schema": "https://json-schema.org/draft-04/schema#",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+            """;
+        }).Location("Content:1");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(A2AConnection connection, UpdateEditorContext context)
+    {
+        var model = new A2AConnectionFieldsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (string.IsNullOrWhiteSpace(model.DisplayText))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.DisplayText), S["The Title is required."]);
+        }
+
+        if (string.IsNullOrWhiteSpace(model.Endpoint))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.Endpoint), S["The Endpoint is required."]);
+        }
+        else if (!Uri.TryCreate(model.Endpoint, UriKind.Absolute, out var uri) ||
+                 (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.Endpoint), S["The Endpoint must be a valid HTTP or HTTPS URL."]);
+        }
+
+        connection.DisplayText = model.DisplayText;
+        connection.Endpoint = model.Endpoint;
+
+        var metadata = connection.As<A2AConnectionMetadata>();
+        var protector = _dataProtectionProvider.CreateProtector(A2AConstants.DataProtectionPurpose);
+
+        var existingApiKey = metadata.ApiKey;
+        var existingBasicPassword = metadata.BasicPassword;
+        var existingOAuth2ClientSecret = metadata.OAuth2ClientSecret;
+        var existingOAuth2PrivateKey = metadata.OAuth2PrivateKey;
+        var existingOAuth2ClientCertificate = metadata.OAuth2ClientCertificate;
+        var existingOAuth2ClientCertificatePassword = metadata.OAuth2ClientCertificatePassword;
+
+        metadata.AuthenticationType = model.AuthenticationType;
+
+        ClearAuthFields(metadata);
+
+        switch (model.AuthenticationType)
+        {
+            case A2AClientAuthenticationType.ApiKey:
+                ValidateAndPopulateApiKey(context, model, metadata, protector, existingApiKey);
+                break;
+
+            case A2AClientAuthenticationType.Basic:
+                ValidateAndPopulateBasic(context, model, metadata, protector, existingBasicPassword);
+                break;
+
+            case A2AClientAuthenticationType.OAuth2ClientCredentials:
+                ValidateAndPopulateOAuth2(context, model, metadata, protector, existingOAuth2ClientSecret);
+                break;
+
+            case A2AClientAuthenticationType.OAuth2PrivateKeyJwt:
+                ValidateAndPopulateOAuth2PrivateKeyJwt(context, model, metadata, protector, existingOAuth2PrivateKey);
+                break;
+
+            case A2AClientAuthenticationType.OAuth2Mtls:
+                ValidateAndPopulateOAuth2Mtls(context, model, metadata, protector, existingOAuth2ClientCertificate, existingOAuth2ClientCertificatePassword);
+                break;
+
+            case A2AClientAuthenticationType.CustomHeaders:
+                ValidateAndPopulateCustomHeaders(context, model, metadata);
+                break;
+        }
+
+        connection.Put(metadata);
+
+        return Edit(connection, context);
+    }
+
+    private void ValidateAndPopulateApiKey(
+        UpdateEditorContext context,
+        A2AConnectionFieldsViewModel model,
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        string existingEncryptedApiKey)
+    {
+        metadata.ApiKeyHeaderName = model.ApiKeyHeaderName;
+        metadata.ApiKeyPrefix = model.ApiKeyPrefix;
+
+        var hasNewKey = !string.IsNullOrWhiteSpace(model.ApiKey);
+        var hasExistingKey = !string.IsNullOrEmpty(existingEncryptedApiKey);
+
+        if (!hasExistingKey && !hasNewKey)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.ApiKey), S["API Key is required."]);
+        }
+
+        if (hasNewKey)
+        {
+            metadata.ApiKey = protector.Protect(model.ApiKey);
+        }
+        else if (hasExistingKey)
+        {
+            metadata.ApiKey = existingEncryptedApiKey;
+        }
+    }
+
+    private void ValidateAndPopulateBasic(
+        UpdateEditorContext context,
+        A2AConnectionFieldsViewModel model,
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        string existingEncryptedPassword)
+    {
+        if (string.IsNullOrWhiteSpace(model.BasicUsername))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.BasicUsername), S["Username is required."]);
+        }
+
+        metadata.BasicUsername = model.BasicUsername;
+
+        var hasNewPassword = !string.IsNullOrWhiteSpace(model.BasicPassword);
+        var hasExistingPassword = !string.IsNullOrEmpty(existingEncryptedPassword);
+
+        if (!hasExistingPassword && !hasNewPassword)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.BasicPassword), S["Password is required."]);
+        }
+
+        if (hasNewPassword)
+        {
+            metadata.BasicPassword = protector.Protect(model.BasicPassword);
+        }
+        else if (hasExistingPassword)
+        {
+            metadata.BasicPassword = existingEncryptedPassword;
+        }
+    }
+
+    private void ValidateAndPopulateOAuth2(
+        UpdateEditorContext context,
+        A2AConnectionFieldsViewModel model,
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        string existingEncryptedClientSecret)
+    {
+        ValidateOAuth2CommonFields(context, model, metadata);
+
+        var hasNewSecret = !string.IsNullOrWhiteSpace(model.OAuth2ClientSecret);
+        var hasExistingSecret = !string.IsNullOrEmpty(existingEncryptedClientSecret);
+
+        if (!hasExistingSecret && !hasNewSecret)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.OAuth2ClientSecret), S["Client Secret is required."]);
+        }
+
+        if (hasNewSecret)
+        {
+            metadata.OAuth2ClientSecret = protector.Protect(model.OAuth2ClientSecret);
+        }
+        else if (hasExistingSecret)
+        {
+            metadata.OAuth2ClientSecret = existingEncryptedClientSecret;
+        }
+    }
+
+    private void ValidateAndPopulateOAuth2PrivateKeyJwt(
+        UpdateEditorContext context,
+        A2AConnectionFieldsViewModel model,
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        string existingEncryptedPrivateKey)
+    {
+        ValidateOAuth2CommonFields(context, model, metadata);
+
+        metadata.OAuth2KeyId = model.OAuth2KeyId;
+
+        var hasNewKey = !string.IsNullOrWhiteSpace(model.OAuth2PrivateKey);
+        var hasExistingKey = !string.IsNullOrEmpty(existingEncryptedPrivateKey);
+
+        if (!hasExistingKey && !hasNewKey)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.OAuth2PrivateKey), S["Private Key is required."]);
+        }
+
+        if (hasNewKey)
+        {
+            metadata.OAuth2PrivateKey = protector.Protect(model.OAuth2PrivateKey);
+        }
+        else if (hasExistingKey)
+        {
+            metadata.OAuth2PrivateKey = existingEncryptedPrivateKey;
+        }
+    }
+
+    private void ValidateAndPopulateOAuth2Mtls(
+        UpdateEditorContext context,
+        A2AConnectionFieldsViewModel model,
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        string existingEncryptedCertificate,
+        string existingEncryptedCertificatePassword)
+    {
+        ValidateOAuth2CommonFields(context, model, metadata);
+
+        var hasNewCert = !string.IsNullOrWhiteSpace(model.OAuth2ClientCertificate);
+        var hasExistingCert = !string.IsNullOrEmpty(existingEncryptedCertificate);
+
+        if (!hasExistingCert && !hasNewCert)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.OAuth2ClientCertificate), S["Client Certificate is required."]);
+        }
+
+        if (hasNewCert)
+        {
+            metadata.OAuth2ClientCertificate = protector.Protect(model.OAuth2ClientCertificate);
+        }
+        else if (hasExistingCert)
+        {
+            metadata.OAuth2ClientCertificate = existingEncryptedCertificate;
+        }
+
+        var hasNewPassword = !string.IsNullOrWhiteSpace(model.OAuth2ClientCertificatePassword);
+
+        if (hasNewPassword)
+        {
+            metadata.OAuth2ClientCertificatePassword = protector.Protect(model.OAuth2ClientCertificatePassword);
+        }
+        else if (!string.IsNullOrEmpty(existingEncryptedCertificatePassword))
+        {
+            metadata.OAuth2ClientCertificatePassword = existingEncryptedCertificatePassword;
+        }
+    }
+
+    private void ValidateAndPopulateCustomHeaders(
+        UpdateEditorContext context,
+        A2AConnectionFieldsViewModel model,
+        A2AConnectionMetadata metadata)
+    {
+        if (!string.IsNullOrWhiteSpace(model.AdditionalHeaders))
+        {
+            try
+            {
+                metadata.AdditionalHeaders = JsonSerializer.Deserialize<Dictionary<string, string>>(model.AdditionalHeaders);
+            }
+            catch
+            {
+                context.Updater.ModelState.AddModelError(Prefix, nameof(model.AdditionalHeaders), S["Invalid additional headers format."]);
+            }
+        }
+    }
+
+    private void ValidateOAuth2CommonFields(
+        UpdateEditorContext context,
+        A2AConnectionFieldsViewModel model,
+        A2AConnectionMetadata metadata)
+    {
+        if (string.IsNullOrEmpty(model.OAuth2TokenEndpoint))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.OAuth2TokenEndpoint), S["Token Endpoint is required."]);
+        }
+        else if (!Uri.TryCreate(model.OAuth2TokenEndpoint, UriKind.Absolute, out _))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.OAuth2TokenEndpoint), S["Invalid Token Endpoint URL."]);
+        }
+
+        if (string.IsNullOrWhiteSpace(model.OAuth2ClientId))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.OAuth2ClientId), S["Client ID is required."]);
+        }
+
+        metadata.OAuth2TokenEndpoint = model.OAuth2TokenEndpoint;
+        metadata.OAuth2ClientId = model.OAuth2ClientId;
+        metadata.OAuth2Scopes = model.OAuth2Scopes;
+    }
+
+    private static void ClearAuthFields(A2AConnectionMetadata metadata)
+    {
+        metadata.ApiKeyHeaderName = null;
+        metadata.ApiKeyPrefix = null;
+        metadata.ApiKey = null;
+        metadata.BasicUsername = null;
+        metadata.BasicPassword = null;
+        metadata.OAuth2TokenEndpoint = null;
+        metadata.OAuth2ClientId = null;
+        metadata.OAuth2ClientSecret = null;
+        metadata.OAuth2Scopes = null;
+        metadata.OAuth2PrivateKey = null;
+        metadata.OAuth2KeyId = null;
+        metadata.OAuth2ClientCertificate = null;
+        metadata.OAuth2ClientCertificatePassword = null;
+        metadata.AdditionalHeaders = null;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Drivers/AIProfileA2AConnectionsDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Drivers/AIProfileA2AConnectionsDisplayDriver.cs
@@ -1,0 +1,84 @@
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.A2A.ViewModels;
+using CrestApps.OrchardCore.AI.Core.Models;
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Entities;
+
+namespace CrestApps.OrchardCore.AI.A2A.Drivers;
+
+internal sealed class AIProfileA2AConnectionsDisplayDriver : DisplayDriver<AIProfile>
+{
+    private readonly ICatalog<A2AConnection> _store;
+
+    internal readonly IStringLocalizer S;
+
+    public AIProfileA2AConnectionsDisplayDriver(
+        ICatalog<A2AConnection> store,
+        IStringLocalizer<AIProfileA2AConnectionsDisplayDriver> stringLocalizer)
+    {
+        _store = store;
+        S = stringLocalizer;
+    }
+
+    public override async Task<IDisplayResult> EditAsync(AIProfile profile, BuildEditorContext context)
+    {
+        var connections = await _store.GetAllAsync();
+
+        if (connections.Count == 0)
+        {
+            return null;
+        }
+
+        return Initialize<EditProfileA2AConnectionsViewModel>("EditProfileA2AConnection_Edit", model =>
+        {
+            var a2aMetadata = profile.As<AIProfileA2AMetadata>();
+
+            model.Connections = connections
+            .Select(entry => new ToolEntry
+            {
+                ItemId = entry.ItemId,
+                DisplayText = entry.DisplayText,
+                IsSelected = a2aMetadata.ConnectionIds?.Contains(entry.ItemId) ?? false,
+            }).OrderBy(entry => entry.DisplayText)
+            .ToArray();
+
+        }).Location("Content:4#Capabilities;8");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(AIProfile profile, UpdateEditorContext context)
+    {
+        var connections = await _store.GetAllAsync();
+
+        if (connections.Count == 0)
+        {
+            return null;
+        }
+
+        var model = new EditProfileA2AConnectionsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        var ids = model.Connections?.Where(x => x.IsSelected).Select(x => x.ItemId).ToArray();
+
+        var metadata = new AIProfileA2AMetadata();
+
+        if (ids is null || ids.Length == 0)
+        {
+            metadata.ConnectionIds = [];
+        }
+        else
+        {
+            metadata.ConnectionIds = connections.Select(x => x.ItemId)
+                .Intersect(ids)
+                .ToArray();
+        }
+
+        profile.Put(metadata);
+
+        return Edit(profile, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Drivers/AIProfileTemplateA2AConnectionsDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Drivers/AIProfileTemplateA2AConnectionsDisplayDriver.cs
@@ -1,0 +1,91 @@
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.A2A.ViewModels;
+using CrestApps.OrchardCore.AI.Core;
+using CrestApps.OrchardCore.AI.Core.Models;
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Entities;
+
+namespace CrestApps.OrchardCore.AI.A2A.Drivers;
+
+internal sealed class AIProfileTemplateA2AConnectionsDisplayDriver : DisplayDriver<AIProfileTemplate>
+{
+    private readonly ICatalog<A2AConnection> _store;
+
+    internal readonly IStringLocalizer S;
+
+    public AIProfileTemplateA2AConnectionsDisplayDriver(
+        ICatalog<A2AConnection> store,
+        IStringLocalizer<AIProfileTemplateA2AConnectionsDisplayDriver> stringLocalizer)
+    {
+        _store = store;
+        S = stringLocalizer;
+    }
+
+    public override async Task<IDisplayResult> EditAsync(AIProfileTemplate template, BuildEditorContext context)
+    {
+        var connections = await _store.GetAllAsync();
+
+        if (connections.Count == 0)
+        {
+            return null;
+        }
+
+        return Initialize<EditProfileA2AConnectionsViewModel>("EditProfileA2AConnection_Edit", model =>
+        {
+            var a2aMetadata = template.As<AIProfileA2AMetadata>();
+
+            model.Connections = connections
+            .Select(entry => new ToolEntry
+            {
+                ItemId = entry.ItemId,
+                DisplayText = entry.DisplayText,
+                IsSelected = a2aMetadata.ConnectionIds?.Contains(entry.ItemId) ?? false,
+            }).OrderBy(entry => entry.DisplayText)
+            .ToArray();
+
+        }).Location("Content:4#Capabilities;8")
+        .RenderWhen(() => Task.FromResult(template.Source == AITemplateSources.Profile));
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(AIProfileTemplate template, UpdateEditorContext context)
+    {
+        if (template.Source != AITemplateSources.Profile)
+        {
+            return null;
+        }
+
+        var connections = await _store.GetAllAsync();
+
+        if (connections.Count == 0)
+        {
+            return null;
+        }
+
+        var model = new EditProfileA2AConnectionsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        var ids = model.Connections?.Where(x => x.IsSelected).Select(x => x.ItemId).ToArray();
+
+        var metadata = new AIProfileA2AMetadata();
+
+        if (ids is null || ids.Length == 0)
+        {
+            metadata.ConnectionIds = [];
+        }
+        else
+        {
+            metadata.ConnectionIds = connections.Select(x => x.ItemId)
+                .Intersect(ids)
+                .ToArray();
+        }
+
+        template.Put(metadata);
+
+        return Edit(template, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Drivers/ChatInteractionA2AConnectionsDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Drivers/ChatInteractionA2AConnectionsDisplayDriver.cs
@@ -1,0 +1,77 @@
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.A2A.ViewModels;
+using CrestApps.OrchardCore.AI.Core.Models;
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.AI.A2A.Drivers;
+
+internal sealed class ChatInteractionA2AConnectionsDisplayDriver : DisplayDriver<ChatInteraction>
+{
+    private readonly ICatalog<A2AConnection> _store;
+
+    internal readonly IStringLocalizer S;
+
+    public ChatInteractionA2AConnectionsDisplayDriver(
+        ICatalog<A2AConnection> store,
+        IStringLocalizer<ChatInteractionA2AConnectionsDisplayDriver> stringLocalizer)
+    {
+        _store = store;
+        S = stringLocalizer;
+    }
+
+    public override async Task<IDisplayResult> EditAsync(ChatInteraction interaction, BuildEditorContext context)
+    {
+        var connections = await _store.GetAllAsync();
+
+        if (connections.Count == 0)
+        {
+            return null;
+        }
+
+        return Initialize<ChatInteractionA2AConnectionsViewModel>("ChatInteractionA2AConnections_Edit", model =>
+        {
+            model.Connections = connections
+            .Select(entry => new ToolEntry
+            {
+                ItemId = entry.ItemId,
+                DisplayText = entry.DisplayText,
+                IsSelected = interaction.A2AConnectionIds?.Contains(entry.ItemId) ?? false,
+            }).OrderBy(entry => entry.DisplayText)
+            .ToArray();
+
+        }).Location("Parameters:4#Capabilities;5");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(ChatInteraction interaction, UpdateEditorContext context)
+    {
+        var connections = await _store.GetAllAsync();
+
+        if (connections.Count == 0)
+        {
+            return null;
+        }
+
+        var model = new ChatInteractionA2AConnectionsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        var ids = model.Connections?.Where(x => x.IsSelected).Select(x => x.ItemId).ToArray();
+
+        if (ids is null || ids.Length == 0)
+        {
+            interaction.A2AConnectionIds = [];
+        }
+        else
+        {
+            interaction.A2AConnectionIds = connections.Select(x => x.ItemId)
+                .Intersect(ids)
+                .ToList();
+        }
+
+        return Edit(interaction, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Functions/FindAgentForTaskFunction.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Functions/FindAgentForTaskFunction.cs
@@ -1,0 +1,220 @@
+using System.Text.Json;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.A2A.Services;
+using CrestApps.OrchardCore.AI.Core.Extensions;
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.OrchardCore.AI.A2A.Functions;
+
+/// <summary>
+/// An AI system function that uses keyword and semantic matching to find the best agents
+/// capable of handling a given task description. Searches both local agent profiles and
+/// remote A2A agents.
+/// </summary>
+internal sealed class FindAgentForTaskFunction : AIFunction
+{
+    public const string TheName = "findAgentForTask";
+
+    private static readonly JsonElement _jsonSchema = JsonSerializer.Deserialize<JsonElement>(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "taskDescription": {
+              "type": "string",
+              "description": "A description of the task to find an agent for."
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of agents to return. Defaults to 5."
+            }
+          },
+          "required": ["taskDescription"],
+          "additionalProperties": false
+        }
+        """);
+
+    public override string Name => TheName;
+
+    public override string Description
+        => "Finds the most relevant AI agents for a specific task using keyword and semantic matching. Searches both local agents and remote A2A agents.";
+
+    public override JsonElement JsonSchema => _jsonSchema;
+
+    public override IReadOnlyDictionary<string, object> AdditionalProperties { get; } =
+        new Dictionary<string, object>()
+        {
+            ["Strict"] = false,
+        };
+
+    protected override async ValueTask<object> InvokeCoreAsync(
+        AIFunctionArguments arguments,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentNullException.ThrowIfNull(arguments.Services);
+
+        var logger = arguments.Services.GetRequiredService<ILogger<FindAgentForTaskFunction>>();
+
+        if (!arguments.TryGetFirstString("taskDescription", out var taskDescription)
+            || string.IsNullOrWhiteSpace(taskDescription))
+        {
+            return "A task description is required to find matching agents.";
+        }
+
+        var maxResults = 5;
+
+        if (arguments.TryGetValue("maxResults", out var maxResultsObj))
+        {
+            if (maxResultsObj is int intVal)
+            {
+                maxResults = intVal;
+            }
+            else if (maxResultsObj is JsonElement element && element.TryGetInt32(out var parsed))
+            {
+                maxResults = parsed;
+            }
+        }
+
+        var tokenizer = arguments.Services.GetRequiredService<ITextTokenizer>();
+        var queryTokens = tokenizer.Tokenize(taskDescription);
+
+        if (queryTokens.Count == 0)
+        {
+            return "Unable to analyze the task description. Please provide more details.";
+        }
+
+        var scoredAgents = new List<(object Agent, double Score)>();
+
+        try
+        {
+            var profileManager = arguments.Services.GetRequiredService<IAIProfileManager>();
+            var localProfiles = await profileManager.GetAsync(AIProfileType.Agent);
+
+            if (localProfiles is not null)
+            {
+                foreach (var profile in localProfiles)
+                {
+                    var text = (profile.DisplayText ?? profile.Name) + " " + profile.Description;
+                    var score = ScoreRelevance(queryTokens, tokenizer.Tokenize(text));
+
+                    scoredAgents.Add((new
+                    {
+                        name = profile.DisplayText ?? profile.Name,
+                        id = profile.Name,
+                        description = profile.Description,
+                        source = "local",
+                        relevanceScore = Math.Round(score, 3),
+                    }, score));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to search local agent profiles.");
+        }
+
+        try
+        {
+            var connectionStore = arguments.Services.GetRequiredService<ICatalog<A2AConnection>>();
+            var agentCardCache = arguments.Services.GetRequiredService<IA2AAgentCardCacheService>();
+            var connections = await connectionStore.GetAllAsync();
+
+            foreach (var connection in connections)
+            {
+                if (string.IsNullOrWhiteSpace(connection.Endpoint))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var agentCard = await agentCardCache.GetAgentCardAsync(
+                        connection.ItemId, connection, cancellationToken);
+
+                    if (agentCard?.Skills is null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var skill in agentCard.Skills)
+                    {
+                        var text = (skill.Name ?? skill.Id) + " " + (skill.Description ?? agentCard.Description);
+
+                        if (skill.Tags is not null)
+                        {
+                            text += " " + string.Join(" ", skill.Tags);
+                        }
+
+                        var score = ScoreRelevance(queryTokens, tokenizer.Tokenize(text));
+
+                        scoredAgents.Add((new
+                        {
+                            name = skill.Name ?? skill.Id,
+                            id = skill.Id,
+                            description = skill.Description ?? agentCard.Description,
+                            source = "remote",
+                            host = connection.DisplayText,
+                            tags = skill.Tags,
+                            relevanceScore = Math.Round(score, 3),
+                        }, score));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Failed to fetch agent card from A2A connection '{ConnectionId}'.",
+                        connection.ItemId);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to search remote A2A agents.");
+        }
+
+        var results = scoredAgents
+            .Where(s => s.Score > 0)
+            .OrderByDescending(s => s.Score)
+            .Take(maxResults)
+            .Select(s => s.Agent)
+            .ToList();
+
+        return results.Count > 0
+            ? JsonSerializer.Serialize(results)
+            : "No agents were found matching the given task description.";
+    }
+
+    private static double ScoreRelevance(HashSet<string> queryTokens, HashSet<string> targetTokens)
+    {
+        if (queryTokens.Count == 0 || targetTokens.Count == 0)
+        {
+            return 0;
+        }
+
+        var matchCount = 0;
+
+        foreach (var token in queryTokens)
+        {
+            if (targetTokens.Contains(token))
+            {
+                matchCount++;
+            }
+        }
+
+        if (matchCount == 0)
+        {
+            return 0;
+        }
+
+        var forwardScore = (double)matchCount / queryTokens.Count;
+        var reverseScore = (double)matchCount / targetTokens.Count;
+
+        return Math.Max(forwardScore, reverseScore);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Functions/FindToolsForTaskFunction.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Functions/FindToolsForTaskFunction.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using CrestApps.OrchardCore.AI.Core.Extensions;
+using CrestApps.OrchardCore.AI.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.OrchardCore.AI.A2A.Functions;
+
+/// <summary>
+/// An AI system function that uses keyword and semantic search to find the most relevant
+/// AI tools for a given task. Delegates to <see cref="IToolRegistry.SearchAsync"/> for
+/// consistent scoring with the orchestrator's tool scoping logic.
+/// </summary>
+internal sealed class FindToolsForTaskFunction : AIFunction
+{
+    public const string TheName = "findToolsForTask";
+
+    private static readonly JsonElement _jsonSchema = JsonSerializer.Deserialize<JsonElement>(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "taskDescription": {
+              "type": "string",
+              "description": "A description of the task to find relevant tools for."
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of tools to return. Defaults to 10."
+            }
+          },
+          "required": ["taskDescription"],
+          "additionalProperties": false
+        }
+        """);
+
+    public override string Name => TheName;
+
+    public override string Description
+        => "Finds the most relevant AI tools for a specific task using keyword and semantic matching. Returns tools ranked by relevance.";
+
+    public override JsonElement JsonSchema => _jsonSchema;
+
+    public override IReadOnlyDictionary<string, object> AdditionalProperties { get; } =
+        new Dictionary<string, object>()
+        {
+            ["Strict"] = false,
+        };
+
+    protected override async ValueTask<object> InvokeCoreAsync(
+        AIFunctionArguments arguments,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentNullException.ThrowIfNull(arguments.Services);
+
+        var logger = arguments.Services.GetRequiredService<ILogger<FindToolsForTaskFunction>>();
+
+        if (!arguments.TryGetFirstString("taskDescription", out var taskDescription)
+            || string.IsNullOrWhiteSpace(taskDescription))
+        {
+            return "A task description is required to find matching tools.";
+        }
+
+        var maxResults = 10;
+
+        if (arguments.TryGetValue("maxResults", out var maxResultsObj))
+        {
+            if (maxResultsObj is int intVal)
+            {
+                maxResults = intVal;
+            }
+            else if (maxResultsObj is JsonElement element && element.TryGetInt32(out var parsed))
+            {
+                maxResults = parsed;
+            }
+        }
+
+        try
+        {
+            var toolRegistry = arguments.Services.GetRequiredService<IToolRegistry>();
+
+            // Build a minimal context that includes all connections to search across all available tools.
+            var context = new AICompletionContext();
+
+            var results = await toolRegistry.SearchAsync(
+                taskDescription,
+                maxResults,
+                context,
+                cancellationToken);
+
+            if (results is null || results.Count == 0)
+            {
+                return "No tools were found matching the given task description.";
+            }
+
+            var tools = results.Select(r => new
+            {
+                name = r.Name,
+                description = r.Description,
+                source = r.Source.ToString(),
+            }).ToList();
+
+            return JsonSerializer.Serialize(tools);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to search for tools.");
+
+            return "An error occurred while searching for tools.";
+        }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Functions/ListAvailableAgentsFunction.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Functions/ListAvailableAgentsFunction.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.A2A.Services;
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.OrchardCore.AI.A2A.Functions;
+
+/// <summary>
+/// An AI system function that lists all available agents, including both local AI Agent profiles
+/// and remote agents from connected A2A hosts.
+/// </summary>
+internal sealed class ListAvailableAgentsFunction : AIFunction
+{
+    public const string TheName = "listAvailableAgents";
+
+    private static readonly JsonElement _jsonSchema = JsonSerializer.Deserialize<JsonElement>(
+        """
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+        """);
+
+    public override string Name => TheName;
+
+    public override string Description
+        => "Lists all available AI agents, including local agents and remote agents from connected A2A hosts. Returns their names, descriptions, and capabilities.";
+
+    public override JsonElement JsonSchema => _jsonSchema;
+
+    public override IReadOnlyDictionary<string, object> AdditionalProperties { get; } =
+        new Dictionary<string, object>()
+        {
+            ["Strict"] = false,
+        };
+
+    protected override async ValueTask<object> InvokeCoreAsync(
+        AIFunctionArguments arguments,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentNullException.ThrowIfNull(arguments.Services);
+
+        var logger = arguments.Services.GetRequiredService<ILogger<ListAvailableAgentsFunction>>();
+
+        var agents = new List<object>();
+
+        try
+        {
+            var profileManager = arguments.Services.GetRequiredService<IAIProfileManager>();
+            var localProfiles = await profileManager.GetAsync(AIProfileType.Agent);
+
+            if (localProfiles is not null)
+            {
+                foreach (var profile in localProfiles)
+                {
+                    agents.Add(new
+                    {
+                        name = profile.DisplayText ?? profile.Name,
+                        id = profile.Name,
+                        description = profile.Description,
+                        source = "local",
+                    });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to list local agent profiles.");
+        }
+
+        try
+        {
+            var connectionStore = arguments.Services.GetRequiredService<ICatalog<A2AConnection>>();
+            var agentCardCache = arguments.Services.GetRequiredService<IA2AAgentCardCacheService>();
+            var connections = await connectionStore.GetAllAsync();
+
+            foreach (var connection in connections)
+            {
+                if (string.IsNullOrWhiteSpace(connection.Endpoint))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var agentCard = await agentCardCache.GetAgentCardAsync(
+                        connection.ItemId, connection, cancellationToken);
+
+                    if (agentCard?.Skills is null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var skill in agentCard.Skills)
+                    {
+                        agents.Add(new
+                        {
+                            name = skill.Name ?? skill.Id,
+                            id = skill.Id,
+                            description = skill.Description ?? agentCard.Description,
+                            source = "remote",
+                            host = connection.DisplayText,
+                            tags = skill.Tags,
+                        });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Failed to fetch agent card from A2A connection '{ConnectionId}'.",
+                        connection.ItemId);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to list remote A2A agents.");
+        }
+
+        return agents.Count > 0
+            ? JsonSerializer.Serialize(agents)
+            : "No agents are currently available.";
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AAICompletionContextBuilderHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AAICompletionContextBuilderHandler.cs
@@ -1,0 +1,22 @@
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.Models;
+using OrchardCore.Entities;
+
+namespace CrestApps.OrchardCore.AI.A2A.Handlers;
+
+internal sealed class A2AAICompletionContextBuilderHandler : IAICompletionContextBuilderHandler
+{
+    public Task BuildingAsync(AICompletionContextBuildingContext context)
+    {
+        if (context.Resource is AIProfile profile &&
+            profile.TryGet<AIProfileA2AMetadata>(out var a2aMetadata))
+        {
+            context.Context.A2AConnectionIds = a2aMetadata.ConnectionIds;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task BuiltAsync(AICompletionContextBuiltContext context)
+        => Task.CompletedTask;
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AApiKeyAuthenticationHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AApiKeyAuthenticationHandler.cs
@@ -1,0 +1,107 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.OrchardCore.AI.A2A.Handlers;
+
+internal sealed class A2AApiKeyAuthenticationHandler : AuthenticationHandler<A2AApiKeyAuthenticationOptions>
+{
+    private readonly IOptionsMonitor<A2AHostOptions> _hostOptionsMonitor;
+
+    public A2AApiKeyAuthenticationHandler(
+        IOptionsMonitor<A2AApiKeyAuthenticationOptions> options,
+        IOptionsMonitor<A2AHostOptions> hostOptionsMonitor,
+        ILoggerFactory loggerFactory,
+        UrlEncoder encoder)
+        : base(options, loggerFactory, encoder)
+    {
+        _hostOptionsMonitor = hostOptionsMonitor;
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var hostOptions = _hostOptionsMonitor.CurrentValue;
+
+        if (hostOptions.AuthenticationType != A2AHostAuthenticationType.ApiKey)
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        if (string.IsNullOrEmpty(hostOptions.ApiKey))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("API key is not configured on the server."));
+        }
+
+        if (!Request.Headers.TryGetValue("Authorization", out var authHeader))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var authHeaderValue = authHeader.ToString();
+
+        if (string.IsNullOrEmpty(authHeaderValue))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        string apiKey;
+
+        if (authHeaderValue.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            apiKey = authHeaderValue["Bearer ".Length..].Trim();
+        }
+        else if (authHeaderValue.StartsWith("ApiKey ", StringComparison.OrdinalIgnoreCase))
+        {
+            apiKey = authHeaderValue["ApiKey ".Length..].Trim();
+        }
+        else
+        {
+            apiKey = authHeaderValue.Trim();
+        }
+
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        if (!FixedTimeEquals(apiKey, hostOptions.ApiKey))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API key."));
+        }
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "a2a-api-key-user"),
+            new Claim(ClaimTypes.Name, "A2A API Key User"),
+            new Claim(ClaimTypes.AuthenticationMethod, A2AApiKeyAuthenticationDefaults.AuthenticationScheme),
+        };
+
+        var identity = new ClaimsIdentity(claims, A2AApiKeyAuthenticationDefaults.AuthenticationScheme);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, A2AApiKeyAuthenticationDefaults.AuthenticationScheme);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+
+    private static bool FixedTimeEquals(string a, string b)
+    {
+        var aBytes = Encoding.UTF8.GetBytes(a);
+        var bBytes = Encoding.UTF8.GetBytes(b);
+
+        return CryptographicOperations.FixedTimeEquals(aBytes, bBytes);
+    }
+}
+
+internal sealed class A2AApiKeyAuthenticationOptions : AuthenticationSchemeOptions
+{
+}
+
+internal static class A2AApiKeyAuthenticationDefaults
+{
+    public const string AuthenticationScheme = "A2AApiKey";
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AConnectionHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AConnectionHandler.cs
@@ -1,0 +1,113 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using System.Text.Json.Nodes;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.A2A.Services;
+using CrestApps.OrchardCore.Core.Handlers;
+using CrestApps.OrchardCore.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.AI.A2A.Handlers;
+
+internal sealed class A2AConnectionHandler : CatalogEntryHandlerBase<A2AConnection>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IA2AAgentCardCacheService _cacheService;
+    private readonly IClock _clock;
+
+    internal readonly IStringLocalizer S;
+
+    public A2AConnectionHandler(
+        IHttpContextAccessor httpContextAccessor,
+        IA2AAgentCardCacheService cacheService,
+        IClock clock,
+        IStringLocalizer<A2AConnectionHandler> stringLocalizer)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _cacheService = cacheService;
+        _clock = clock;
+        S = stringLocalizer;
+    }
+
+    public override Task InitializingAsync(InitializingContext<A2AConnection> context)
+        => PopulateAsync(context.Model, context.Data, true);
+
+    public override Task UpdatingAsync(UpdatingContext<A2AConnection> context)
+        => PopulateAsync(context.Model, context.Data, false);
+
+    public override Task UpdatedAsync(UpdatedContext<A2AConnection> context)
+    {
+        _cacheService.Invalidate(context.Model.ItemId);
+
+        return Task.CompletedTask;
+    }
+
+    public override Task DeletedAsync(DeletedContext<A2AConnection> context)
+    {
+        _cacheService.Invalidate(context.Model.ItemId);
+
+        return Task.CompletedTask;
+    }
+
+    public override Task ValidatingAsync(ValidatingContext<A2AConnection> context)
+    {
+        if (string.IsNullOrEmpty(context.Model.DisplayText))
+        {
+            context.Result.Fail(new ValidationResult(S["The Title is required."], [nameof(A2AConnection.DisplayText)]));
+        }
+
+        if (string.IsNullOrEmpty(context.Model.Endpoint))
+        {
+            context.Result.Fail(new ValidationResult(S["The Endpoint is required."], [nameof(A2AConnection.Endpoint)]));
+        }
+        else if (!Uri.TryCreate(context.Model.Endpoint, UriKind.Absolute, out var uri) ||
+                 (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            context.Result.Fail(new ValidationResult(S["The Endpoint must be a valid HTTP or HTTPS URL."], [nameof(A2AConnection.Endpoint)]));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task PopulateAsync(A2AConnection connection, JsonNode data, bool isNew)
+    {
+        if (isNew)
+        {
+            connection.CreatedUtc = _clock.UtcNow;
+
+            var user = _httpContextAccessor.HttpContext?.User;
+
+            if (user is not null)
+            {
+                connection.Author = user.Identity.Name;
+                connection.OwnerId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            }
+        }
+
+        var displayText = data[nameof(A2AConnection.DisplayText)]?.ToString();
+
+        if (!string.IsNullOrWhiteSpace(displayText))
+        {
+            connection.DisplayText = displayText;
+        }
+
+        var endpoint = data[nameof(A2AConnection.Endpoint)]?.ToString();
+
+        if (!string.IsNullOrWhiteSpace(endpoint))
+        {
+            connection.Endpoint = endpoint;
+        }
+
+        var properties = data[nameof(A2AConnection.Properties)]?.AsObject();
+
+        if (properties is not null)
+        {
+            connection.Properties ??= [];
+            connection.Properties.Merge(properties);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AConnectionSettingsHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AConnectionSettingsHandler.cs
@@ -1,0 +1,81 @@
+using System.Text.Json.Nodes;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.Core.Handlers;
+using CrestApps.OrchardCore.Models;
+using Microsoft.AspNetCore.DataProtection;
+using OrchardCore.Entities;
+
+namespace CrestApps.OrchardCore.AI.A2A.Handlers;
+
+internal sealed class A2AConnectionSettingsHandler : CatalogEntryHandlerBase<A2AConnection>
+{
+    private readonly IDataProtectionProvider _dataProtectionProvider;
+
+    public A2AConnectionSettingsHandler(IDataProtectionProvider dataProtectionProvider)
+    {
+        _dataProtectionProvider = dataProtectionProvider;
+    }
+
+    public override Task InitializingAsync(InitializingContext<A2AConnection> context)
+        => ProtectSensitiveFieldsAsync(context.Model, context.Data);
+
+    public override Task UpdatingAsync(UpdatingContext<A2AConnection> context)
+        => ProtectSensitiveFieldsAsync(context.Model, context.Data);
+
+    private Task ProtectSensitiveFieldsAsync(A2AConnection connection, JsonNode data)
+    {
+        var metadataNode = data[nameof(A2AConnection.Properties)]?[nameof(A2AConnectionMetadata)]?.AsObject();
+
+        if (metadataNode == null || metadataNode.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        var protector = _dataProtectionProvider.CreateProtector(A2AConstants.DataProtectionPurpose);
+        var metadata = connection.As<A2AConnectionMetadata>();
+
+        ProtectField(protector, metadataNode, nameof(A2AConnectionMetadata.ApiKey), val =>
+        {
+            metadata.ApiKey = val;
+        });
+
+        ProtectField(protector, metadataNode, nameof(A2AConnectionMetadata.BasicPassword), val =>
+        {
+            metadata.BasicPassword = val;
+        });
+
+        ProtectField(protector, metadataNode, nameof(A2AConnectionMetadata.OAuth2ClientSecret), val =>
+        {
+            metadata.OAuth2ClientSecret = val;
+        });
+
+        ProtectField(protector, metadataNode, nameof(A2AConnectionMetadata.OAuth2PrivateKey), val =>
+        {
+            metadata.OAuth2PrivateKey = val;
+        });
+
+        ProtectField(protector, metadataNode, nameof(A2AConnectionMetadata.OAuth2ClientCertificate), val =>
+        {
+            metadata.OAuth2ClientCertificate = val;
+        });
+
+        ProtectField(protector, metadataNode, nameof(A2AConnectionMetadata.OAuth2ClientCertificatePassword), val =>
+        {
+            metadata.OAuth2ClientCertificatePassword = val;
+        });
+
+        connection.Put(metadata);
+
+        return Task.CompletedTask;
+    }
+
+    private static void ProtectField(IDataProtector protector, JsonObject node, string fieldName, Action<string> setter)
+    {
+        var value = node[fieldName]?.GetValue<string>();
+
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            setter(protector.Protect(value));
+        }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AHostAuthorizationHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Handlers/A2AHostAuthorizationHandler.cs
@@ -1,0 +1,65 @@
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.A2A.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.OrchardCore.AI.A2A.Handlers;
+
+internal sealed class A2AHostAuthorizationHandler : AuthorizationHandler<A2AHostAuthorizationRequirement>
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    private IAuthorizationService _authorizationService;
+
+    public A2AHostAuthorizationHandler(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        A2AHostAuthorizationRequirement requirement)
+    {
+        var options = _serviceProvider.GetRequiredService<IOptions<A2AHostOptions>>().Value;
+
+        switch (options.AuthenticationType)
+        {
+            case A2AHostAuthenticationType.None:
+                context.Succeed(requirement);
+                break;
+
+            case A2AHostAuthenticationType.ApiKey:
+                if (context.User.Identity?.IsAuthenticated == true &&
+                    context.User.Identity.AuthenticationType == A2AApiKeyAuthenticationDefaults.AuthenticationScheme)
+                {
+                    context.Succeed(requirement);
+                }
+                break;
+
+            case A2AHostAuthenticationType.OpenId:
+            default:
+                if (context.User.Identity?.IsAuthenticated == true)
+                {
+                    if (!options.RequireAccessPermission)
+                    {
+                        context.Succeed(requirement);
+                    }
+                    else
+                    {
+                        _authorizationService ??= _serviceProvider.GetRequiredService<IAuthorizationService>();
+
+                        if (await _authorizationService.AuthorizeAsync(context.User, A2AHostPermissionsProvider.AccessA2AHost))
+                        {
+                            context.Succeed(requirement);
+                        }
+                    }
+                }
+                break;
+        }
+    }
+}
+
+internal sealed class A2AHostAuthorizationRequirement : IAuthorizationRequirement
+{
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Manifest.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Manifest.cs
@@ -1,0 +1,34 @@
+using CrestApps.OrchardCore;
+using CrestApps.OrchardCore.AI.A2A;
+using CrestApps.OrchardCore.AI.Core;
+using OrchardCore.Modules.Manifest;
+
+[assembly: Module(
+    Name = "Agent-to-Agent (A2A) Protocol",
+    Author = CrestAppsManifestConstants.Author,
+    Website = CrestAppsManifestConstants.Website,
+    Version = CrestAppsManifestConstants.Version
+)]
+
+[assembly: Feature(
+    Id = A2AConstants.Feature.Area,
+    Name = "Agent-to-Agent (A2A) Client",
+    Description = "Provides a user interface for connecting to remote Agent-to-Agent (A2A) hosts, enabling AI profiles to leverage external agents for multi-agent orchestration.",
+    Category = "Artificial Intelligence",
+    Dependencies =
+    [
+        AIConstants.Feature.Area,
+        "CrestApps.OrchardCore.Resources",
+    ]
+)]
+
+[assembly: Feature(
+    Id = A2AConstants.Feature.Host,
+    Name = "Agent-to-Agent (A2A) Host",
+    Description = "Exposes all AI Agent profiles through the A2A protocol, enabling external agents and clients to discover and communicate with locally hosted agents.",
+    Category = "Artificial Intelligence",
+    Dependencies =
+    [
+        AIConstants.Feature.Area,
+    ]
+)]

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AClientAuthenticationType.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AClientAuthenticationType.cs
@@ -1,0 +1,12 @@
+namespace CrestApps.OrchardCore.AI.A2A.Models;
+
+public enum A2AClientAuthenticationType
+{
+    Anonymous,
+    ApiKey,
+    Basic,
+    OAuth2ClientCredentials,
+    OAuth2PrivateKeyJwt,
+    OAuth2Mtls,
+    CustomHeaders,
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AConnection.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AConnection.cs
@@ -1,0 +1,31 @@
+using CrestApps.OrchardCore.Models;
+using CrestApps.OrchardCore.Services;
+
+namespace CrestApps.OrchardCore.AI.A2A.Models;
+
+public sealed class A2AConnection : CatalogItem, IDisplayTextAwareModel, ICloneable<A2AConnection>
+{
+    public string DisplayText { get; set; }
+
+    public string Endpoint { get; set; }
+
+    public DateTime CreatedUtc { get; set; }
+
+    public string Author { get; set; }
+
+    public string OwnerId { get; set; }
+
+    public A2AConnection Clone()
+    {
+        return new A2AConnection()
+        {
+            ItemId = ItemId,
+            DisplayText = DisplayText,
+            Endpoint = Endpoint,
+            CreatedUtc = CreatedUtc,
+            Author = Author,
+            OwnerId = OwnerId,
+            Properties = Properties,
+        };
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AConnectionMetadata.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AConnectionMetadata.cs
@@ -1,0 +1,40 @@
+namespace CrestApps.OrchardCore.AI.A2A.Models;
+
+public sealed class A2AConnectionMetadata
+{
+    public A2AClientAuthenticationType AuthenticationType { get; set; }
+
+    // API Key authentication.
+    public string ApiKeyHeaderName { get; set; }
+
+    public string ApiKeyPrefix { get; set; }
+
+    public string ApiKey { get; set; }
+
+    // Basic authentication.
+    public string BasicUsername { get; set; }
+
+    public string BasicPassword { get; set; }
+
+    // OAuth 2.0 Client Credentials.
+    public string OAuth2TokenEndpoint { get; set; }
+
+    public string OAuth2ClientId { get; set; }
+
+    public string OAuth2ClientSecret { get; set; }
+
+    public string OAuth2Scopes { get; set; }
+
+    // OAuth 2.0 Private Key JWT.
+    public string OAuth2PrivateKey { get; set; }
+
+    public string OAuth2KeyId { get; set; }
+
+    // OAuth 2.0 Mutual TLS (mTLS).
+    public string OAuth2ClientCertificate { get; set; }
+
+    public string OAuth2ClientCertificatePassword { get; set; }
+
+    // Custom headers (advanced).
+    public Dictionary<string, string> AdditionalHeaders { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AHostAuthenticationType.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AHostAuthenticationType.cs
@@ -1,0 +1,26 @@
+namespace CrestApps.OrchardCore.AI.A2A.Models;
+
+/// <summary>
+/// Defines the authentication types supported by the A2A host.
+/// </summary>
+public enum A2AHostAuthenticationType
+{
+    /// <summary>
+    /// Uses OpenID Connect authentication via the "Api" scheme.
+    /// This is the default and most secure option for production environments.
+    /// </summary>
+    OpenId,
+
+    /// <summary>
+    /// Uses a predefined API key for authentication.
+    /// The API key must be configured in the settings and provided via the Authorization header.
+    /// </summary>
+    ApiKey,
+
+    /// <summary>
+    /// Disables authentication completely.
+    /// WARNING: This option should only be used for local development and testing.
+    /// Never use this option in production environments.
+    /// </summary>
+    None,
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AHostOptions.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/A2AHostOptions.cs
@@ -1,0 +1,37 @@
+namespace CrestApps.OrchardCore.AI.A2A.Models;
+
+/// <summary>
+/// Configuration options for the A2A host authentication and authorization.
+/// </summary>
+public sealed class A2AHostOptions
+{
+    /// <summary>
+    /// Gets or sets the authentication type to use for the A2A host.
+    /// Default is <see cref="A2AHostAuthenticationType.OpenId"/>.
+    /// </summary>
+    public A2AHostAuthenticationType AuthenticationType { get; set; } = A2AHostAuthenticationType.OpenId;
+
+    /// <summary>
+    /// Gets or sets the API key required for authentication when
+    /// <see cref="AuthenticationType"/> is set to <see cref="A2AHostAuthenticationType.ApiKey"/>.
+    /// </summary>
+    public string ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to require the <c>AccessA2AHost</c> permission.
+    /// When set to <c>false</c>, any authenticated user can access the A2A host.
+    /// Default is <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// This setting only applies when <see cref="AuthenticationType"/> is
+    /// <see cref="A2AHostAuthenticationType.OpenId"/>.
+    /// </remarks>
+    public bool RequireAccessPermission { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to expose all agent profiles as skills of a single combined agent card.
+    /// When <c>false</c> (default), each agent profile is exposed as its own independent agent card.
+    /// When <c>true</c>, a single agent card is created with each agent profile listed as a skill.
+    /// </summary>
+    public bool ExposeAgentsAsSkill { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/AIProfileA2AMetadata.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Models/AIProfileA2AMetadata.cs
@@ -1,0 +1,9 @@
+namespace CrestApps.OrchardCore.AI.A2A.Models;
+
+/// <summary>
+/// Stores the selected A2A connection IDs on an AI profile, template, or chat interaction.
+/// </summary>
+public sealed class AIProfileA2AMetadata
+{
+    public string[] ConnectionIds { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AAdminMenu.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AAdminMenu.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Localization;
+using OrchardCore.Navigation;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+internal sealed class A2AAdminMenu : AdminNavigationProvider
+{
+    internal readonly IStringLocalizer S;
+
+    public A2AAdminMenu(IStringLocalizer<A2AAdminMenu> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    protected override ValueTask BuildAsync(NavigationBuilder builder)
+    {
+        builder
+            .Add(S["Artificial Intelligence"], ai => ai
+                .Add(S["Agent to Agent Hosts"], S["Agent to Agent Hosts"].PrefixPosition(), a2a => a2a
+                    .AddClass("ai-a2a-connections")
+                    .Id("aiA2AConnections")
+                    .Action("Index", "Connections", A2AConstants.Feature.Area)
+                    .Permission(A2APermissions.ManageA2AConnections)
+                    .LocalNav()
+                )
+            );
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AAgentProxyTool.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AAgentProxyTool.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using A2A;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OrchardCore.Entities;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+/// <summary>
+/// An AI tool that proxies execution to a remote agent via the A2A protocol.
+/// When the AI model invokes this tool, it sends a message to the remote agent
+/// and returns the response.
+/// </summary>
+internal sealed class A2AAgentProxyTool : AIFunction
+{
+    private readonly string _agentName;
+    private readonly string _description;
+    private readonly string _endpoint;
+    private readonly string _connectionId;
+
+    public A2AAgentProxyTool(string agentName, string description, string endpoint, string connectionId)
+    {
+        _agentName = agentName;
+        _description = description;
+        _endpoint = endpoint;
+        _connectionId = connectionId;
+    }
+
+    public override string Name => _agentName;
+
+    public override string Description => _description;
+
+    public override JsonElement JsonSchema { get; } = JsonDocument.Parse("""
+        {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "The message or task to send to the remote agent for processing."
+                },
+                "contextId": {
+                    "type": "string",
+                    "description": "An optional context identifier to maintain conversation continuity with the remote agent."
+                }
+            },
+            "required": ["message"]
+        }
+        """).RootElement;
+
+    public override IReadOnlyDictionary<string, object> AdditionalProperties { get; } = new Dictionary<string, object>()
+    {
+        ["Strict"] = false,
+    };
+
+    protected override async ValueTask<object> InvokeCoreAsync(
+        AIFunctionArguments arguments,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentNullException.ThrowIfNull(arguments.Services);
+
+        var logger = arguments.Services.GetRequiredService<ILogger<A2AAgentProxyTool>>();
+
+        if (!TryGetString(arguments, "message", out var message) || string.IsNullOrWhiteSpace(message))
+        {
+            return "No message was provided to the agent.";
+        }
+
+        TryGetString(arguments, "contextId", out var contextId);
+
+        try
+        {
+            var httpClientFactory = arguments.Services.GetRequiredService<IHttpClientFactory>();
+            var httpClient = httpClientFactory.CreateClient();
+
+            var authService = arguments.Services.GetService<IA2AConnectionAuthService>();
+            if (authService is not null)
+            {
+                var connectionStore = arguments.Services.GetRequiredService<ICatalog<A2AConnection>>();
+                var connection = await connectionStore.FindByIdAsync(_connectionId);
+
+                if (connection is not null)
+                {
+                    var metadata = connection.As<A2AConnectionMetadata>();
+                    await authService.ConfigureHttpClientAsync(httpClient, metadata, cancellationToken);
+                }
+            }
+
+            var client = new A2AClient(new Uri(_endpoint), httpClient);
+
+            var agentMessage = new AgentMessage
+            {
+                Role = MessageRole.User,
+                MessageId = Guid.NewGuid().ToString(),
+                ContextId = contextId ?? Guid.NewGuid().ToString(),
+                Parts = [new TextPart { Text = message }],
+                Metadata = new Dictionary<string, JsonElement>
+                {
+                    ["agentName"] = JsonSerializer.SerializeToElement(_agentName),
+                },
+            };
+
+            var sendParams = new MessageSendParams
+            {
+                Message = agentMessage,
+            };
+
+            var response = await client.SendMessageAsync(sendParams, cancellationToken);
+
+            var responseText = ExtractTextFromResponse(response);
+
+            return responseText ?? "The remote agent did not produce a text response.";
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to communicate with remote A2A agent '{AgentName}' at '{Endpoint}'.", _agentName, _endpoint);
+
+            return $"An error occurred while communicating with remote agent '{_agentName}'.";
+        }
+    }
+
+    private static bool TryGetString(AIFunctionArguments arguments, string key, out string value)
+    {
+        value = null;
+
+        if (arguments.TryGetValue(key, out var obj))
+        {
+            if (obj is string str)
+            {
+                value = str;
+                return true;
+            }
+
+            if (obj is JsonElement element && element.ValueKind == JsonValueKind.String)
+            {
+                value = element.GetString();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ExtractTextFromResponse(A2AResponse response)
+    {
+        if (response is AgentMessage message)
+        {
+            var texts = message.Parts?.OfType<TextPart>().Select(p => p.Text);
+
+            if (texts?.Any() == true)
+            {
+                return string.Join(string.Empty, texts);
+            }
+        }
+        else if (response is AgentTask task)
+        {
+            if (task.Artifacts?.Count > 0)
+            {
+                var artifactTexts = task.Artifacts
+                    .SelectMany(a => a.Parts?.OfType<TextPart>() ?? [])
+                    .Select(p => p.Text);
+
+                var combined = string.Join(string.Empty, artifactTexts);
+
+                if (!string.IsNullOrEmpty(combined))
+                {
+                    return combined;
+                }
+            }
+
+            if (task.Status.Message?.Parts is not null)
+            {
+                var statusTexts = task.Status.Message.Parts.OfType<TextPart>().Select(p => p.Text);
+
+                var combined = string.Join(string.Empty, statusTexts);
+
+                if (!string.IsNullOrEmpty(combined))
+                {
+                    return combined;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AHostPermissionsProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AHostPermissionsProvider.cs
@@ -1,0 +1,19 @@
+using OrchardCore.Security.Permissions;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+public sealed class A2AHostPermissionsProvider : IPermissionProvider
+{
+    public static readonly Permission AccessA2AHost = new("AccessA2AHost", "Access the A2A Host", isSecurityCritical: true);
+
+    private readonly IEnumerable<Permission> _allPermissions =
+    [
+        AccessA2AHost,
+    ];
+
+    public Task<IEnumerable<Permission>> GetPermissionsAsync()
+        => Task.FromResult(_allPermissions);
+
+    public IEnumerable<PermissionStereotype> GetDefaultStereotypes()
+        => [];
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2APermissionsProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2APermissionsProvider.cs
@@ -1,0 +1,24 @@
+using OrchardCore;
+using OrchardCore.Security.Permissions;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+internal sealed class A2APermissionsProvider : IPermissionProvider
+{
+    private readonly IEnumerable<Permission> _allPermissions =
+    [
+        A2APermissions.ManageA2AConnections,
+    ];
+
+    public Task<IEnumerable<Permission>> GetPermissionsAsync()
+        => Task.FromResult(_allPermissions);
+
+    public IEnumerable<PermissionStereotype> GetDefaultStereotypes() =>
+    [
+        new PermissionStereotype
+        {
+            Name = OrchardCoreConstants.Roles.Administrator,
+            Permissions = _allPermissions,
+        },
+    ];
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AToolRegistryProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AToolRegistryProvider.cs
@@ -1,0 +1,99 @@
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+/// <summary>
+/// Provides tool registry entries for agents from remote A2A connections.
+/// Each agent exposed by a connected A2A host becomes a tool entry that the orchestrator can invoke.
+/// </summary>
+internal sealed class A2AToolRegistryProvider : IToolRegistryProvider
+{
+    private readonly ICatalog<A2AConnection> _connectionStore;
+    private readonly IA2AAgentCardCacheService _agentCardCache;
+    private readonly ILogger _logger;
+
+    public A2AToolRegistryProvider(
+        ICatalog<A2AConnection> connectionStore,
+        IA2AAgentCardCacheService agentCardCache,
+        ILogger<A2AToolRegistryProvider> logger)
+    {
+        _connectionStore = connectionStore;
+        _agentCardCache = agentCardCache;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<ToolRegistryEntry>> GetToolsAsync(
+        AICompletionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var connectionIds = context?.A2AConnectionIds;
+
+        if (connectionIds is null || connectionIds.Length == 0)
+        {
+            return [];
+        }
+
+        var entries = new List<ToolRegistryEntry>();
+
+        foreach (var connectionId in connectionIds)
+        {
+            var connection = await _connectionStore.FindByIdAsync(connectionId);
+
+            if (connection is null || string.IsNullOrWhiteSpace(connection.Endpoint))
+            {
+                continue;
+            }
+
+            try
+            {
+                var agentCard = await _agentCardCache.GetAgentCardAsync(connectionId, connection, cancellationToken);
+
+                if (agentCard?.Skills is null)
+                {
+                    continue;
+                }
+
+                foreach (var skill in agentCard.Skills)
+                {
+                    var skillName = SanitizeToolName(skill.Id ?? skill.Name ?? connection.DisplayText);
+                    var capturedConnectionId = connectionId;
+
+                    entries.Add(new ToolRegistryEntry
+                    {
+                        Id = $"a2a:{connectionId}:{skillName}",
+                        Name = skillName,
+                        Description = skill.Description ?? agentCard.Description,
+                        Source = ToolRegistryEntrySource.A2AAgent,
+                        SourceId = connectionId,
+                        CreateAsync = _ => ValueTask.FromResult<AITool>(
+                            new A2AAgentProxyTool(skillName, skill.Description ?? agentCard.Description, connection.Endpoint, capturedConnectionId)),
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to load agent card for A2A connection '{ConnectionId}'.", connectionId);
+            }
+        }
+
+        return entries;
+    }
+
+    private static string SanitizeToolName(string name)
+    {
+        // Tool names must be valid identifiers. Replace invalid characters.
+        var sanitized = new char[name.Length];
+
+        for (var i = 0; i < name.Length; i++)
+        {
+            var c = name[i];
+            sanitized[i] = char.IsLetterOrDigit(c) || c == '_' ? c : '_';
+        }
+
+        return new string(sanitized);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AWellKnownEndpointHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/A2AWellKnownEndpointHandler.cs
@@ -1,0 +1,98 @@
+using A2A;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+/// <summary>
+/// Handles GET requests to <c>/.well-known/agent-card.json</c>.
+/// Returns individual agent cards (multi-agent mode) or a single card with skills (skill mode).
+/// Includes security scheme information so clients know how to authenticate.
+/// </summary>
+internal static class A2AWellKnownEndpointHandler
+{
+    public static async Task HandleAsync(HttpContext context)
+    {
+        var options = context.RequestServices.GetRequiredService<IOptions<A2AHostOptions>>().Value;
+        var profileManager = context.RequestServices.GetRequiredService<IAIProfileManager>();
+        var profiles = await profileManager.GetAsync(AIProfileType.Agent);
+
+        var baseUrl = $"{context.Request.Scheme}://{context.Request.Host}";
+
+        context.Response.ContentType = "application/json";
+
+        if (options.ExposeAgentsAsSkill)
+        {
+            var card = A2ATaskManagerFactory.BuildSkillModeCard($"{baseUrl}/a2a", profiles);
+            ApplySecuritySchemes(card, options, baseUrl);
+            await context.Response.WriteAsJsonAsync(card, A2AJsonOptions.Default, context.RequestAborted);
+        }
+        else
+        {
+            var cards = BuildAgentCards(profiles, baseUrl, options);
+            await context.Response.WriteAsJsonAsync(cards, A2AJsonOptions.Default, context.RequestAborted);
+        }
+    }
+
+    private static List<AgentCard> BuildAgentCards(IEnumerable<AIProfile> profiles, string baseUrl, A2AHostOptions options)
+    {
+        var cards = new List<AgentCard>();
+
+        if (profiles is null)
+        {
+            return cards;
+        }
+
+        foreach (var profile in profiles)
+        {
+            var agentUrl = $"{baseUrl}/a2a?agent={Uri.EscapeDataString(profile.Name)}";
+            var card = A2ATaskManagerFactory.BuildAgentCard(profile, agentUrl);
+            ApplySecuritySchemes(card, options, baseUrl);
+            cards.Add(card);
+        }
+
+        return cards;
+    }
+
+    /// <summary>
+    /// Populates the <see cref="AgentCard.SecuritySchemes"/> and <see cref="AgentCard.Security"/>
+    /// fields based on the configured authentication type so clients know how to authenticate.
+    /// </summary>
+    private static void ApplySecuritySchemes(AgentCard card, A2AHostOptions options, string baseUrl)
+    {
+        switch (options.AuthenticationType)
+        {
+            case A2AHostAuthenticationType.ApiKey:
+                card.SecuritySchemes = new Dictionary<string, SecurityScheme>
+                {
+                    ["apiKey"] = new ApiKeySecurityScheme(
+                        name: "Authorization",
+                        keyLocation: "header",
+                        description: "API key authentication. Send as 'Bearer {key}' or 'ApiKey {key}' in the Authorization header."),
+                };
+                card.Security =
+                [
+                    new Dictionary<string, string[]> { ["apiKey"] = [] },
+                ];
+                break;
+
+            case A2AHostAuthenticationType.OpenId:
+                card.SecuritySchemes = new Dictionary<string, SecurityScheme>
+                {
+                    ["openId"] = new OpenIdConnectSecurityScheme(
+                        openIdConnectUrl: new Uri($"{baseUrl}/.well-known/openid-configuration"),
+                        description: "OpenID Connect authentication. Obtain an access token from the OpenID Connect provider and send it as a Bearer token."),
+                };
+                card.Security =
+                [
+                    new Dictionary<string, string[]> { ["openId"] = [] },
+                ];
+                break;
+
+                // AuthenticationType.None — no security schemes needed.
+        }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/DefaultA2AAgentCardCacheService.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/DefaultA2AAgentCardCacheService.cs
@@ -1,0 +1,83 @@
+using A2A;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OrchardCore.Entities;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+internal sealed class DefaultA2AAgentCardCacheService : IA2AAgentCardCacheService
+{
+    private static readonly TimeSpan _cacheDuration = TimeSpan.FromMinutes(15);
+
+    private readonly IMemoryCache _memoryCache;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger _logger;
+
+    public DefaultA2AAgentCardCacheService(
+        IMemoryCache memoryCache,
+        IHttpClientFactory httpClientFactory,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<DefaultA2AAgentCardCacheService> logger)
+    {
+        _memoryCache = memoryCache;
+        _httpClientFactory = httpClientFactory;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<AgentCard> GetAgentCardAsync(string connectionId, A2AConnection connection, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = GetCacheKey(connectionId);
+
+        if (_memoryCache.TryGetValue(cacheKey, out AgentCard cachedCard))
+        {
+            return cachedCard;
+        }
+
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+
+            var metadata = connection.As<A2AConnectionMetadata>();
+
+            // Resolve the scoped auth service from the current request to avoid
+            // capturing a scoped service in this singleton.
+            var authService = _httpContextAccessor.HttpContext?.RequestServices
+                .GetService<IA2AConnectionAuthService>();
+
+            if (authService is not null)
+            {
+                await authService.ConfigureHttpClientAsync(httpClient, metadata, cancellationToken);
+            }
+
+            var resolver = new A2ACardResolver(new Uri(connection.Endpoint), httpClient);
+
+            var agentCard = await resolver.GetAgentCardAsync(cancellationToken);
+
+            if (agentCard is not null)
+            {
+                _memoryCache.Set(cacheKey, agentCard, _cacheDuration);
+            }
+
+            return agentCard;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch agent card from A2A host '{Endpoint}' for connection '{ConnectionId}'.", connection.Endpoint, connectionId);
+
+            return null;
+        }
+    }
+
+    public void Invalidate(string connectionId)
+    {
+        _memoryCache.Remove(GetCacheKey(connectionId));
+    }
+
+    private static string GetCacheKey(string connectionId)
+        => $"A2AAgentCard:{connectionId}";
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/DefaultA2AConnectionAuthService.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/DefaultA2AConnectionAuthService.cs
@@ -1,0 +1,432 @@
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+internal sealed class DefaultA2AConnectionAuthService : IA2AConnectionAuthService
+{
+    private const int ExpirationBufferSeconds = 60;
+
+    private readonly IDataProtectionProvider _dataProtectionProvider;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger _logger;
+
+    public DefaultA2AConnectionAuthService(
+        IDataProtectionProvider dataProtectionProvider,
+        IHttpClientFactory httpClientFactory,
+        IMemoryCache cache,
+        ILogger<DefaultA2AConnectionAuthService> logger)
+    {
+        _dataProtectionProvider = dataProtectionProvider;
+        _httpClientFactory = httpClientFactory;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<Dictionary<string, string>> BuildHeadersAsync(
+        A2AConnectionMetadata metadata,
+        CancellationToken cancellationToken = default)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (metadata is null)
+        {
+            return headers;
+        }
+
+        var protector = _dataProtectionProvider.CreateProtector(A2AConstants.DataProtectionPurpose);
+
+        switch (metadata.AuthenticationType)
+        {
+            case A2AClientAuthenticationType.ApiKey:
+                BuildApiKeyHeaders(metadata, protector, headers);
+                break;
+
+            case A2AClientAuthenticationType.Basic:
+                BuildBasicHeaders(metadata, protector, headers);
+                break;
+
+            case A2AClientAuthenticationType.OAuth2ClientCredentials:
+                await BuildOAuth2ClientCredentialsHeadersAsync(metadata, protector, headers, cancellationToken);
+                break;
+
+            case A2AClientAuthenticationType.OAuth2PrivateKeyJwt:
+                await BuildOAuth2PrivateKeyJwtHeadersAsync(metadata, protector, headers, cancellationToken);
+                break;
+
+            case A2AClientAuthenticationType.OAuth2Mtls:
+                await BuildOAuth2MtlsHeadersAsync(metadata, protector, headers, cancellationToken);
+                break;
+
+            case A2AClientAuthenticationType.CustomHeaders:
+                BuildCustomHeaders(metadata, headers);
+                break;
+        }
+
+        return headers;
+    }
+
+    public async Task ConfigureHttpClientAsync(
+        HttpClient httpClient,
+        A2AConnectionMetadata metadata,
+        CancellationToken cancellationToken = default)
+    {
+        var headers = await BuildHeadersAsync(metadata, cancellationToken);
+
+        foreach (var header in headers)
+        {
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
+        }
+    }
+
+    private void BuildApiKeyHeaders(
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        Dictionary<string, string> headers)
+    {
+        if (string.IsNullOrEmpty(metadata.ApiKey))
+        {
+            return;
+        }
+
+        var apiKey = Unprotect(protector, metadata.ApiKey);
+        var headerName = string.IsNullOrWhiteSpace(metadata.ApiKeyHeaderName)
+            ? "Authorization"
+            : metadata.ApiKeyHeaderName;
+        var value = !string.IsNullOrWhiteSpace(metadata.ApiKeyPrefix)
+            ? $"{metadata.ApiKeyPrefix} {apiKey}"
+            : apiKey;
+
+        headers[headerName] = value;
+    }
+
+    private void BuildBasicHeaders(
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        Dictionary<string, string> headers)
+    {
+        if (string.IsNullOrEmpty(metadata.BasicUsername))
+        {
+            return;
+        }
+
+        var password = !string.IsNullOrEmpty(metadata.BasicPassword)
+            ? Unprotect(protector, metadata.BasicPassword)
+            : string.Empty;
+        var credentials = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes($"{metadata.BasicUsername}:{password}"));
+
+        headers["Authorization"] = $"Basic {credentials}";
+    }
+
+    private async Task BuildOAuth2ClientCredentialsHeadersAsync(
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        Dictionary<string, string> headers,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(metadata.OAuth2TokenEndpoint) ||
+            string.IsNullOrEmpty(metadata.OAuth2ClientId) ||
+            string.IsNullOrEmpty(metadata.OAuth2ClientSecret))
+        {
+            return;
+        }
+
+        var clientSecret = Unprotect(protector, metadata.OAuth2ClientSecret);
+
+        try
+        {
+            var token = await AcquireTokenAsync(
+                "cc",
+                metadata.OAuth2TokenEndpoint,
+                metadata.OAuth2ClientId,
+                metadata.OAuth2Scopes,
+                new Dictionary<string, string>
+                {
+                    ["grant_type"] = "client_credentials",
+                    ["client_id"] = metadata.OAuth2ClientId,
+                    ["client_secret"] = clientSecret,
+                },
+                cancellationToken);
+
+            headers["Authorization"] = $"Bearer {token}";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to acquire OAuth2 token from '{TokenEndpoint}'.", metadata.OAuth2TokenEndpoint);
+            throw;
+        }
+    }
+
+    private async Task BuildOAuth2PrivateKeyJwtHeadersAsync(
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        Dictionary<string, string> headers,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(metadata.OAuth2TokenEndpoint) ||
+            string.IsNullOrEmpty(metadata.OAuth2ClientId) ||
+            string.IsNullOrEmpty(metadata.OAuth2PrivateKey))
+        {
+            return;
+        }
+
+        var privateKey = Unprotect(protector, metadata.OAuth2PrivateKey);
+        var assertion = CreateClientAssertion(
+            metadata.OAuth2TokenEndpoint, metadata.OAuth2ClientId, privateKey, metadata.OAuth2KeyId);
+
+        try
+        {
+            var token = await AcquireTokenAsync(
+                "pkjwt",
+                metadata.OAuth2TokenEndpoint,
+                metadata.OAuth2ClientId,
+                metadata.OAuth2Scopes,
+                new Dictionary<string, string>
+                {
+                    ["grant_type"] = "client_credentials",
+                    ["client_id"] = metadata.OAuth2ClientId,
+                    ["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                    ["client_assertion"] = assertion,
+                },
+                cancellationToken);
+
+            headers["Authorization"] = $"Bearer {token}";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to acquire OAuth2 token via Private Key JWT from '{TokenEndpoint}'.", metadata.OAuth2TokenEndpoint);
+            throw;
+        }
+    }
+
+    private async Task BuildOAuth2MtlsHeadersAsync(
+        A2AConnectionMetadata metadata,
+        IDataProtector protector,
+        Dictionary<string, string> headers,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(metadata.OAuth2TokenEndpoint) ||
+            string.IsNullOrEmpty(metadata.OAuth2ClientId) ||
+            string.IsNullOrEmpty(metadata.OAuth2ClientCertificate))
+        {
+            return;
+        }
+
+        var certBase64 = Unprotect(protector, metadata.OAuth2ClientCertificate);
+        var certBytes = Convert.FromBase64String(certBase64);
+        var certPassword = !string.IsNullOrEmpty(metadata.OAuth2ClientCertificatePassword)
+            ? Unprotect(protector, metadata.OAuth2ClientCertificatePassword)
+            : null;
+
+        try
+        {
+            var parameters = new Dictionary<string, string>
+            {
+                ["grant_type"] = "client_credentials",
+                ["client_id"] = metadata.OAuth2ClientId,
+            };
+
+            if (!string.IsNullOrWhiteSpace(metadata.OAuth2Scopes))
+            {
+                parameters["scope"] = metadata.OAuth2Scopes;
+            }
+
+            var cacheKey = GetOAuth2CacheKey("mtls", metadata.OAuth2TokenEndpoint, metadata.OAuth2ClientId, metadata.OAuth2Scopes);
+
+            if (_cache.TryGetValue(cacheKey, out string cachedToken))
+            {
+                headers["Authorization"] = $"Bearer {cachedToken}";
+                return;
+            }
+
+            var cert = string.IsNullOrEmpty(certPassword)
+                ? X509CertificateLoader.LoadPkcs12(certBytes, null)
+                : X509CertificateLoader.LoadPkcs12(certBytes, certPassword);
+
+            using (cert)
+            {
+                var handler = new HttpClientHandler();
+                handler.ClientCertificates.Add(cert);
+
+                using var httpClient = new HttpClient(handler);
+                var token = await SendTokenRequestAsync(httpClient, metadata.OAuth2TokenEndpoint, parameters, cacheKey, cancellationToken);
+
+                headers["Authorization"] = $"Bearer {token}";
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to acquire OAuth2 token via mTLS from '{TokenEndpoint}'.", metadata.OAuth2TokenEndpoint);
+            throw;
+        }
+    }
+
+    private static void BuildCustomHeaders(
+        A2AConnectionMetadata metadata,
+        Dictionary<string, string> headers)
+    {
+        if (metadata.AdditionalHeaders is null)
+        {
+            return;
+        }
+
+        foreach (var header in metadata.AdditionalHeaders)
+        {
+            headers[header.Key] = header.Value;
+        }
+    }
+
+    private async Task<string> AcquireTokenAsync(
+        string grantType,
+        string tokenEndpoint,
+        string clientId,
+        string scopes,
+        Dictionary<string, string> parameters,
+        CancellationToken cancellationToken)
+    {
+        var cacheKey = GetOAuth2CacheKey(grantType, tokenEndpoint, clientId, scopes);
+
+        if (_cache.TryGetValue(cacheKey, out string cachedToken))
+        {
+            return cachedToken;
+        }
+
+        if (!string.IsNullOrWhiteSpace(scopes) && !parameters.ContainsKey("scope"))
+        {
+            parameters["scope"] = scopes;
+        }
+
+        using var httpClient = _httpClientFactory.CreateClient(nameof(DefaultA2AConnectionAuthService));
+
+        return await SendTokenRequestAsync(httpClient, tokenEndpoint, parameters, cacheKey, cancellationToken);
+    }
+
+    private async Task<string> SendTokenRequestAsync(
+        HttpClient httpClient,
+        string tokenEndpoint,
+        Dictionary<string, string> parameters,
+        string cacheKey,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(parameters),
+        };
+
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError(
+                "OAuth2 token request to '{TokenEndpoint}' failed with status {StatusCode}: {ErrorBody}",
+                tokenEndpoint,
+                response.StatusCode,
+                errorBody);
+
+            throw new HttpRequestException(
+                $"OAuth2 token request failed with status {response.StatusCode}.");
+        }
+
+        var tokenResponse = await response.Content.ReadFromJsonAsync<OAuth2TokenResponse>(cancellationToken);
+
+        if (string.IsNullOrEmpty(tokenResponse?.AccessToken))
+        {
+            throw new InvalidOperationException("OAuth2 token response did not contain an access token.");
+        }
+
+        var expiration = tokenResponse.ExpiresIn > ExpirationBufferSeconds
+            ? TimeSpan.FromSeconds(tokenResponse.ExpiresIn - ExpirationBufferSeconds)
+            : TimeSpan.FromMinutes(5);
+
+        _cache.Set(cacheKey, tokenResponse.AccessToken, expiration);
+
+        return tokenResponse.AccessToken;
+    }
+
+    private static string CreateClientAssertion(string tokenEndpoint, string clientId, string privateKeyPem, string keyId)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var headerObj = new Dictionary<string, string>
+        {
+            ["alg"] = "RS256",
+            ["typ"] = "JWT",
+        };
+
+        if (!string.IsNullOrEmpty(keyId))
+        {
+            headerObj["kid"] = keyId;
+        }
+
+        var headerJson = JsonSerializer.Serialize(headerObj);
+        var headerBase64 = Base64UrlEncode(Encoding.UTF8.GetBytes(headerJson));
+
+        var payloadObj = new Dictionary<string, object>
+        {
+            ["iss"] = clientId,
+            ["sub"] = clientId,
+            ["aud"] = tokenEndpoint,
+            ["jti"] = Guid.NewGuid().ToString("N"),
+            ["iat"] = now.ToUnixTimeSeconds(),
+            ["exp"] = now.AddMinutes(5).ToUnixTimeSeconds(),
+        };
+
+        var payloadJson = JsonSerializer.Serialize(payloadObj);
+        var payloadBase64 = Base64UrlEncode(Encoding.UTF8.GetBytes(payloadJson));
+
+        var dataToSign = Encoding.UTF8.GetBytes($"{headerBase64}.{payloadBase64}");
+
+        using var rsa = RSA.Create();
+        rsa.ImportFromPem(privateKeyPem);
+
+        var signature = rsa.SignData(dataToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var signatureBase64 = Base64UrlEncode(signature);
+
+        return $"{headerBase64}.{payloadBase64}.{signatureBase64}";
+    }
+
+    private static string Base64UrlEncode(byte[] input)
+        => Convert.ToBase64String(input)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+
+    private static string GetOAuth2CacheKey(string grantType, string tokenEndpoint, string clientId, string scopes)
+        => $"a2a_oauth2_{grantType}_{tokenEndpoint}_{clientId}_{scopes}";
+
+    private string Unprotect(IDataProtector protector, string value)
+    {
+        try
+        {
+            return protector.Unprotect(value);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to unprotect a credential value for A2A connection.");
+            return value;
+        }
+    }
+
+    private sealed class OAuth2TokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonPropertyName("token_type")]
+        public string TokenType { get; set; }
+
+        [JsonPropertyName("expires_in")]
+        public int ExpiresIn { get; set; }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/IA2AAgentCardCacheService.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/IA2AAgentCardCacheService.cs
@@ -1,0 +1,20 @@
+using A2A;
+using CrestApps.OrchardCore.AI.A2A.Models;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+/// <summary>
+/// Provides cached access to agent cards from remote A2A host connections.
+/// </summary>
+public interface IA2AAgentCardCacheService
+{
+    /// <summary>
+    /// Gets the agent card for the specified A2A connection, using a cached value if available.
+    /// </summary>
+    Task<AgentCard> GetAgentCardAsync(string connectionId, A2AConnection connection, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invalidates the cached agent card for the specified connection.
+    /// </summary>
+    void Invalidate(string connectionId);
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/IA2AConnectionAuthService.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/IA2AConnectionAuthService.cs
@@ -1,0 +1,16 @@
+using CrestApps.OrchardCore.AI.A2A.Models;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+public interface IA2AConnectionAuthService
+{
+    /// <summary>
+    /// Builds the HTTP authentication headers for the given A2A connection metadata.
+    /// </summary>
+    Task<Dictionary<string, string>> BuildHeadersAsync(A2AConnectionMetadata metadata, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Configures an HttpClient with the authentication headers for the given connection metadata.
+    /// </summary>
+    Task ConfigureHttpClientAsync(HttpClient httpClient, A2AConnectionMetadata metadata, CancellationToken cancellationToken = default);
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/OrchardCoreA2ATaskManager.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Services/OrchardCoreA2ATaskManager.cs
@@ -1,0 +1,304 @@
+using A2A;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.OrchardCore.AI.A2A.Services;
+
+/// <summary>
+/// Creates and configures an A2A <see cref="TaskManager"/> that routes incoming messages to local AI Agent profiles.
+/// Uses the task-based flow (<see cref="ITaskManager.OnTaskCreated"/>) instead of <see cref="ITaskManager.OnMessageReceived"/>
+/// to enable true streaming: each AI completion chunk is pushed as a <see cref="TaskArtifactUpdateEvent"/> via SSE.
+/// Uses <see cref="IHttpContextAccessor"/> to resolve services per-request, avoiding captured service provider disposal issues.
+/// </summary>
+internal static class A2ATaskManagerFactory
+{
+    public static ITaskManager Create(IServiceProvider serviceProvider)
+    {
+        var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
+
+        var taskManager = new TaskManager();
+
+        taskManager.OnAgentCardQuery = async (agentUrl, cancellationToken) =>
+        {
+            var services = httpContextAccessor.HttpContext.RequestServices;
+            var options = services.GetRequiredService<IOptions<A2AHostOptions>>().Value;
+            var profileManager = services.GetRequiredService<IAIProfileManager>();
+            var profiles = await profileManager.GetAsync(AIProfileType.Agent);
+
+            if (options.ExposeAgentsAsSkill)
+            {
+                return BuildSkillModeCard(agentUrl, profiles);
+            }
+
+            // Multi-agent mode: return card for the specific agent from query parameter.
+            var agentName = httpContextAccessor.HttpContext?.Request.Query["agent"].FirstOrDefault();
+            var targetProfile = ResolveAgentProfile(profiles, agentName);
+
+            if (targetProfile is null)
+            {
+                return BuildSkillModeCard(agentUrl, profiles);
+            }
+
+            return BuildAgentCard(targetProfile, agentUrl);
+        };
+
+        // Use the task-based flow for both streaming and non-streaming.
+        // When streaming, OnTaskCreated runs in a background Task.Run and pushes
+        // artifact/status events through the TaskUpdateEventEnumerator.
+        // When non-streaming, OnTaskCreated runs synchronously before the task is returned.
+        taskManager.OnTaskCreated = (agentTask, cancellationToken) =>
+            ProcessAgentTaskAsync(taskManager, httpContextAccessor, agentTask, cancellationToken);
+
+        taskManager.OnTaskUpdated = (agentTask, cancellationToken) =>
+            ProcessAgentTaskAsync(taskManager, httpContextAccessor, agentTask, cancellationToken);
+
+        return taskManager;
+    }
+
+    private static async Task ProcessAgentTaskAsync(
+        TaskManager taskManager,
+        IHttpContextAccessor httpContextAccessor,
+        AgentTask agentTask,
+        CancellationToken cancellationToken)
+    {
+        var services = httpContextAccessor.HttpContext?.RequestServices;
+
+        if (services is null)
+        {
+            await taskManager.UpdateStatusAsync(
+                agentTask.Id,
+                TaskState.Failed,
+                CreateAgentMessage(agentTask.ContextId, "Request services are not available."),
+                final: true,
+                cancellationToken);
+
+            return;
+        }
+
+        var logger = services.GetRequiredService<ILogger<TaskManager>>();
+        var options = services.GetRequiredService<IOptions<A2AHostOptions>>().Value;
+
+        // Extract the user's prompt from the last message in the task history.
+        var lastMessage = agentTask.History?.LastOrDefault();
+        var prompt = lastMessage?.Parts?.OfType<TextPart>().FirstOrDefault()?.Text;
+
+        if (string.IsNullOrWhiteSpace(prompt))
+        {
+            await taskManager.UpdateStatusAsync(
+                agentTask.Id,
+                TaskState.Failed,
+                CreateAgentMessage(agentTask.ContextId, "No text message was provided."),
+                final: true,
+                cancellationToken);
+
+            return;
+        }
+
+        var targetProfile = await ResolveTargetProfileAsync(
+            services, httpContextAccessor, options, lastMessage);
+
+        if (targetProfile is null)
+        {
+            await taskManager.UpdateStatusAsync(
+                agentTask.Id,
+                TaskState.Failed,
+                CreateAgentMessage(agentTask.ContextId, "No agents are available to process this request."),
+                final: true,
+                cancellationToken);
+
+            return;
+        }
+
+        try
+        {
+            await taskManager.UpdateStatusAsync(
+                agentTask.Id,
+                TaskState.Working,
+                cancellationToken: cancellationToken);
+
+            var completionService = services.GetRequiredService<IAICompletionService>();
+            var contextBuilder = services.GetRequiredService<IAICompletionContextBuilder>();
+
+            var context = await contextBuilder.BuildAsync(targetProfile);
+            context.DisableTools = true;
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.User, prompt),
+            };
+
+            var responseText = new System.Text.StringBuilder();
+
+            await foreach (var update in completionService.CompleteStreamingAsync(
+                targetProfile.Source,
+                messages,
+                context,
+                cancellationToken))
+            {
+                var chunk = update.Text;
+
+                if (!string.IsNullOrEmpty(chunk))
+                {
+                    responseText.Append(chunk);
+
+                    // Push each chunk as an artifact update so streaming clients receive it in real-time.
+                    await taskManager.ReturnArtifactAsync(
+                        agentTask.Id,
+                        new Artifact
+                        {
+                            Parts = [new TextPart { Text = chunk }],
+                        },
+                        cancellationToken);
+                }
+            }
+
+            var finalText = responseText.Length > 0
+                ? responseText.ToString()
+                : "The agent did not produce a response.";
+
+            await taskManager.UpdateStatusAsync(
+                agentTask.Id,
+                TaskState.Completed,
+                CreateAgentMessage(agentTask.ContextId, finalText),
+                final: true,
+                cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            await taskManager.UpdateStatusAsync(
+                agentTask.Id,
+                TaskState.Canceled,
+                final: true,
+                cancellationToken: CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to execute agent '{AgentName}'.", targetProfile.Name);
+
+            await taskManager.UpdateStatusAsync(
+                agentTask.Id,
+                TaskState.Failed,
+                CreateAgentMessage(agentTask.ContextId, $"An error occurred while executing agent '{targetProfile.Name}'."),
+                final: true,
+                cancellationToken: CancellationToken.None);
+        }
+    }
+
+    private static async Task<AIProfile> ResolveTargetProfileAsync(
+        IServiceProvider services,
+        IHttpContextAccessor httpContextAccessor,
+        A2AHostOptions options,
+        AgentMessage lastMessage)
+    {
+        var profileManager = services.GetRequiredService<IAIProfileManager>();
+        var profiles = await profileManager.GetAsync(AIProfileType.Agent);
+
+        AIProfile targetProfile = null;
+
+        // In multi-agent mode, check query parameter first.
+        if (!options.ExposeAgentsAsSkill)
+        {
+            var agentName = httpContextAccessor.HttpContext?.Request.Query["agent"].FirstOrDefault();
+
+            if (!string.IsNullOrEmpty(agentName))
+            {
+                targetProfile = profiles?.FirstOrDefault(p =>
+                    string.Equals(p.Name, agentName, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        // Fall back to message metadata-based routing.
+        if (targetProfile is null &&
+            lastMessage?.Metadata?.TryGetValue("agentName", out var agentNameElement) == true)
+        {
+            var metaAgentName = agentNameElement.GetString();
+
+            if (!string.IsNullOrEmpty(metaAgentName))
+            {
+                targetProfile = profiles?.FirstOrDefault(p =>
+                    string.Equals(p.Name, metaAgentName, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        // Fall back to the first available agent.
+        return targetProfile ?? profiles?.FirstOrDefault();
+    }
+
+    internal static AgentCard BuildSkillModeCard(string agentUrl, IEnumerable<AIProfile> profiles)
+    {
+        var skills = new List<AgentSkill>();
+
+        if (profiles is not null)
+        {
+            foreach (var profile in profiles)
+            {
+                skills.Add(new AgentSkill
+                {
+                    Id = profile.Name,
+                    Name = profile.DisplayText ?? profile.Name,
+                    Description = profile.Description,
+                    Tags = ["agent"],
+                });
+            }
+        }
+
+        return new AgentCard
+        {
+            Name = "Orchard Core A2A Host",
+            Description = "Exposes Orchard Core AI Agent profiles via the Agent-to-Agent protocol.",
+            Url = agentUrl,
+            Version = CrestAppsManifestConstants.Version,
+            DefaultInputModes = ["text"],
+            DefaultOutputModes = ["text"],
+            Capabilities = new AgentCapabilities
+            {
+                Streaming = true,
+            },
+            Skills = skills,
+        };
+    }
+
+    internal static AgentCard BuildAgentCard(AIProfile profile, string agentUrl)
+    {
+        return new AgentCard
+        {
+            Name = profile.DisplayText ?? profile.Name,
+            Description = profile.Description ?? $"AI Agent: {profile.DisplayText ?? profile.Name}",
+            Url = agentUrl,
+            Version = CrestAppsManifestConstants.Version,
+            DefaultInputModes = ["text"],
+            DefaultOutputModes = ["text"],
+            Capabilities = new AgentCapabilities
+            {
+                Streaming = true,
+            },
+        };
+    }
+
+    private static AIProfile ResolveAgentProfile(IEnumerable<AIProfile> profiles, string agentName)
+    {
+        if (string.IsNullOrEmpty(agentName) || profiles is null)
+        {
+            return null;
+        }
+
+        return profiles.FirstOrDefault(p =>
+            string.Equals(p.Name, agentName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static AgentMessage CreateAgentMessage(string contextId, string text)
+    {
+        return new AgentMessage
+        {
+            Role = MessageRole.Agent,
+            MessageId = Guid.NewGuid().ToString(),
+            ContextId = contextId,
+            Parts = [new TextPart { Text = text }],
+        };
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Startup.cs
@@ -1,0 +1,93 @@
+using A2A;
+using A2A.AspNetCore;
+using CrestApps.OrchardCore.AI.A2A.Drivers;
+using CrestApps.OrchardCore.AI.A2A.Functions;
+using CrestApps.OrchardCore.AI.A2A.Handlers;
+using CrestApps.OrchardCore.AI.A2A.Models;
+using CrestApps.OrchardCore.AI.A2A.Services;
+using CrestApps.OrchardCore.AI.Models;
+using CrestApps.OrchardCore.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.Environment.Shell.Configuration;
+using OrchardCore.Modules;
+using OrchardCore.Navigation;
+using OrchardCore.Security.Permissions;
+
+namespace CrestApps.OrchardCore.AI.A2A;
+
+public sealed class Startup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddDisplayDriver<AIProfile, AIProfileA2AConnectionsDisplayDriver>();
+        services.AddDisplayDriver<AIProfileTemplate, AIProfileTemplateA2AConnectionsDisplayDriver>();
+        services.AddDisplayDriver<ChatInteraction, ChatInteractionA2AConnectionsDisplayDriver>();
+        services.AddScoped<IToolRegistryProvider, A2AToolRegistryProvider>();
+        services.AddNavigationProvider<A2AAdminMenu>();
+        services.AddPermissionProvider<A2APermissionsProvider>();
+        services.AddScoped<ICatalogEntryHandler<A2AConnection>, A2AConnectionHandler>();
+        services.AddScoped<ICatalogEntryHandler<A2AConnection>, A2AConnectionSettingsHandler>();
+        services.AddDisplayDriver<A2AConnection, A2AConnectionDisplayDriver>();
+        services.AddScoped<IAICompletionContextBuilderHandler, A2AAICompletionContextBuilderHandler>();
+        services.AddSingleton<IA2AAgentCardCacheService, DefaultA2AAgentCardCacheService>();
+        services.AddScoped<IA2AConnectionAuthService, DefaultA2AConnectionAuthService>();
+
+        // Register AI system functions for agent and tool discovery.
+        services.AddAITool<ListAvailableAgentsFunction>(ListAvailableAgentsFunction.TheName);
+        services.AddAITool<FindAgentForTaskFunction>(FindAgentForTaskFunction.TheName);
+        services.AddAITool<FindToolsForTaskFunction>(FindToolsForTaskFunction.TheName);
+    }
+}
+
+[Feature(A2AConstants.Feature.Host)]
+public sealed class A2AHostStartup : StartupBase
+{
+    private const string A2AHostPolicyName = "A2AHostPolicy";
+
+    private readonly IShellConfiguration _shellConfiguration;
+
+    public A2AHostStartup(IShellConfiguration shellConfiguration)
+    {
+        _shellConfiguration = shellConfiguration;
+    }
+
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.Configure<A2AHostOptions>(_shellConfiguration.GetSection("CrestApps_AI:A2AHost"));
+
+        services.AddPermissionProvider<A2AHostPermissionsProvider>();
+
+        services.AddScoped<IAuthorizationHandler, A2AHostAuthorizationHandler>();
+
+        services.AddAuthentication()
+            .AddScheme<A2AApiKeyAuthenticationOptions, A2AApiKeyAuthenticationHandler>(
+                A2AApiKeyAuthenticationDefaults.AuthenticationScheme, options => { });
+
+        services.AddSingleton(A2ATaskManagerFactory.Create);
+
+        services.AddAuthorizationBuilder()
+            .AddPolicy(A2AHostPolicyName, policy =>
+            {
+                policy.AddAuthenticationSchemes(A2AApiKeyAuthenticationDefaults.AuthenticationScheme, "Api");
+                policy.AddRequirements(new A2AHostAuthorizationRequirement());
+            });
+    }
+
+    public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
+    {
+        var taskManager = serviceProvider.GetRequiredService<ITaskManager>();
+
+        // The well-known endpoint is always public so clients can discover agents and auth requirements.
+        routes.MapGet("/.well-known/agent-card.json", A2AWellKnownEndpointHandler.HandleAsync);
+
+        // Always apply the authorization policy. The A2AHostAuthorizationHandler dynamically
+        // checks A2AHostOptions.AuthenticationType on every request, allowing the "None" mode
+        // to pass through without credentials.
+        routes.MapA2A(taskManager, "a2a")
+            .RequireAuthorization(A2AHostPolicyName);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/ViewModels/A2AConnectionFieldsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/ViewModels/A2AConnectionFieldsViewModel.cs
@@ -1,0 +1,69 @@
+using CrestApps.OrchardCore.AI.A2A.Models;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace CrestApps.OrchardCore.AI.A2A.ViewModels;
+
+public class A2AConnectionFieldsViewModel
+{
+    public string DisplayText { get; set; }
+
+    public string Endpoint { get; set; }
+
+    public A2AClientAuthenticationType AuthenticationType { get; set; }
+
+    // API Key.
+    public string ApiKeyHeaderName { get; set; }
+
+    public string ApiKeyPrefix { get; set; }
+
+    public string ApiKey { get; set; }
+
+    // Basic.
+    public string BasicUsername { get; set; }
+
+    public string BasicPassword { get; set; }
+
+    // OAuth 2.0.
+    public string OAuth2TokenEndpoint { get; set; }
+
+    public string OAuth2ClientId { get; set; }
+
+    public string OAuth2ClientSecret { get; set; }
+
+    public string OAuth2Scopes { get; set; }
+
+    // OAuth 2.0 Private Key JWT.
+    public string OAuth2PrivateKey { get; set; }
+
+    public string OAuth2KeyId { get; set; }
+
+    // OAuth 2.0 mTLS.
+    public string OAuth2ClientCertificate { get; set; }
+
+    public string OAuth2ClientCertificatePassword { get; set; }
+
+    // Custom headers.
+    public string AdditionalHeaders { get; set; }
+
+    // Read-only flags for secured placeholder display.
+    [BindNever]
+    public bool HasApiKey { get; set; }
+
+    [BindNever]
+    public bool HasBasicPassword { get; set; }
+
+    [BindNever]
+    public bool HasOAuth2ClientSecret { get; set; }
+
+    [BindNever]
+    public bool HasOAuth2PrivateKey { get; set; }
+
+    [BindNever]
+    public bool HasOAuth2ClientCertificate { get; set; }
+
+    [BindNever]
+    public bool HasOAuth2ClientCertificatePassword { get; set; }
+
+    [BindNever]
+    public string Schema { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/ViewModels/ChatInteractionA2AConnectionsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/ViewModels/ChatInteractionA2AConnectionsViewModel.cs
@@ -1,0 +1,8 @@
+using CrestApps.OrchardCore.AI.Core.Models;
+
+namespace CrestApps.OrchardCore.AI.A2A.ViewModels;
+
+public class ChatInteractionA2AConnectionsViewModel
+{
+    public ToolEntry[] Connections { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/ViewModels/EditProfileA2AConnectionsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/ViewModels/EditProfileA2AConnectionsViewModel.cs
@@ -1,0 +1,8 @@
+using CrestApps.OrchardCore.AI.Core.Models;
+
+namespace CrestApps.OrchardCore.AI.A2A.ViewModels;
+
+public class EditProfileA2AConnectionsViewModel
+{
+    public ToolEntry[] Connections { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/A2AConnection.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/A2AConnection.Edit.cshtml
@@ -1,0 +1,1 @@
+@await DisplayAsync(Model.Content)

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/A2AConnection.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/A2AConnection.SummaryAdmin.cshtml
@@ -1,0 +1,56 @@
+<div class="row g-0">
+    <div class="col-lg col-12 title d-flex align-items-center">
+
+        <div class="summary">
+            <div class="d-flex flex-column flex-md-row">
+                <div class="me-2">
+                    @if (Model.Content != null)
+                    {
+                        @await DisplayAsync(Model.Content)
+                    }
+                </div>
+
+                @if (Model.Tags != null)
+                {
+                    <div class="tags me-1">
+                        @await DisplayAsync(Model.Tags)
+                    </div>
+                }
+                @if (Model.Meta != null)
+                {
+                    <div class="metadata me-1">
+                        @await DisplayAsync(Model.Meta)
+                    </div>
+                }
+            </div>
+
+            @if (Model.Description != null)
+            {
+                <div>
+                    @await DisplayAsync(Model.Description)
+                </div>
+            }
+        </div>
+
+    </div>
+    <div class="col-lg-auto col-12 d-flex justify-content-end align-items-center">
+        <div class="actions">
+            @if (Model.Actions != null)
+            {
+                @await DisplayAsync(Model.Actions)
+            }
+
+            @if (Model.ActionsMenu != null && Model.ActionsMenu.HasItems)
+            {
+                <div class="btn-group" title="@T["Actions"]">
+                    <button type="button" class="btn btn-sm btn-secondary dropdown-toggle actions" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span>@T["Actions"]</span>
+                    </button>
+                    <ul class="actions-menu dropdown-menu dropdown-menu-end">
+                        @await DisplayAsync(Model.ActionsMenu)
+                    </ul>
+                </div>
+            }
+        </div>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/A2AConnectionFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/A2AConnectionFields.Edit.cshtml
@@ -1,0 +1,306 @@
+@using CrestApps.OrchardCore.AI.A2A.Models
+@using CrestApps.OrchardCore.AI.A2A.ViewModels
+@using OrchardCore
+
+@model A2AConnectionFieldsViewModel
+
+@{
+    var securedPlaceholder = T["Securely stored — leave blank to keep, or enter new value"];
+}
+
+<div class="@Orchard.GetWrapperClasses()">
+    <label asp-for="DisplayText" class="@Orchard.GetLabelClasses()">@T["Title"]</label>
+    <div class="@Orchard.GetEndClasses()">
+        <input type="text" asp-for="DisplayText" class="form-control" />
+        <span asp-validation-for="DisplayText" class="text-danger"></span>
+        <span class="hint">@T["The display name for the A2A connection."]</span>
+    </div>
+</div>
+
+<div class="@Orchard.GetWrapperClasses()">
+    <label asp-for="Endpoint" class="@Orchard.GetLabelClasses()">@T["Endpoint"]</label>
+    <div class="@Orchard.GetEndClasses()">
+        <input type="url" asp-for="Endpoint" class="form-control" placeholder="https://example.com" />
+        <span asp-validation-for="Endpoint" class="text-danger"></span>
+        <span class="hint">@T["The base URL of the A2A host (e.g., https://example.com). The agent card will be resolved at /.well-known/agent-card.json."]</span>
+    </div>
+</div>
+
+<div class="@Orchard.GetWrapperClasses()">
+    <label asp-for="AuthenticationType" class="@Orchard.GetLabelClasses()">@T["Authentication"]</label>
+    <div class="@Orchard.GetEndClasses()">
+        <select asp-for="AuthenticationType" class="form-select">
+            <option value="@A2AClientAuthenticationType.Anonymous">@T["Anonymous (No Authentication)"]</option>
+            <option value="@A2AClientAuthenticationType.ApiKey">@T["API Key"]</option>
+            <option value="@A2AClientAuthenticationType.Basic">@T["Basic Authentication"]</option>
+            <option value="@A2AClientAuthenticationType.OAuth2ClientCredentials">@T["OAuth 2.0 Client Credentials"]</option>
+            <option value="@A2AClientAuthenticationType.OAuth2PrivateKeyJwt">@T["OAuth 2.0 + Private Key JWT"]</option>
+            <option value="@A2AClientAuthenticationType.OAuth2Mtls">@T["OAuth 2.0 + Mutual TLS (mTLS)"]</option>
+            <option value="@A2AClientAuthenticationType.CustomHeaders">@T["Custom Headers (Advanced)"]</option>
+        </select>
+        <span class="hint">@T["Select the authentication method to use when connecting to the A2A host."]</span>
+    </div>
+</div>
+
+@* API Key Fields *@
+<div class="d-none authentication-type-dependent authentication-type-dependent-@A2AClientAuthenticationType.ApiKey">
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="ApiKeyHeaderName" class="@Orchard.GetLabelClasses()">@T["Header Name"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="ApiKeyHeaderName" class="form-control" placeholder="Authorization" />
+            <span class="hint">@T["The HTTP header name. Defaults to 'Authorization' if left empty."]</span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="ApiKeyPrefix" class="@Orchard.GetLabelClasses()">@T["Key Prefix"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="ApiKeyPrefix" class="form-control" placeholder="Bearer" />
+            <span class="hint">@T["Optional prefix prepended to the key (e.g., 'Bearer', 'ApiKey')."]</span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="ApiKey" class="@Orchard.GetLabelClasses()">@T["API Key"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="password" asp-for="ApiKey" class="form-control" autocomplete="off" placeholder="@(Model.HasApiKey? securedPlaceholder : string.Empty)" />
+            <span asp-validation-for="ApiKey" class="text-danger"></span>
+        </div>
+    </div>
+</div>
+
+@* Basic Authentication Fields *@
+<div class="d-none authentication-type-dependent authentication-type-dependent-@A2AClientAuthenticationType.Basic">
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="BasicUsername" class="@Orchard.GetLabelClasses()">@T["Username"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="BasicUsername" class="form-control" autocomplete="off" />
+            <span asp-validation-for="BasicUsername" class="text-danger"></span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="BasicPassword" class="@Orchard.GetLabelClasses()">@T["Password"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="password" asp-for="BasicPassword" class="form-control" autocomplete="off" placeholder="@(Model.HasBasicPassword? securedPlaceholder : string.Empty)" />
+            <span asp-validation-for="BasicPassword" class="text-danger"></span>
+        </div>
+    </div>
+</div>
+
+@* OAuth 2.0 Client Credentials Fields *@
+<div class="d-none authentication-type-dependent authentication-type-dependent-@A2AClientAuthenticationType.OAuth2ClientCredentials">
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2TokenEndpoint" class="@Orchard.GetLabelClasses()">@T["Token Endpoint"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="url" asp-for="OAuth2TokenEndpoint" class="form-control" placeholder="https://auth.example.com/oauth2/token" />
+            <span asp-validation-for="OAuth2TokenEndpoint" class="text-danger"></span>
+            <span class="hint">@T["The OAuth 2.0 token endpoint URL."]</span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2ClientId" class="@Orchard.GetLabelClasses()">@T["Client ID"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="OAuth2ClientId" class="form-control" autocomplete="off" />
+            <span asp-validation-for="OAuth2ClientId" class="text-danger"></span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2ClientSecret" class="@Orchard.GetLabelClasses()">@T["Client Secret"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="password" asp-for="OAuth2ClientSecret" class="form-control" autocomplete="off" placeholder="@(Model.HasOAuth2ClientSecret? securedPlaceholder : string.Empty)" />
+            <span asp-validation-for="OAuth2ClientSecret" class="text-danger"></span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2Scopes" class="@Orchard.GetLabelClasses()">@T["Scopes"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="OAuth2Scopes" class="form-control" placeholder="api read write" />
+            <span class="hint">@T["Optional space-separated list of scopes to request."]</span>
+        </div>
+    </div>
+</div>
+
+@* OAuth 2.0 Private Key JWT Fields *@
+<div class="d-none authentication-type-dependent authentication-type-dependent-@A2AClientAuthenticationType.OAuth2PrivateKeyJwt">
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2TokenEndpoint" class="@Orchard.GetLabelClasses()">@T["Token Endpoint"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="url" asp-for="OAuth2TokenEndpoint" class="form-control" placeholder="https://auth.example.com/oauth2/token" />
+            <span asp-validation-for="OAuth2TokenEndpoint" class="text-danger"></span>
+            <span class="hint">@T["The OAuth 2.0 token endpoint URL."]</span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2ClientId" class="@Orchard.GetLabelClasses()">@T["Client ID"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="OAuth2ClientId" class="form-control" autocomplete="off" />
+            <span asp-validation-for="OAuth2ClientId" class="text-danger"></span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2PrivateKey" class="@Orchard.GetLabelClasses()">@T["Private Key (PEM)"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <textarea asp-for="OAuth2PrivateKey" class="form-control" rows="4" autocomplete="off" placeholder="@(Model.HasOAuth2PrivateKey? securedPlaceholder : T["-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"])"></textarea>
+            <span asp-validation-for="OAuth2PrivateKey" class="text-danger"></span>
+            <span class="hint">@T["The PEM-encoded RSA or EC private key used to sign the JWT client assertion."]</span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2KeyId" class="@Orchard.GetLabelClasses()">@T["Key ID (kid)"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="OAuth2KeyId" class="form-control" />
+            <span class="hint">@T["Optional key identifier included in the JWT header. Required by some identity providers."]</span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2Scopes" class="@Orchard.GetLabelClasses()">@T["Scopes"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="OAuth2Scopes" class="form-control" placeholder="api read write" />
+            <span class="hint">@T["Optional space-separated list of scopes to request."]</span>
+        </div>
+    </div>
+</div>
+
+@* OAuth 2.0 Mutual TLS (mTLS) Fields *@
+<div class="d-none authentication-type-dependent authentication-type-dependent-@A2AClientAuthenticationType.OAuth2Mtls">
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2TokenEndpoint" class="@Orchard.GetLabelClasses()">@T["Token Endpoint"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="url" asp-for="OAuth2TokenEndpoint" class="form-control" placeholder="https://auth.example.com/oauth2/token" />
+            <span asp-validation-for="OAuth2TokenEndpoint" class="text-danger"></span>
+            <span class="hint">@T["The OAuth 2.0 token endpoint URL."]</span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2ClientId" class="@Orchard.GetLabelClasses()">@T["Client ID"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="OAuth2ClientId" class="form-control" autocomplete="off" />
+            <span asp-validation-for="OAuth2ClientId" class="text-danger"></span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2ClientCertificate" class="@Orchard.GetLabelClasses()">@T["Client Certificate (Base64 PFX)"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <textarea asp-for="OAuth2ClientCertificate" class="form-control" rows="4" autocomplete="off" placeholder="@(Model.HasOAuth2ClientCertificate? securedPlaceholder : string.Empty)"></textarea>
+            <span asp-validation-for="OAuth2ClientCertificate" class="text-danger"></span>
+            <span class="hint">@T["The Base64-encoded PFX/PKCS#12 client certificate."]</span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2ClientCertificatePassword" class="@Orchard.GetLabelClasses()">@T["Certificate Password"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="password" asp-for="OAuth2ClientCertificatePassword" class="form-control" autocomplete="off" placeholder="@(Model.HasOAuth2ClientCertificatePassword? securedPlaceholder : string.Empty)" />
+            <span asp-validation-for="OAuth2ClientCertificatePassword" class="text-danger"></span>
+            <span class="hint">@T["Optional password for the PFX certificate file."]</span>
+        </div>
+    </div>
+
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="OAuth2Scopes" class="@Orchard.GetLabelClasses()">@T["Scopes"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <input type="text" asp-for="OAuth2Scopes" class="form-control" placeholder="api read write" />
+            <span class="hint">@T["Optional space-separated list of scopes to request."]</span>
+        </div>
+    </div>
+</div>
+
+@* Custom Headers Fields *@
+<div class="d-none authentication-type-dependent authentication-type-dependent-@A2AClientAuthenticationType.CustomHeaders">
+    <div class="@Orchard.GetWrapperClasses()">
+        <label asp-for="AdditionalHeaders" class="@Orchard.GetLabelClasses()">@T["Additional headers"]</label>
+        <div class="@Orchard.GetEndClasses()">
+            <div class="form-control">
+                <div id="@Html.IdFor(x => x.AdditionalHeaders)_editor" style="min-height: 180px;" dir="@Orchard.CultureDir()" data-schema="@Model.Schema"></div>
+            </div>
+            <textarea asp-for="AdditionalHeaders" hidden></textarea>
+            <span asp-validation-for="AdditionalHeaders" class="text-danger"></span>
+            <span class="hint">@T["Additional HTTP headers as a JSON object (e.g., {0}).", """{"Authorization": "Bearer token"}"""]</span>
+        </div>
+    </div>
+</div>
+
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var authSelect = document.getElementById('@Html.IdFor(x => x.AuthenticationType)');
+
+        if (!authSelect) {
+            return;
+        }
+
+        function toggleSections() {
+            var allSections = document.querySelectorAll('.authentication-type-dependent');
+            for (var i = 0; i < allSections.length; i++) {
+                allSections[i].classList.add('d-none');
+
+                if (allSections[i].classList.contains('authentication-type-dependent-' + authSelect.value)) {
+                    allSections[i].classList.remove('d-none');
+                }
+            }
+        }
+
+        authSelect.addEventListener('change', toggleSections);
+        toggleSections();
+    });
+</script>
+
+<script at="Foot" asp-name="monaco"></script>
+<script at="Foot" asp-name="a2a-connection-editor" depends-on="monaco">
+    document.addEventListener('DOMContentLoaded', function() {
+
+        require(['vs/editor/editor.main'], function () {
+
+            var html = document.documentElement;
+            const mutationObserver = new MutationObserver(setTheme);
+            mutationObserver.observe(html, { attributes: true });
+
+            function setTheme() {
+                var theme = html.dataset.bsTheme;
+                if (theme === 'dark' || (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                    monaco.editor.setTheme('vs-dark')
+                } else {
+                    monaco.editor.setTheme('vs')
+                }
+            }
+
+            setTheme();
+
+            var modelUri = monaco.Uri.parse("x://crestapps.orchardcore.ai.a2a.additionalheaders.json");
+            var editorContainer = document.getElementById('@Html.IdFor(x => x.AdditionalHeaders)_editor');
+            var textArea = document.getElementById('@Html.IdFor(x => x.AdditionalHeaders)');
+            var schema = JSON.parse(editorContainer.dataset.schema)
+            var model = monaco.editor.createModel(textArea.value, "json", modelUri);
+
+            monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+                validate: true,
+                schemas: [{
+                    uri: "x://crestapps.orchardcore.ai.a2a.additionalheaders.schema.json",
+                    fileMatch: [modelUri.toString()],
+                    schema: schema
+                }]
+            });
+
+            var editor = monaco.editor.create(editorContainer, {
+                model: model
+            });
+
+            new ResizeObserver(function () {
+                editor.layout();
+            }).observe(editorContainer);
+
+            window.addEventListener("submit", function () {
+                textArea.value = editor.getValue();
+            });
+        });
+    });
+</script>

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/ChatInteractionA2AConnections.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/ChatInteractionA2AConnections.Edit.cshtml
@@ -1,0 +1,19 @@
+@using CrestApps.OrchardCore.AI.A2A.ViewModels
+
+@model ChatInteractionA2AConnectionsViewModel
+
+@if (Model.Connections is not null && Model.Connections.Length > 0)
+{
+    <h5 class="border-bottom pb-2">@T["A2A Connections"]</h5>
+
+    <div class="mb-3">
+        @for (var i = 0; i < Model.Connections.Length; i++)
+        {
+            <div class="form-check">
+                <input type="hidden" asp-for="Connections[i].ItemId" />
+                <input asp-for="Connections[i].IsSelected" type="checkbox" class="form-check-input">
+                <label class="form-check-label" asp-for="Connections[i].IsSelected">@Model.Connections[i].DisplayText</label>
+            </div>
+        }
+    </div>
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Connections/Create.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Connections/Create.cshtml
@@ -1,0 +1,19 @@
+@using CrestApps.OrchardCore.Core.Models
+
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["New A2A Connection"])</h1>
+</zone>
+
+<form method="post" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <button class="btn btn-primary" type="submit">@T["Save"]</button>
+
+    <a class="btn btn-secondary cancel"
+       role="button"
+       asp-route-action="Index"
+       asp-route-controller="Connections">@T["Cancel"]</a>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Connections/Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Connections/Edit.cshtml
@@ -1,0 +1,19 @@
+@using CrestApps.OrchardCore.Core.Models
+
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["Edit A2A Connection"])</h1>
+</zone>
+
+<form method="post" asp-route-id="@ViewContext.HttpContext.Request.RouteValues["id"]" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <button class="btn btn-primary" type="submit">@T["Save"]</button>
+
+    <a class="btn btn-secondary cancel"
+       role="button"
+       asp-route-action="Index"
+       asp-route-controller="Connections">@T["Cancel"]</a>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Connections/Index.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Connections/Index.cshtml
@@ -1,0 +1,106 @@
+@using CrestApps.OrchardCore.AI.A2A.Models
+@using CrestApps.OrchardCore.Core.Models
+@using Microsoft.AspNetCore.Mvc.Localization
+@using OrchardCore.DisplayManagement
+
+@model ListCatalogEntryViewModel<CatalogEntryViewModel<A2AConnection>>
+
+<zone Name="Title"><h1>@RenderTitleSegments(T["A2A Connections"])</h1></zone>
+
+@* The form is necessary to generate an antiforgery token for the delete and toggle actions. *@
+<form asp-action="Index" method="post" class="no-multisubmit">
+    <input type="submit" name="submit.Filter" id="submitFilter" class="visually-hidden" />
+    <input asp-for="Options.BulkAction" type="hidden" />
+    <input type="submit" name="submit.BulkAction" class="visually-hidden" />
+
+    <div class="card text-bg-theme mb-3 position-sticky action-bar">
+        <div class="card-body">
+            <div class="row gx-3">
+                <div class="col">
+                    <div class="has-search">
+                        <i class="fa-solid fa-search form-control-feedback" aria-hidden="true"></i>
+                        <input id="search-box" asp-for="Options.Search" class="form-control" placeholder="@T["Search"]" type="search" autofocus autocomplete="off" />
+                    </div>
+                </div>
+                <div class="col-auto">
+                    <a class="btn btn-secondary create" role="button" asp-action="Create">@T["Add Connection"]</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <ul class="list-group with-checkbox" id="rewrite-rules-sortable-list">
+        @if (Model.Models.Count > 0)
+        {
+            int startIndex = 0;
+            int endIndex = startIndex + Model.Models.Count - 1;
+
+            <li class="list-group-item text-bg-theme ignore-elements">
+                <div class="row gx-3">
+                    <div class="col">
+                        <div class="form-check my-1">
+                            <input type="checkbox" class="form-check-input" id="select-all">
+                            <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
+                            <label id="items" for="select-all">
+                                @T.Plural(Model.Models.Count, "1 item", "{0} items")
+                                <span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">
+                                    @T.Plural(Model.Models.Count, " / {0} item in total", " / {0} items in total")
+                                </span>
+                            </label>
+                            <label id="selected-items" class="text-muted" for="select-all"></label>
+                        </div>
+                    </div>
+                    <div class="col-auto">
+                        <div class="dropdown d-none" id="actions">
+                            <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                @T["Actions"]
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                                @foreach (var item in Model.Options.BulkActions)
+                                {
+                                    <li>
+                                        <a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a>
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </li>
+            @foreach (var entry in Model.Models)
+            {
+                <li class="list-group-item item d-flex justify-content-between align-items-center" data-filter-value="@entry.Model.DisplayText?.ToLowerInvariant()">
+                    <div class="d-flex flex-row">
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" value="@entry.Model.ItemId" name="itemIds" id="itemIds-@entry.Model.ItemId">
+                            <label class="form-check-label" for="itemIds-@entry.Model.ItemId">&nbsp;</label>
+                        </div>
+                    </div>
+
+                    <div class="flex-grow-1">
+                        @await DisplayAsync(entry.Shape)
+                    </div>
+                </li>
+            }
+        }
+        else
+        {
+            <li class="list-group-item list-group-item-info text-center ignore-elements">
+                @T["<strong>Nothing here!</strong> There are no connections at the moment."]
+            </li>
+        }
+    </ul>
+
+    <div id="list-alert" class="alert alert-info my-3 d-none text-center" role="alert">
+        @T["Your search returned no results."]
+    </div>
+
+</form>
+
+<script asp-name="list-management-ui" at="Foot"></script>
+
+<script at="Foot" depends-on="list-management-ui">
+    document.addEventListener('DOMContentLoaded', () => {
+        listManagementUI.initialize('@T["selected"]', { clientSideSearch: true });
+    });
+</script>

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/EditProfileA2AConnection.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/EditProfileA2AConnection.Edit.cshtml
@@ -1,0 +1,19 @@
+@using CrestApps.OrchardCore.AI.A2A.ViewModels
+
+@model EditProfileA2AConnectionsViewModel
+
+@if (Model.Connections is not null && Model.Connections.Length > 0)
+{
+    <h5 class="border-bottom pb-2">@T["A2A Connections"]</h5>
+
+    <div class="mb-3">
+        @for (var i = 0; i < Model.Connections.Length; i++)
+        {
+            <div class="form-check">
+                <input type="hidden" asp-for="Connections[i].ItemId" />
+                <input asp-for="Connections[i].IsSelected" type="checkbox" class="form-check-input">
+                <label class="form-check-label" asp-for="Connections[i].IsSelected">@Model.Connections[i].DisplayText</label>
+            </div>
+        }
+    </div>
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Items/A2AConnection.Buttons.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Items/A2AConnection.Buttons.SummaryAdmin.cshtml
@@ -1,0 +1,13 @@
+@using CrestApps.OrchardCore.AI.A2A.Models
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<A2AConnection>
+
+<a asp-action="Edit"
+   asp-route-id="@Model.Value.ItemId"
+   class="btn btn-primary btn-sm">@T["Edit"]</a>
+
+<a asp-action="Delete"
+   asp-route-id="@Model.Value.ItemId"
+   class="btn btn-danger btn-sm"
+   data-url-af="RemoveUrl UnsafeUrl">@T["Delete"]</a>

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Items/A2AConnection.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Items/A2AConnection.DefaultMeta.SummaryAdmin.cshtml
@@ -1,0 +1,27 @@
+@using System.Globalization
+@using CrestApps.OrchardCore.AI.A2A.Models
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<A2AConnection>
+
+@{
+    var createdAt = Model.Value.CreatedUtc.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture);
+}
+
+<span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.CreatedUtc, Format: "g"))">
+    <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i>
+    <time datetime="@createdAt">@await DisplayAsync(await New.Timespan(Utc: Model.Value.CreatedUtc))</time>
+</span>
+
+@if (!string.IsNullOrEmpty(Model.Value.Endpoint))
+{
+    <span class="badge ta-badge bg-info-subtle font-weight-normal" data-bs-toggle="tooltip" title="@T["Endpoint"]">
+        <i class="fa-solid fa-link text-secondary me-1" aria-hidden="true"></i>
+        @Model.Value.Endpoint
+    </span>
+}
+
+@if (!string.IsNullOrEmpty(Model.Value.Author))
+{
+    <user-display-name user-name="@(Model.Value.Author)" display-type="SummaryAdmin" cache-id="user-display-name-author" />
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Items/A2AConnection.Fields.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/Items/A2AConnection.Fields.SummaryAdmin.cshtml
@@ -1,0 +1,6 @@
+@using CrestApps.OrchardCore.AI.A2A.Models
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<A2AConnection>
+
+<h5>@(Model.Value.DisplayText)</h5>

--- a/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/_ViewImports.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.A2A/Views/_ViewImports.cshtml
@@ -1,0 +1,9 @@
+@inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>
+
+@using OrchardCore.DisplayManagement
+@using OrchardCore.DisplayManagement.Views
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, OrchardCore.DisplayManagement
+@addTagHelper *, OrchardCore.ResourceManagement
+@addTagHelper *, OrchardCore.Contents.TagHelpers

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Startup.cs
@@ -340,15 +340,11 @@ public sealed class McpServerStartup : StartupBase
 
     public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
     {
-        var mcpServerOptions = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
-
-        var endpoint = routes.MapMcp("mcp");
-
-        // Only require authorization if not using anonymous access.
-        if (mcpServerOptions.AuthenticationType != McpServerAuthenticationType.None)
-        {
-            endpoint.RequireAuthorization(McpServerPolicyName);
-        }
+        // Always apply the authorization policy. The McpServerAuthorizationHandler dynamically
+        // checks McpServerOptions.AuthenticationType on every request, allowing the "None" mode
+        // to pass through without credentials.
+        routes.MapMcp("mcp")
+            .RequireAuthorization(McpServerPolicyName);
     }
 }
 

--- a/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
@@ -1,3 +1,4 @@
+using CrestApps.AI.Prompting.Extensions;
 using CrestApps.OrchardCore.AI.Core;
 using CrestApps.OrchardCore.AI.Core.Handlers;
 using CrestApps.OrchardCore.AI.Core.Models;
@@ -45,6 +46,10 @@ public sealed class Startup : StartupBase
     public override void ConfigureServices(IServiceCollection services)
     {
         services.AddAICoreServices();
+
+        // Register embedded AI templates from this module so they are always
+        // available, even when the AI Prompting feature is not enabled.
+        services.AddAITemplatesFromAssembly(typeof(Startup).Assembly);
         services.AddPermissionProvider<AIPermissionsProvider>();
         services.Configure<TemplateOptions>(o =>
         {

--- a/src/Startup/CrestApps.Aspire.AppHost/CrestApps.Aspire.AppHost.csproj
+++ b/src/Startup/CrestApps.Aspire.AppHost/CrestApps.Aspire.AppHost.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CrestApps.OrchardCore.Cms.Web\CrestApps.OrchardCore.Cms.Web.csproj" />
+    <ProjectReference Include="..\CrestApps.OrchardCore.Samples.A2AClient\CrestApps.OrchardCore.Samples.A2AClient.csproj" />
     <ProjectReference Include="..\CrestApps.OrchardCore.Samples.McpClient\CrestApps.OrchardCore.Samples.McpClient.csproj" />
   </ItemGroup>
 

--- a/src/Startup/CrestApps.Aspire.AppHost/Program.cs
+++ b/src/Startup/CrestApps.Aspire.AppHost/Program.cs
@@ -9,7 +9,7 @@ var ollama = builder.AddOllama("Ollama")
 
 ollama.AddModel(ollamaModelName);
 
-var password = builder.AddParameter("Password", secret: true);
+// var password = builder.AddParameter("Password", secret: true);
 
 // var elasticsearch = builder.AddElasticsearch("Elasticsearch", password)
 //     .WithDataVolume()
@@ -57,6 +57,12 @@ var orchardCore = builder.AddProject<Projects.CrestApps_OrchardCore_Cms_Web>("Or
         // options.EnvironmentVariables.Add("OrchardCore__CrestApps_OrchardCore_AI_Chat_Copilot__ApiKey", "<your-api-key>");
         // options.EnvironmentVariables.Add("OrchardCore__CrestApps_OrchardCore_AI_Chat_Copilot__DefaultModel", "gpt-4o");
         // options.EnvironmentVariables.Add("OrchardCore__CrestApps_OrchardCore_AI_Chat_Copilot__AzureApiVersion", "2024-10-21");
+
+        // Configure authentication for sample projects.
+        // Set to "None" so the sample MCP and A2A clients can connect without tokens.
+        options.EnvironmentVariables.Add("OrchardCore__CrestApps_AI__McpServer__AuthenticationType", "None");
+        options.EnvironmentVariables.Add("OrchardCore__CrestApps_AI__A2AHost__AuthenticationType", "None");
+        options.EnvironmentVariables.Add("OrchardCore__CrestApps_AI__A2AHost__ExposeAgentsAsSkill", "true");
     });
 
 builder.AddProject<Projects.CrestApps_OrchardCore_Samples_McpClient>("McpClientSample")
@@ -64,6 +70,12 @@ builder.AddProject<Projects.CrestApps_OrchardCore_Samples_McpClient>("McpClientS
     .WaitFor(orchardCore)
     .WithHttpsEndpoint(5002, name: "HttpsMcpClient")
     .WithEnvironment("Mcp__Endpoint", "https://localhost:5001/mcp/sse");
+
+builder.AddProject<Projects.CrestApps_OrchardCore_Samples_A2AClient>("A2AClientSample")
+    .WithReference(orchardCore)
+    .WaitFor(orchardCore)
+    .WithHttpsEndpoint(5003, name: "HttpsA2AClient")
+    .WithEnvironment("A2A__Endpoint", "https://localhost:5001");
 
 var app = builder.Build();
 

--- a/src/Startup/CrestApps.OrchardCore.Cms.Web/appsettings.development.json
+++ b/src/Startup/CrestApps.OrchardCore.Cms.Web/appsettings.development.json
@@ -8,10 +8,14 @@
   },
   "OrchardCore": {
     "CrestApps_AI": {
-      "McpServer": {
-        "AuthenticationType": "None", // Options: None, ApiKey, OpenId
-        "ApiKey": null
-      }
+      // McpServer and A2AHost default to OpenId authentication.
+      // Uncomment below to disable auth for local testing:
+      // "McpServer": {
+      //   "AuthenticationType": "None"
+      // },
+      // "A2AHost": {
+      //   "AuthenticationType": "None"
+      // }
     }
   }
 }

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/CrestApps.OrchardCore.Samples.A2AClient.csproj
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/CrestApps.OrchardCore.Samples.A2AClient.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="A2A" />
+  </ItemGroup>
+
+</Project>

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Agents.cshtml
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Agents.cshtml
@@ -1,0 +1,264 @@
+@page
+@model CrestApps.OrchardCore.Samples.A2AClient.Pages.AgentsModel
+@using System.Text.Json
+
+<h1>Agents</h1>
+
+@if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+{
+    <div class="alert alert-danger" role="alert">
+        @Model.ErrorMessage
+    </div>
+}
+
+<div class="d-flex align-items-center gap-3 mb-3">
+    <p class="text-muted mb-0">Agents exposed by the A2A host that can receive messages.</p>
+    <form method="post" asp-page-handler="Refresh" class="d-inline">
+        <button class="btn btn-secondary btn-sm" type="submit">Refresh</button>
+    </form>
+</div>
+
+@if (Model.AgentCards.Count > 0)
+{
+    <div class="mb-3">
+        <input type="text" id="agentSearch" class="form-control" placeholder="Search agents by name or description…" />
+    </div>
+
+    <div class="accordion" id="agentsAccordion">
+        @for (var i = 0; i < Model.AgentCards.Count; i++)
+        {
+            var card = Model.AgentCards[i];
+            var collapseId = $"collapse-agent-{i}";
+            var headerId = $"header-agent-{i}";
+            var resultId = $"result-agent-{i}";
+            var hasSkills = card.Skills?.Count > 0;
+
+            <div class="accordion-item searchable-item" data-search-text="@card.Name?.ToLowerInvariant() @card.Description?.ToLowerInvariant()">
+                <h2 class="accordion-header" id="@headerId">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@collapseId">
+                        <span class="fw-semibold">@(card.Name ?? "Unknown Agent")</span>
+                        @if (!string.IsNullOrWhiteSpace(card.Description))
+                        {
+                            <span class="text-muted ms-2">— @card.Description</span>
+                        }
+                    </button>
+                </h2>
+                <div id="@collapseId" class="accordion-collapse collapse" data-bs-parent="#agentsAccordion">
+                    <div class="accordion-body">
+                        @if (!string.IsNullOrWhiteSpace(card.Version))
+                        {
+                            <small class="text-muted d-block mb-2">Version: @card.Version</small>
+                        }
+
+                        @if (hasSkills)
+                        {
+                            <div class="mb-3">
+                                <strong class="d-block mb-1">Skills:</strong>
+                                @foreach (var skill in card.Skills)
+                                {
+                                    <span class="badge bg-info me-1">@(skill.Name ?? skill.Id)</span>
+                                }
+                            </div>
+                        }
+
+                        <div class="agent-form" data-agent-url="@card.Url" data-agent-name="@card.Name" data-result-target="#@resultId">
+                            <div class="mb-2">
+                                <label class="form-label small mb-0">Message <span class="text-danger">*</span></label>
+                                <textarea class="form-control form-control-sm agent-message" rows="3" placeholder="Type a message to send to this agent…" required></textarea>
+                            </div>
+                            <div class="d-flex align-items-center gap-3">
+                                <button class="btn btn-primary btn-sm btn-send-message" type="button">Send Message</button>
+                                <div class="form-check">
+                                    <input class="form-check-input agent-stream-check" type="checkbox" id="stream-@i">
+                                    <label class="form-check-label small" for="stream-@i">Stream response</label>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div id="@resultId" class="mt-3" style="display:none">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
+    <p class="text-muted mt-2" id="agentNoResults" style="display:none">No agents match your search.</p>
+}
+else if (string.IsNullOrWhiteSpace(Model.ErrorMessage))
+{
+    <p class="text-muted">No agents were returned by the A2A host.</p>
+}
+
+<script>
+    (function () {
+        // Handle Send Message button clicks via AJAX.
+        document.querySelectorAll('.btn-send-message').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var form = btn.closest('.agent-form');
+                var agentUrl = form.dataset.agentUrl || '';
+                var agentName = form.dataset.agentName || '';
+                var resultDiv = document.querySelector(form.dataset.resultTarget);
+                var messageInput = form.querySelector('.agent-message');
+                var streamCheck = form.querySelector('.agent-stream-check');
+                var message = messageInput.value.trim();
+                var useStream = streamCheck && streamCheck.checked;
+
+                if (!message) {
+                    messageInput.reportValidity();
+                    return;
+                }
+
+                btn.disabled = true;
+                btn.textContent = 'Sending…';
+                resultDiv.style.display = 'block';
+                resultDiv.innerHTML = '<p class="text-muted">Loading…</p>';
+
+                var formData = new FormData();
+                formData.append('agentUrl', agentUrl);
+                formData.append('agentName', agentName);
+                formData.append('message', message);
+                formData.append('stream', useStream ? 'true' : 'false');
+
+                if (useStream) {
+                    handleStreamingRequest(formData, resultDiv, btn);
+                } else {
+                    handleNonStreamingRequest(formData, resultDiv, btn);
+                }
+            });
+        });
+
+        function handleNonStreamingRequest(formData, resultDiv, btn) {
+            fetch('?handler=SendMessage', {
+                method: 'POST',
+                headers: {
+                    'RequestVerificationToken': document.querySelector('input[name="__RequestVerificationToken"]')?.value || ''
+                },
+                body: formData
+            })
+            .then(function (response) { return response.json(); })
+            .then(function (data) {
+                if (data.error) {
+                    resultDiv.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(data.error) + '</div>';
+                    return;
+                }
+                if (!data.response) {
+                    resultDiv.innerHTML = '<p class="text-muted mb-0">No response returned.</p>';
+                    return;
+                }
+                resultDiv.innerHTML = '<pre class="bg-light p-3 rounded mb-2" style="max-height:400px;overflow:auto">' + escapeHtml(data.response) + '</pre>';
+            })
+            .catch(function (err) {
+                resultDiv.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(err.message || 'An error occurred.') + '</div>';
+            })
+            .finally(function () {
+                btn.disabled = false;
+                btn.textContent = 'Send Message';
+            });
+        }
+
+        function handleStreamingRequest(formData, resultDiv, btn) {
+            resultDiv.innerHTML = '<pre class="bg-light p-3 rounded mb-2" style="max-height:400px;overflow:auto"></pre>';
+            var pre = resultDiv.querySelector('pre');
+
+            fetch('?handler=SendMessage', {
+                method: 'POST',
+                headers: {
+                    'RequestVerificationToken': document.querySelector('input[name="__RequestVerificationToken"]')?.value || ''
+                },
+                body: formData
+            })
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error('Server returned ' + response.status);
+                }
+
+                var contentType = response.headers.get('content-type') || '';
+
+                // If the server returned JSON instead of SSE (e.g. error), handle it.
+                if (contentType.indexOf('application/json') !== -1) {
+                    return response.json().then(function (data) {
+                        if (data.error) {
+                            resultDiv.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(data.error) + '</div>';
+                        }
+                    });
+                }
+
+                // Process the SSE stream.
+                var reader = response.body.getReader();
+                var decoder = new TextDecoder();
+                var buffer = '';
+
+                function processChunk(result) {
+                    if (result.done) return;
+
+                    buffer += decoder.decode(result.value, { stream: true });
+
+                    // Parse SSE events from the buffer.
+                    var lines = buffer.split('\n');
+                    buffer = lines.pop(); // Keep incomplete last line in buffer.
+
+                    for (var i = 0; i < lines.length; i++) {
+                        var line = lines[i];
+
+                        if (line.indexOf('data: ') === 0) {
+                            var data = line.substring(6);
+
+                            if (data === '[DONE]') {
+                                return;
+                            }
+
+                            if (data.indexOf('[ERROR]') === 0) {
+                                var errorMsg = data.substring(7) || 'An error occurred during streaming.';
+                                resultDiv.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(errorMsg) + '</div>';
+                                return;
+                            }
+
+                            pre.textContent += data;
+                            pre.scrollTop = pre.scrollHeight;
+                        }
+                    }
+
+                    return reader.read().then(processChunk);
+                }
+
+                return reader.read().then(processChunk);
+            })
+            .catch(function (err) {
+                if (!resultDiv.querySelector('.alert-danger')) {
+                    resultDiv.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(err.message || 'An error occurred.') + '</div>';
+                }
+            })
+            .finally(function () {
+                btn.disabled = false;
+                btn.textContent = 'Send Message';
+            });
+        }
+
+        // Client-side search.
+        var searchInput = document.getElementById('agentSearch');
+        if (!searchInput) return;
+        var items = document.querySelectorAll('#agentsAccordion .searchable-item');
+        var noResults = document.getElementById('agentNoResults');
+        searchInput.addEventListener('input', function () {
+            var query = this.value.toLowerCase().trim();
+            var visible = 0;
+            items.forEach(function (item) {
+                var match = !query || item.dataset.searchText.indexOf(query) !== -1;
+                item.style.display = match ? '' : 'none';
+                if (match) visible++;
+            });
+            noResults.style.display = visible === 0 && query ? '' : 'none';
+        });
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.appendChild(document.createTextNode(text));
+            return div.innerHTML;
+        }
+    })();
+</script>
+
+@* Antiforgery token for AJAX calls *@
+<form id="__AjaxAntiForgeryForm" method="post" style="display:none">
+</form>

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Agents.cshtml.cs
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Agents.cshtml.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using A2A;
+using CrestApps.OrchardCore.Samples.A2AClient.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace CrestApps.OrchardCore.Samples.A2AClient.Pages;
+
+public sealed class AgentsModel : PageModel
+{
+    private readonly A2AClientFactory _clientFactory;
+    private readonly ILogger<AgentsModel> _logger;
+
+    public AgentsModel(A2AClientFactory clientFactory, ILogger<AgentsModel> logger)
+    {
+        _clientFactory = clientFactory;
+        _logger = logger;
+    }
+
+    public List<AgentCard> AgentCards { get; private set; } = [];
+
+    public string ErrorMessage { get; private set; }
+
+    public async Task OnGetAsync(CancellationToken cancellationToken)
+    {
+        await LoadAgentCardsAsync(cancellationToken);
+    }
+
+    public async Task<IActionResult> OnPostRefreshAsync(CancellationToken cancellationToken)
+    {
+        await LoadAgentCardsAsync(cancellationToken);
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostSendMessageAsync(string agentUrl, string agentName, string message, bool stream, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return new JsonResult(new { error = "Message is required." });
+        }
+
+        try
+        {
+            var client = _clientFactory.Create(agentUrl);
+
+            var agentMessage = new AgentMessage
+            {
+                Role = MessageRole.User,
+                MessageId = Guid.NewGuid().ToString(),
+                ContextId = Guid.NewGuid().ToString(),
+                Parts = [new TextPart { Text = message }],
+            };
+
+            if (!string.IsNullOrWhiteSpace(agentName))
+            {
+                agentMessage.Metadata = new Dictionary<string, JsonElement>
+                {
+                    ["agentName"] = JsonSerializer.SerializeToElement(agentName),
+                };
+            }
+
+            var sendParams = new MessageSendParams
+            {
+                Message = agentMessage,
+            };
+
+            if (stream)
+            {
+                return new StreamingA2AResult(client, sendParams, _logger);
+            }
+
+            var response = await client.SendMessageAsync(sendParams, cancellationToken);
+
+            var responseText = ExtractTextFromResponse(response);
+
+            return new JsonResult(new { response = responseText ?? "The agent did not produce a text response." });
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+        {
+            _logger.LogWarning(ex, "Authentication failed when communicating with the A2A agent.");
+
+            return new JsonResult(new
+            {
+                error = "Authentication failed (401 Unauthorized). " +
+                        "The A2A host requires authentication. Check the agent card's security schemes for details."
+            });
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+        {
+            _logger.LogWarning(ex, "Access denied when communicating with the A2A agent.");
+
+            return new JsonResult(new
+            {
+                error = "Access denied (403 Forbidden). " +
+                        "You do not have permission to access this agent."
+            });
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return new JsonResult(new
+            {
+                error = "The A2A host returned a 404 Not Found response. " +
+                        "Please ensure the A2A Host feature is enabled on the default tenant " +
+                        "(Configuration > Features > search for 'A2A Host')."
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to communicate with the A2A agent at '{AgentUrl}'.", agentUrl);
+
+            return new JsonResult(new { error = $"An error occurred while communicating with the agent: {ex.Message}" });
+        }
+    }
+
+    private static string ExtractTextFromResponse(A2AResponse response)
+    {
+        if (response is AgentMessage message)
+        {
+            var texts = message.Parts?.OfType<TextPart>().Select(p => p.Text);
+
+            if (texts?.Any() == true)
+            {
+                return string.Join(string.Empty, texts);
+            }
+        }
+        else if (response is AgentTask task)
+        {
+            if (task.Artifacts?.Count > 0)
+            {
+                var artifactTexts = task.Artifacts
+                    .SelectMany(a => a.Parts?.OfType<TextPart>() ?? [])
+                    .Select(p => p.Text);
+
+                var combined = string.Join(string.Empty, artifactTexts);
+
+                if (!string.IsNullOrEmpty(combined))
+                {
+                    return combined;
+                }
+            }
+
+            if (task.Status.Message?.Parts is not null)
+            {
+                var statusTexts = task.Status.Message.Parts.OfType<TextPart>().Select(p => p.Text);
+
+                var combined = string.Join(string.Empty, statusTexts);
+
+                if (!string.IsNullOrEmpty(combined))
+                {
+                    return combined;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private async Task LoadAgentCardsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            AgentCards = await _clientFactory.GetAgentCardsAsync(cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            ErrorMessage = "The A2A host returned a 404 Not Found response. " +
+                           "Please ensure the A2A Host feature is enabled on the default tenant " +
+                           "(Configuration > Features > search for 'A2A Host').";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load agent cards.");
+            ErrorMessage = $"An error occurred while loading agent cards: {ex.Message}";
+        }
+    }
+
+    /// <summary>
+    /// Custom <see cref="IActionResult"/> that streams A2A events as text/event-stream
+    /// so the browser receives chunks incrementally.
+    /// </summary>
+    private sealed class StreamingA2AResult : IActionResult
+    {
+        private readonly A2A.A2AClient _client;
+        private readonly MessageSendParams _sendParams;
+        private readonly ILogger _logger;
+
+        public StreamingA2AResult(A2A.A2AClient client, MessageSendParams sendParams, ILogger logger)
+        {
+            _client = client;
+            _sendParams = sendParams;
+            _logger = logger;
+        }
+
+        public async Task ExecuteResultAsync(ActionContext context)
+        {
+            var httpResponse = context.HttpContext.Response;
+            httpResponse.ContentType = "text/event-stream";
+            httpResponse.Headers.CacheControl = "no-cache";
+            httpResponse.Headers.Connection = "keep-alive";
+
+            var cancellationToken = context.HttpContext.RequestAborted;
+
+            try
+            {
+                await foreach (var sseItem in _client.SendMessageStreamingAsync(_sendParams, cancellationToken))
+                {
+                    var a2aEvent = sseItem.Data;
+                    string chunk = null;
+
+                    if (a2aEvent is TaskArtifactUpdateEvent artifactUpdate)
+                    {
+                        chunk = string.Join(string.Empty,
+                            artifactUpdate.Artifact?.Parts?.OfType<TextPart>().Select(p => p.Text) ?? []);
+                    }
+                    else if (a2aEvent is TaskStatusUpdateEvent statusUpdate)
+                    {
+                        if (statusUpdate.Final)
+                        {
+                            // If the task failed, send the error message.
+                            if (statusUpdate.Status.State == TaskState.Failed)
+                            {
+                                var errorText = statusUpdate.Status.Message?.Parts
+                                    ?.OfType<TextPart>()
+                                    .Select(p => p.Text)
+                                    .FirstOrDefault() ?? "Agent task failed.";
+
+                                await httpResponse.WriteAsync($"data: [ERROR]{errorText}\n\n", cancellationToken);
+                                await httpResponse.Body.FlushAsync(cancellationToken);
+                                break;
+                            }
+
+                            await httpResponse.WriteAsync("data: [DONE]\n\n", cancellationToken);
+                            await httpResponse.Body.FlushAsync(cancellationToken);
+                            break;
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(chunk))
+                    {
+                        var escaped = chunk.Replace("\n", "\ndata: ");
+                        await httpResponse.WriteAsync($"data: {escaped}\n\n", cancellationToken);
+                        await httpResponse.Body.FlushAsync(cancellationToken);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Client disconnected.
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                _logger.LogWarning(ex, "Authentication failed during streaming.");
+                await WriteErrorAsync(httpResponse, "Authentication failed (401 Unauthorized).");
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                _logger.LogWarning(ex, "Access denied during streaming.");
+                await WriteErrorAsync(httpResponse, "Access denied (403 Forbidden).");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during A2A streaming.");
+                await WriteErrorAsync(httpResponse, ex.Message);
+            }
+        }
+
+        private static async Task WriteErrorAsync(HttpResponse httpResponse, string message)
+        {
+            try
+            {
+                await httpResponse.WriteAsync($"data: [ERROR]{message}\n\n", CancellationToken.None);
+                await httpResponse.Body.FlushAsync(CancellationToken.None);
+            }
+            catch
+            {
+                // Response may already be completed.
+            }
+        }
+    }
+}

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Index.cshtml
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Index.cshtml
@@ -1,0 +1,37 @@
+@page
+@model CrestApps.OrchardCore.Samples.A2AClient.Pages.IndexModel
+
+<h1>A2A Client Samples</h1>
+
+<p class="lead">This sample app connects to the A2A host served by <strong>CrestApps.OrchardCore.Cms.Web</strong> and demonstrates listing agents and sending messages.</p>
+
+<div class="card mb-3">
+    <div class="card-body">
+        <h5 class="card-title">Prerequisites</h5>
+        <ol class="mb-0">
+            <li>Start the Aspire AppHost.</li>
+            <li>
+                Enable the <strong>A2A Host</strong> feature on the default tenant.
+                <ul>
+                    <li>Feature ID: <code>CrestApps.OrchardCore.AI.A2A.Host</code></li>
+                    <li>Admin UI: <strong>Tools → Features</strong></li>
+                </ul>
+            </li>
+            <li>Create at least one AI Profile of type <strong>Agent</strong> so the host has agents to expose.</li>
+        </ol>
+    </div>
+</div>
+
+<p>Use the navigation tabs above to explore A2A capabilities:</p>
+
+<div class="row g-3">
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">Agents</h5>
+                <p class="card-text">Discover all agents exposed by the A2A host, view their skills, and send messages.</p>
+                <a asp-page="/Agents" class="btn btn-primary btn-sm">Go to Agents</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Index.cshtml.cs
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Index.cshtml.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace CrestApps.OrchardCore.Samples.A2AClient.Pages;
+
+public sealed class IndexModel : PageModel
+{
+}

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Shared/_Layout.cshtml
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>A2A Client Samples</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+        <div class="container">
+            <a class="navbar-brand" asp-page="/Index">A2A Client</a>
+            <div class="navbar-nav">
+                <a class="nav-link" asp-page="/Index">Home</a>
+                <a class="nav-link" asp-page="/Agents">Agents</a>
+            </div>
+        </div>
+    </nav>
+    <div class="container pb-4">
+        @RenderBody()
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/_ViewImports.cshtml
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/_ViewStart.cshtml
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Program.cs
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Program.cs
@@ -1,0 +1,15 @@
+using CrestApps.OrchardCore.Samples.A2AClient.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton<A2AClientFactory>();
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.MapRazorPages();
+
+await app.RunAsync();

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Properties/launchSettings.json
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "CrestApps.OrchardCore.Samples.A2AClient": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:59396;http://localhost:59397"
+    }
+  }
+}

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Services/A2AClientFactory.cs
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/Services/A2AClientFactory.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using A2A;
+
+namespace CrestApps.OrchardCore.Samples.A2AClient.Services;
+
+public sealed class A2AClientFactory
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IConfiguration _configuration;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public A2AClientFactory(
+        IConfiguration configuration,
+        IHttpClientFactory httpClientFactory)
+    {
+        _configuration = configuration;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public A2A.A2AClient Create(string agentUrl = null)
+    {
+        var url = agentUrl ?? GetEndpoint() + "/a2a";
+        var httpClient = _httpClientFactory.CreateClient();
+
+        return new A2A.A2AClient(new Uri(url), httpClient);
+    }
+
+    public async Task<List<AgentCard>> GetAgentCardsAsync(CancellationToken cancellationToken)
+    {
+        var endpoint = GetEndpoint();
+        var httpClient = _httpClientFactory.CreateClient();
+
+        var cardUrl = $"{endpoint.TrimEnd('/')}/.well-known/agent-card.json";
+        var response = await httpClient.GetAsync(cardUrl, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        // Try to parse as array first (multi-agent mode), then as single card (skill mode).
+        try
+        {
+            var cards = JsonSerializer.Deserialize<List<AgentCard>>(json, _jsonOptions);
+
+            if (cards is not null)
+            {
+                return cards;
+            }
+        }
+        catch (JsonException)
+        {
+            // Not an array, try single card.
+        }
+
+        var singleCard = JsonSerializer.Deserialize<AgentCard>(json, _jsonOptions);
+
+        return singleCard is not null ? [singleCard] : [];
+    }
+
+    private string GetEndpoint()
+    {
+        var endpoint = _configuration["A2A:Endpoint"];
+
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            throw new InvalidOperationException("A2A:Endpoint is not configured.");
+        }
+
+        return endpoint;
+    }
+}

--- a/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/appsettings.json
+++ b/src/Startup/CrestApps.OrchardCore.Samples.A2AClient/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "A2A": {
+    "Endpoint": "https://localhost:5001"
+  }
+}

--- a/src/Startup/CrestApps.OrchardCore.Samples.McpClient/Pages/Index.cshtml
+++ b/src/Startup/CrestApps.OrchardCore.Samples.McpClient/Pages/Index.cshtml
@@ -10,10 +10,11 @@
         <h5 class="card-title">Prerequisites</h5>
         <ol class="mb-0">
             <li>Start the Aspire AppHost.</li>
-            <li>Enable the <strong>MCP Server</strong> feature on the default tenant.
+            <li>
+                Enable the <strong>MCP Server</strong> feature on the default tenant.
                 <ul>
                     <li>Feature ID: <code>CrestApps.OrchardCore.AI.Mcp.Server</code></li>
-                    <li>Admin UI: <strong>Configuration → Features</strong></li>
+                    <li>Admin UI: <strong>Tools → Features</strong></li>
                 </ul>
             </li>
         </ol>

--- a/src/Targets/CrestApps.OrchardCore.Cms.Core.Targets/CrestApps.OrchardCore.Cms.Core.Targets.csproj
+++ b/src/Targets/CrestApps.OrchardCore.Cms.Core.Targets/CrestApps.OrchardCore.Cms.Core.Targets.csproj
@@ -45,6 +45,7 @@
     <ProjectReference Include="..\..\Modules\CrestApps.OrchardCore.AI.Documents.Elasticsearch\CrestApps.OrchardCore.AI.Documents.Elasticsearch.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\Modules\CrestApps.OrchardCore.AI.Documents.OpenXml\CrestApps.OrchardCore.AI.Documents.OpenXml.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\Modules\CrestApps.OrchardCore.AI.Documents.Pdf\CrestApps.OrchardCore.AI.Documents.Pdf.csproj" PrivateAssets="none" />
+    <ProjectReference Include="..\..\Modules\CrestApps.OrchardCore.AI.A2A\CrestApps.OrchardCore.AI.A2A.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\Modules\CrestApps.OrchardCore.AI.Mcp\CrestApps.OrchardCore.AI.Mcp.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\Modules\CrestApps.OrchardCore.AI.Mcp.Resources.Ftp\CrestApps.OrchardCore.AI.Mcp.Resources.Ftp.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\Modules\CrestApps.OrchardCore.AI.Mcp.Resources.Sftp\CrestApps.OrchardCore.AI.Mcp.Resources.Sftp.csproj" PrivateAssets="none" />


### PR DESCRIPTION
This pull request introduces comprehensive support for the Agent-to-Agent (A2A) protocol in the CrestApps Orchard Core ecosystem, enabling both hosting and connecting to external AI agents via a standardized interface. It includes new modules, documentation, configuration options, and sample applications to facilitate multi-agent interoperability. The changes span solution structure, package dependencies, model updates, documentation, and sidebar navigation.

**Key changes include:**

### A2A Protocol Feature Implementation

- **New A2A Modules Added:**  
  - Added `CrestApps.OrchardCore.AI.A2A` (A2A Client) and `CrestApps.OrchardCore.AI.A2A.Host` (A2A Host) modules to the solution, enabling both client and host support for the A2A protocol.  
    [[1]](diffhunk://#diff-1ee7084d3fd4c192326af5dcc260811364c5ef6054eddc54d75622cc15c47ca3R49) [[2]](diffhunk://#diff-210223f4b8a79d087b0049f9d714f227cb94db9b9078e6214d58d81a6ec693e4R1-R13) [[3]](diffhunk://#diff-9c933c0695eff2be5b6763cfa2d112159bf5623071a29ae5afb617352fb00c3fR1-R12) [[4]](diffhunk://#diff-b0ea0640a78d02984015e9b045ae3f8a79e1ae181691469077173fccb3e2beaaR1-R8)

- **Sample Client Application:**  
  - Introduced `CrestApps.OrchardCore.Samples.A2AClient`, a Razor Pages sample app for testing A2A agent connectivity and messaging, with Aspire integration.  
    [[1]](diffhunk://#diff-1ee7084d3fd4c192326af5dcc260811364c5ef6054eddc54d75622cc15c47ca3R79) [[2]](diffhunk://#diff-281d67400894d8ce0420b0db5b59ba59aae5aa69177c495d8fa8e9481af2755fR1-R51)

- **NuGet Dependencies:**  
  - Updated `Directory.Packages.props` to include `A2A` and `A2A.AspNetCore` packages (version `0.3.4-preview`).  
   

### Model and Enum Enhancements

- **Model Updates for A2A:**  
  - Added `A2AConnectionIds` to `AICompletionContext` and `ChatInteraction` models, allowing assignment of A2A connections to AI profiles, templates, and chat interactions.  
    [[1]](diffhunk://#diff-5a1817428d3e67f12d461848b79f128cb652f758a6173defc6a5a520884fcd28R35-R36) [[2]](diffhunk://#diff-9566505f7d61fccc5378e75662a92566e03639258bf5884c57b8666cb00b7a25R127-R131)

- **Tool Registry Extension:**  
  - Introduced a new `A2AAgent` value to the `ToolRegistryEntrySource` enum to distinguish remote agents accessed via A2A.  
   

### Documentation and User Guidance

- **Comprehensive Docs for A2A:**  
  - Added new documentation pages covering A2A overview, client configuration, host setup, and the sample client. These include usage instructions, configuration options, authentication methods, permissions, and agent discovery mechanisms.  
    [[1]](diffhunk://#diff-fee54d8e9be85e1ade8c566ab5043892ade9198e1905652fd56de4350a8545f0R1-R46) [[2]](diffhunk://#diff-b7cf9358cfcabb4ae73dfbf12e9a46fcc138f6cd669639491a64f3af5eee46baR1-R95) [[3]](diffhunk://#diff-83b13a1d8f3165acbff670a4ca9f125abe8796c396b4f10b3b5d55a454e4fb88R1-R95) [[4]](diffhunk://#diff-281d67400894d8ce0420b0db5b59ba59aae5aa69177c495d8fa8e9481af2755fR1-R51)

- **Changelog Update:**  
  - Updated the v2.0.0 changelog to announce A2A protocol support, describing both client and host features, authentication, agent discovery, and the sample app.  
   

### Documentation Navigation

- **Sidebar Structure:**  
  - Updated documentation sidebars to include the new A2A documentation category and sample client page for easier navigation.  
    [[1]](diffhunk://#diff-354695b160d4e63e1cb18f929f50b008409ea2c92248c18cc30926004c112274R69-R77) [[2]](diffhunk://#diff-354695b160d4e63e1cb18f929f50b008409ea2c92248c18cc30926004c112274R109)

---

These changes collectively enable seamless discovery, registration, and invocation of remote AI agents using the open A2A protocol, and provide clear guidance and tooling for users to leverage multi-agent orchestration in their solutions.