### PR TITLE
Add Source to AIDataSource Recipe Step

### DIFF
--- a/src/Core/CrestApps.OrchardCore.Recipes.Core/Schemas/Steps/AIDataSourceRecipeStep.cs
+++ b/src/Core/CrestApps.OrchardCore.Recipes.Core/Schemas/Steps/AIDataSourceRecipeStep.cs
@@ -1,4 +1,6 @@
+using CrestApps.Core.AI.Models;
 using Json.Schema;
+using Microsoft.Extensions.Options;
 
 namespace CrestApps.OrchardCore.Recipes.Core.Schemas.Steps;
 
@@ -7,7 +9,17 @@ namespace CrestApps.OrchardCore.Recipes.Core.Schemas.Steps;
 /// </summary>
 public sealed class AIDataSourceRecipeStep : IRecipeStep
 {
+    private readonly AIDataSourceSourceOptions _sourceOptions;
     private JsonSchema _cached;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIDataSourceRecipeStep"/> class.
+    /// </summary>
+    /// <param name="sourceOptions">The source options.</param>
+    public AIDataSourceRecipeStep(IOptions<AIDataSourceSourceOptions> sourceOptions)
+    {
+        _sourceOptions = sourceOptions.Value;
+    }
 
     public string Name => "AIDataSource";
 
@@ -21,13 +33,24 @@ public sealed class AIDataSourceRecipeStep : IRecipeStep
         return ValueTask.FromResult(_cached);
     }
 
-    private static JsonSchema CreateSchema()
+    private JsonSchema CreateSchema()
     {
+        var sourceTypes = GetRegisteredSourceTypes();
+        var sourceSchema = new JsonSchemaBuilder()
+            .Type(SchemaValueType.String)
+            .Description("Optional data source type. When omitted, the import defaults to SearchIndexProfile for backward compatibility.");
+
+        if (sourceTypes.Length > 0)
+        {
+            sourceSchema = sourceSchema.Enum(sourceTypes);
+        }
+
         var dataSourceSchema = new JsonSchemaBuilder()
             .Type(SchemaValueType.Object)
             .Properties(
                 ("ItemId", RecipeStepSchemaBuilders.String().Description("Optional unique identifier. When supplied and found, the existing data source is updated.")),
                 ("DisplayText", RecipeStepSchemaBuilders.String().Description("Human-readable name for the data source.")),
+                ("Source", sourceSchema),
                 ("SourceIndexProfileName", RecipeStepSchemaBuilders.String().Description("Index profile that provides the raw source documents to ingest.")),
                 ("AIKnowledgeBaseIndexProfileName", RecipeStepSchemaBuilders.String().Description("Knowledge-base index profile that stores the normalized AI-ready documents.")),
                 ("KeyFieldName", RecipeStepSchemaBuilders.String().Description("Field name that uniquely identifies each source record.")),
@@ -49,4 +72,10 @@ public sealed class AIDataSourceRecipeStep : IRecipeStep
             [("DataSources", RecipeStepSchemaBuilders.Array(dataSourceSchema, 1).Description("The AI data sources to create or update."))],
             ["DataSources"]);
     }
+
+    private string[] GetRegisteredSourceTypes()
+        => _sourceOptions.Sources
+            .Select(source => source.SourceType)
+            .OrderBy(static sourceType => sourceType, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 }

--- a/src/CrestApps.Docs/docs/ai/data-sources/index.md
+++ b/src/CrestApps.Docs/docs/ai/data-sources/index.md
@@ -141,6 +141,7 @@ The resolver receives the `referenceId` and optional metadata, and returns a URL
       "DataSources": [
         {
           "DisplayText": "Articles",
+          "Source": "SearchIndexProfile",
           "SourceIndexProfileName": "articles",
           "AIKnowledgeBaseIndexProfileName": "AIRagKnowledgeBase",
           "KeyFieldName": "ContentItemId",
@@ -152,6 +153,8 @@ The resolver receives the `referenceId` and optional metadata, and returns a URL
   ]
 }
 ```
+
+Set `Source` to the registered source type you want to import. Built-in values include `SearchIndexProfile`, `AzureAISearch`, `Elasticsearch`, and `PostgreSQL` when the corresponding provider modules are enabled. Older recipes can omit `Source`, in which case import still defaults to `SearchIndexProfile`.
 
 When **OrchardCore.Deployment** is enabled, the deployment-plan editor groups the **AIDataSource** export step under the **Artificial Intelligence** category.
 

--- a/src/CrestApps.Docs/docs/changelog/v2.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/v2.0.0.md
@@ -137,6 +137,7 @@ At a high level, the platform changes are:
 - The Data Sources editor now shows source-specific inputs first, then the shared **Search Index Profile** destination section, and keeps the shared **Field Mapping** section at the bottom for every source type.
 - The Data Sources admin editor now uses dedicated view models per editor shape and bundled `data-*` initialized JavaScript assets instead of inline view-level editor scripts, keeping the admin UI wiring consistent with the broader v2 admin patterns.
 - The Orchard AI Data Sources integration now aligns with the updated shared Core source-aware model by creating new data sources through `ISourceCatalogManager<AIDataSource>`, while the migration/index path persists and backfills the indexed **Source** column for upgraded tenants.
+- The `AIDataSource` recipe step now imports persisted `Source` values, validates them against the registered AI data source source types, and exposes the same registered source-type enum through the exported recipe schema.
 - AI Data Sources now support source-type-based extensibility. Existing mappings still default to **Search Index Profile**, while built-in external source editors and handlers now cover **Elasticsearch**, **Azure AI Search**, and **PostgreSQL**.
 - Existing AI data sources now backfill a persisted source type during migration so older tenants continue to behave as Orchard-managed **Search Index Profile** mappings after upgrade.
 - See [AI Data Sources](../ai/data-sources/index.md).

--- a/src/CrestApps.Docs/docs/modules/recipes.md
+++ b/src/CrestApps.Docs/docs/modules/recipes.md
@@ -64,6 +64,8 @@ The `AIProfileTemplate` recipe step now extends that catalog with template-speci
 
 The Recipes feature now also exports dedicated step schemas for `AIDataSource`, `McpConnection`, `McpPrompt`, `McpResource`, and `A2AConnection`. Their `Properties` objects document the known built-in metadata envelopes such as `SseMcpConnectionMetadata`, `StdioMcpConnectionMetadata`, `FtpConnectionMetadata`, `SftpConnectionMetadata`, and `A2AConnectionMetadata`, while still allowing extra keys for future extensions.
 
+For `AIDataSource`, the schema also derives the `Source` enum from the currently registered `AIDataSourceSourceOptions` entries, so recipe tooling can suggest only the source types that are actually enabled for the tenant. Recipe imports honor that same `Source` value and still default to `SearchIndexProfile` when older payloads omit it.
+
 More broadly, the exported recipe-step schemas now attach descriptions to the known properties across the built-in CrestApps recipe steps so human authors and AI tools can discover what each property is for directly from the schema surface.
 
 ## Creating a Recipe Step

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources/Recipes/AIDataSourceStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources/Recipes/AIDataSourceStep.cs
@@ -3,6 +3,7 @@ using CrestApps.Core;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.Services;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 using OrchardCore.Recipes.Models;
 using OrchardCore.Recipes.Services;
 
@@ -13,6 +14,7 @@ internal sealed class AIDataSourceStep : NamedRecipeStepHandler
     public const string StepKey = "AIDataSource";
 
     private readonly ISourceCatalogManager<AIDataSource> _dataManager;
+    private readonly AIDataSourceSourceOptions _sourceOptions;
 
     internal readonly IStringLocalizer S;
 
@@ -20,13 +22,16 @@ internal sealed class AIDataSourceStep : NamedRecipeStepHandler
     /// Initializes a new instance of the <see cref="AIDataSourceStep"/> class.
     /// </summary>
     /// <param name="dataManager">The data manager.</param>
+    /// <param name="sourceOptions">The source options.</param>
     /// <param name="stringLocalizer">The string localizer.</param>
     public AIDataSourceStep(
         ISourceCatalogManager<AIDataSource> dataManager,
+        IOptions<AIDataSourceSourceOptions> sourceOptions,
         IStringLocalizer<AIDataSourceStep> stringLocalizer)
     : base(StepKey)
     {
         _dataManager = dataManager;
+        _sourceOptions = sourceOptions.Value;
         S = stringLocalizer;
     }
 
@@ -39,6 +44,18 @@ internal sealed class AIDataSourceStep : NamedRecipeStepHandler
         {
             AIDataSource dataSource = null;
             var isNew = false;
+
+            var sourceType = token[nameof(AIDataSource.Source)]?.GetValue<string>();
+            sourceType = string.IsNullOrWhiteSpace(sourceType)
+                ? AIDataSourceSourceTypes.SearchIndexProfile
+                : sourceType;
+
+            if (!TryGetSource(sourceType))
+            {
+                context.Errors.Add(S["Invalid source used for AI data source '{0}'.", sourceType]);
+
+                continue;
+            }
 
             var id = token[nameof(AIDataSource.ItemId)]?.GetValue<string>();
 
@@ -56,7 +73,7 @@ internal sealed class AIDataSourceStep : NamedRecipeStepHandler
             else
             {
                 isNew = true;
-                dataSource = await _dataManager.NewAsync(token);
+                dataSource = await _dataManager.NewAsync(sourceType, token);
 
                 if (hasId && UniqueId.IsValid(id))
                 {
@@ -82,6 +99,10 @@ internal sealed class AIDataSourceStep : NamedRecipeStepHandler
             }
         }
     }
+
+    private bool TryGetSource(string sourceType)
+        => _sourceOptions.Sources.Any(entry =>
+            string.Equals(entry.SourceType, sourceType, StringComparison.OrdinalIgnoreCase));
 
     private sealed class AIDataSourcesStepModel
     {

--- a/tests/CrestApps.OrchardCore.Tests/Core/Schemas/AIProfileRecipeStepTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Core/Schemas/AIProfileRecipeStepTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using CrestApps.Core.AI;
+using CrestApps.Core.AI.Models;
 using CrestApps.OrchardCore.Recipes.Core;
 using CrestApps.OrchardCore.Recipes.Core.Schemas.Steps;
 using Microsoft.Extensions.Options;
@@ -101,7 +102,7 @@ public sealed class AIProfileRecipeStepTests
             new McpResourceRecipeStep(),
             new McpPromptRecipeStep(),
             new A2AConnectionRecipeStep(),
-            new AIDataSourceRecipeStep(),
+            new AIDataSourceRecipeStep(CreateAIDataSourceSourceOptions()),
         };
 
         var json = JsonSerializer.Serialize(await Task.WhenAll(steps.Select(step => step.GetSchemaAsync(TestContext.Current.CancellationToken).AsTask())));
@@ -118,6 +119,26 @@ public sealed class AIProfileRecipeStepTests
     }
 
     [Fact]
+    public async Task AIDataSourceSchema_UsesRegisteredSourceTypesForSourceEnums()
+    {
+        var step = new AIDataSourceRecipeStep(CreateAIDataSourceSourceOptions());
+        var json = JsonNode.Parse(JsonSerializer.Serialize(await step.GetSchemaAsync(TestContext.Current.CancellationToken)))!;
+        var sourceValues = json["properties"]?["DataSources"]?["items"]?["properties"]?["Source"]?["enum"]?
+            .AsArray()
+            .Select(node => node?.GetValue<string>())
+            .ToArray();
+
+        Assert.Equal(
+            [
+                "AzureAISearch",
+                "Elasticsearch",
+                "PostgreSQL",
+                "SearchIndexProfile",
+            ],
+            sourceValues);
+    }
+
+    [Fact]
     public async Task AIProviderConnectionsSchema_UsesRegisteredProviderNamesForSourceEnums()
     {
         var options = new AIOptions();
@@ -125,7 +146,7 @@ public sealed class AIProfileRecipeStepTests
         connectionSources["OpenAI"] = new AIProviderConnectionOptionsEntry("OpenAI");
         connectionSources["Azure"] = new AIProviderConnectionOptionsEntry("Azure");
         connectionSources["openai"] = new AIProviderConnectionOptionsEntry("OpenAI");
-        var step = new AIProviderConnectionsRecipeStep(Options.Create(options));
+        var step = new AIProviderConnectionsRecipeStep(Microsoft.Extensions.Options.Options.Create(options));
 
         var json = JsonNode.Parse(JsonSerializer.Serialize(await step.GetSchemaAsync(TestContext.Current.CancellationToken)))!;
         var sourceValues = json["properties"]?["Connections"]?["items"]?["properties"]?["Source"]?["enum"]?
@@ -139,5 +160,16 @@ public sealed class AIProfileRecipeStepTests
 
         Assert.Equal(["Azure", "OpenAI"], sourceValues);
         Assert.Equal(["Azure", "OpenAI"], clientNameValues);
+    }
+
+    private static IOptions<AIDataSourceSourceOptions> CreateAIDataSourceSourceOptions()
+    {
+        var options = new AIDataSourceSourceOptions();
+        options.AddOrUpdate("SearchIndexProfile", new("Search Index Profile", "Search Index Profile"), new("Read source documents from an Orchard-managed search index profile.", "Read source documents from an Orchard-managed search index profile."));
+        options.AddOrUpdate("AzureAISearch", new("Azure AI Search", "Azure AI Search"), new("Read source documents from an external Azure AI Search index.", "Read source documents from an external Azure AI Search index."));
+        options.AddOrUpdate("Elasticsearch", new("Elasticsearch", "Elasticsearch"), new("Read source documents from an external Elasticsearch index.", "Read source documents from an external Elasticsearch index."));
+        options.AddOrUpdate("PostgreSQL", new("PostgreSQL", "PostgreSQL"), new("Read source documents from a PostgreSQL table.", "Read source documents from a PostgreSQL table."));
+
+        return Options.Create(options);
     }
 }

--- a/tests/CrestApps.OrchardCore.Tests/Core/Schemas/BuiltInRecipeStepTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Core/Schemas/BuiltInRecipeStepTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using CrestApps.Core.AI.Models;
 using CrestApps.OrchardCore.Recipes.Core;
 using CrestApps.OrchardCore.Recipes.Core.Schemas;
 using CrestApps.OrchardCore.Recipes.Core.Schemas.Fields;
@@ -8,6 +9,7 @@ using CrestApps.OrchardCore.Recipes.Core.Schemas.SiteSettings;
 using CrestApps.OrchardCore.Recipes.Core.Schemas.Steps;
 using CrestApps.OrchardCore.Recipes.Core.Services;
 using Json.Schema;
+using Microsoft.Extensions.Options;
 using Moq;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -67,6 +69,17 @@ public sealed class BuiltInRecipeStepTests
             .ReturnsAsync((Permission)null);
 
         return permissionService.Object;
+    }
+
+    private static IOptions<AIDataSourceSourceOptions> CreateAIDataSourceSourceOptions()
+    {
+        var options = new AIDataSourceSourceOptions();
+        options.AddOrUpdate("SearchIndexProfile", new("Search Index Profile", "Search Index Profile"), new("Read source documents from an Orchard-managed search index profile.", "Read source documents from an Orchard-managed search index profile."));
+        options.AddOrUpdate("AzureAISearch", new("Azure AI Search", "Azure AI Search"), new("Read source documents from an external Azure AI Search index.", "Read source documents from an external Azure AI Search index."));
+        options.AddOrUpdate("Elasticsearch", new("Elasticsearch", "Elasticsearch"), new("Read source documents from an external Elasticsearch index.", "Read source documents from an external Elasticsearch index."));
+        options.AddOrUpdate("PostgreSQL", new("PostgreSQL", "PostgreSQL"), new("Read source documents from a PostgreSQL table.", "Read source documents from a PostgreSQL table."));
+
+        return Options.Create(options);
     }
 
     private static ISiteSettingsSchemaDefinition[] CreateAllSiteSettingsSchemaDefinitions()
@@ -197,6 +210,11 @@ public sealed class BuiltInRecipeStepTests
         if (stepType == typeof(RolesRecipeStep))
         {
             return new RolesRecipeStep(CreatePermissionService());
+        }
+
+        if (stepType == typeof(AIDataSourceRecipeStep))
+        {
+            return new AIDataSourceRecipeStep(CreateAIDataSourceSourceOptions());
         }
 
         return (IRecipeStep)Activator.CreateInstance(stepType);

--- a/tests/CrestApps.OrchardCore.Tests/Modules/Recipes/NamedRecipeStepHandlerTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/Recipes/NamedRecipeStepHandlerTests.cs
@@ -2,9 +2,9 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json.Nodes;
 using CrestApps.Core.AI;
+using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Mcp.Models;
-using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Profiles;
 using CrestApps.Core.Models;
 using CrestApps.Core.Services;
@@ -296,9 +296,11 @@ public sealed class NamedRecipeStepHandlerTests
         manager.Setup(x => x.ValidateAsync(dataSource, It.IsAny<CancellationToken>()))
             .Returns(() => ValueTask.FromResult(new ValidationResultDetails()));
 
+        var options = CreateAIDataSourceSourceOptions();
         var handler = CreateHandler(
             "CrestApps.OrchardCore.AI.DataSources.Recipes.AIDataSourceStep, CrestApps.OrchardCore.AI.DataSources",
             manager.Object,
+            options,
             null);
 
         var context = CreateContext("AIDataSource", new JsonObject
@@ -319,6 +321,52 @@ public sealed class NamedRecipeStepHandlerTests
         Assert.Empty(context.Errors);
         manager.Verify(x => x.UpdateAsync(dataSource, It.IsAny<JsonNode>(), It.IsAny<CancellationToken>()), Times.Once);
         manager.Verify(x => x.CreateAsync(It.IsAny<AIDataSource>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AIDataSourceStep_WhenDataSourceIsNew_ShouldUseRecipeSourceValue()
+    {
+        // Arrange
+        var token = new JsonObject
+        {
+            [nameof(AIDataSource.DisplayText)] = "Products",
+            [nameof(AIDataSource.Source)] = "PostgreSQL",
+        };
+
+        var dataSource = new AIDataSource
+        {
+            DisplayText = "Products",
+            Source = "PostgreSQL",
+        };
+
+        var manager = new Mock<ISourceCatalogManager<AIDataSource>>();
+        manager.Setup(x => x.NewAsync("PostgreSQL", It.IsAny<JsonNode>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTask.FromResult(dataSource));
+        manager.Setup(x => x.ValidateAsync(dataSource, It.IsAny<CancellationToken>()))
+            .Returns(() => ValueTask.FromResult(new ValidationResultDetails()));
+
+        var options = CreateAIDataSourceSourceOptions();
+        var handler = CreateHandler(
+            "CrestApps.OrchardCore.AI.DataSources.Recipes.AIDataSourceStep, CrestApps.OrchardCore.AI.DataSources",
+            manager.Object,
+            options,
+            null);
+
+        var context = CreateContext("AIDataSource", new JsonObject
+        {
+            ["DataSources"] = new JsonArray
+            {
+                token,
+            },
+        });
+
+        // Act
+        await ExecuteAsync(handler, context);
+
+        // Assert
+        Assert.Empty(context.Errors);
+        manager.Verify(x => x.NewAsync("PostgreSQL", It.IsAny<JsonNode>(), It.IsAny<CancellationToken>()), Times.Once);
+        manager.Verify(x => x.CreateAsync(dataSource, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -519,5 +567,16 @@ public sealed class NamedRecipeStepHandlerTests
         var task = (Task)executeMethod.Invoke(handler, [context])!;
 
         await task;
+    }
+
+    private static IOptions<AIDataSourceSourceOptions> CreateAIDataSourceSourceOptions()
+    {
+        var options = new AIDataSourceSourceOptions();
+        options.AddOrUpdate("SearchIndexProfile", new("Search Index Profile", "Search Index Profile"), new("Read source documents from an Orchard-managed search index profile.", "Read source documents from an Orchard-managed search index profile."));
+        options.AddOrUpdate("AzureAISearch", new("Azure AI Search", "Azure AI Search"), new("Read source documents from an external Azure AI Search index.", "Read source documents from an external Azure AI Search index."));
+        options.AddOrUpdate("Elasticsearch", new("Elasticsearch", "Elasticsearch"), new("Read source documents from an external Elasticsearch index.", "Read source documents from an external Elasticsearch index."));
+        options.AddOrUpdate("PostgreSQL", new("PostgreSQL", "PostgreSQL"), new("Read source documents from a PostgreSQL table.", "Read source documents from a PostgreSQL table."));
+
+        return Options.Create(options);
     }
 }


### PR DESCRIPTION
This pull request introduces first-class support for the `Source` property in the `AIDataSource` recipe step, making it schema-aware and validated against registered source types. It updates both the schema and import logic to ensure only valid, enabled source types are accepted, while maintaining backward compatibility for older recipes. The documentation and tests are also updated to reflect and verify these enhancements.

**AIDataSource Recipe Step Improvements:**

* The `AIDataSourceRecipeStep` now exposes the `Source` property as an enum in its JSON schema, derived from the currently registered source types, so recipe tooling can suggest only enabled types. [[1]](diffhunk://#diff-4a3a5b62f8ab657b70685812cc8d6224101a4044299ac13fba989ec7cacc6c45R1-R3) [[2]](diffhunk://#diff-4a3a5b62f8ab657b70685812cc8d6224101a4044299ac13fba989ec7cacc6c45R12-R23) [[3]](diffhunk://#diff-4a3a5b62f8ab657b70685812cc8d6224101a4044299ac13fba989ec7cacc6c45L24-R53) [[4]](diffhunk://#diff-4a3a5b62f8ab657b70685812cc8d6224101a4044299ac13fba989ec7cacc6c45R75-R80)
* The `AIDataSourceStep` import logic now validates the `Source` value against registered types, defaults to `SearchIndexProfile` if omitted (for backward compatibility), and rejects invalid values with an error. [[1]](diffhunk://#diff-944e5d044973e2adc19360cd6bc6b49af9be1ad73d86fe8c4c4bfc5b2418b989R17-R34) [[2]](diffhunk://#diff-944e5d044973e2adc19360cd6bc6b49af9be1ad73d86fe8c4c4bfc5b2418b989R48-R59) [[3]](diffhunk://#diff-944e5d044973e2adc19360cd6bc6b49af9be1ad73d86fe8c4c4bfc5b2418b989L59-R76) [[4]](diffhunk://#diff-944e5d044973e2adc19360cd6bc6b49af9be1ad73d86fe8c4c4bfc5b2418b989R103-R106)

**Documentation Updates:**

* The AI data sources documentation and changelog are updated to describe the new `Source` property, its valid values, and backward compatibility. [[1]](diffhunk://#diff-efd1dacee1334f46b026c64f480321bfb25dac9838809f094a23bc3d90cc285dR144) [[2]](diffhunk://#diff-efd1dacee1334f46b026c64f480321bfb25dac9838809f094a23bc3d90cc285dR157-R158) [[3]](diffhunk://#diff-43e1803d5b3fcd4ff615dd3c1524caa5610b2bb21e93886e709d174692dfb39bR140) [[4]](diffhunk://#diff-6dad37184d69dcca3f77c000d34d912bfe14e72fd0ba2a11132d4ec63d4284b3R67-R68)

**Testing Enhancements:**

* Unit tests are added and updated to verify that the schema exposes the correct enum values for `Source`, and that import logic correctly handles and validates the `Source` property. [[1]](diffhunk://#diff-36019f1f737f3b588527fc3077dc40b90e0aa5b4801cbae4a5a8844a2c3da1ccR4) [[2]](diffhunk://#diff-36019f1f737f3b588527fc3077dc40b90e0aa5b4801cbae4a5a8844a2c3da1ccL104-R105) [[3]](diffhunk://#diff-36019f1f737f3b588527fc3077dc40b90e0aa5b4801cbae4a5a8844a2c3da1ccR121-R140) [[4]](diffhunk://#diff-36019f1f737f3b588527fc3077dc40b90e0aa5b4801cbae4a5a8844a2c3da1ccL128-R149) [[5]](diffhunk://#diff-36019f1f737f3b588527fc3077dc40b90e0aa5b4801cbae4a5a8844a2c3da1ccR164-R174) [[6]](diffhunk://#diff-61b846fd96e9d8b2d760a1533238147bf262d85b7ae068586ca9d19f41434548R5-L7) [[7]](diffhunk://#diff-61b846fd96e9d8b2d760a1533238147bf262d85b7ae068586ca9d19f41434548R299-R303) [[8]](diffhunk://#diff-61b846fd96e9d8b2d760a1533238147bf262d85b7ae068586ca9d19f41434548R326-R371) [[9]](diffhunk://#diff-61b846fd96e9d8b2d760a1533238147bf262d85b7ae068586ca9d19f41434548R571-R581)

These changes ensure that AI data source recipes are both more robust and easier to author, with clear schema guidance and strict validation of source types.