### PR TITLE
Authenticate SignalR hubs with the Api scheme and log tool denials

### DIFF
--- a/src/Abstractions/CrestApps.OrchardCore.Abstractions/SignalR/AllowApiTokenAuthenticationAttribute.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Abstractions/SignalR/AllowApiTokenAuthenticationAttribute.cs
@@ -1,0 +1,17 @@
+namespace CrestApps.OrchardCore.SignalR;
+
+/// <summary>
+/// Indicates that a SignalR hub accepts the Orchard Core <c>Api</c> authentication scheme, allowing token based
+/// clients such as headless front-ends, mobile applications, and service-to-service callers to connect to the hub
+/// the same way they call the API endpoints.
+/// </summary>
+/// <remarks>
+/// Hubs are opt-in. Without this attribute the hub keeps the default behavior, where only the authentication
+/// schemes configured by the host, such as the cookie scheme, are evaluated. Applying the attribute never weakens
+/// the hub's authorization requirements. It only allows an otherwise anonymous request that carries a valid bearer
+/// token to be associated with the token's user before authorization runs.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class AllowApiTokenAuthenticationAttribute : Attribute
+{
+}

--- a/src/Core/CrestApps.OrchardCore.AI.Chat.Core/Hubs/AIChatHub.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Chat.Core/Hubs/AIChatHub.cs
@@ -12,6 +12,7 @@ using CrestApps.Core.AI.ResponseHandling;
 using CrestApps.OrchardCore.AI.Chat.Core.Services;
 using CrestApps.OrchardCore.AI.Core;
 using CrestApps.OrchardCore.AI.Core.Services;
+using CrestApps.OrchardCore.SignalR;
 using Cysharp.Text;
 using Fluid;
 using Fluid.Values;
@@ -33,6 +34,7 @@ namespace CrestApps.OrchardCore.AI.Chat.Hubs;
 /// and overrides hooks to integrate with OrchardCore's scoping, authorization, localization,
 /// analytics, and citation systems.
 /// </summary>
+[AllowApiTokenAuthentication]
 public class AIChatHub : AIChatHubCore<IAIChatHubClient>
 {
     private readonly IStringLocalizer S;

--- a/src/Core/CrestApps.OrchardCore.AI.Chat.Interactions.Core/Hubs/ChatInteractionHub.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Chat.Interactions.Core/Hubs/ChatInteractionHub.cs
@@ -6,6 +6,7 @@ using CrestApps.Core.AI.ResponseHandling;
 using CrestApps.OrchardCore.AI.Chat.Interactions.Settings;
 using CrestApps.OrchardCore.AI.Core;
 using CrestApps.OrchardCore.AI.Core.Services;
+using CrestApps.OrchardCore.SignalR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,7 @@ namespace CrestApps.OrchardCore.AI.Chat.Interactions.Hubs;
 /// <see cref="ChatInteractionHubBase"/> and overrides hooks to integrate with
 /// OrchardCore's scoping, authorization, localization, analytics, and citation systems.
 /// </summary>
+[AllowApiTokenAuthentication]
 public class ChatInteractionHub : ChatInteractionHubBase
 {
     private readonly IStringLocalizer S;

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Orchestration/LocalToolRegistryProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Orchestration/LocalToolRegistryProvider.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace CrestApps.OrchardCore.AI.Core.Orchestration;
@@ -16,6 +17,7 @@ internal sealed class LocalToolRegistryProvider : IToolRegistryProvider
     private readonly IOptions<AIToolDefinitionOptions> _toolDefinitions;
     private readonly IAuthorizationService _authorizationService;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LocalToolRegistryProvider"/> class.
@@ -23,14 +25,17 @@ internal sealed class LocalToolRegistryProvider : IToolRegistryProvider
     /// <param name="toolDefinitions">The registered AI tool definitions.</param>
     /// <param name="authorizationService">The authorization service for verifying tool access.</param>
     /// <param name="httpContextAccessor">The HTTP context accessor for retrieving the current user.</param>
+    /// <param name="logger">The logger.</param>
     public LocalToolRegistryProvider(
         IOptions<AIToolDefinitionOptions> toolDefinitions,
         IAuthorizationService authorizationService,
-        IHttpContextAccessor httpContextAccessor)
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<LocalToolRegistryProvider> logger)
     {
         _toolDefinitions = toolDefinitions;
         _authorizationService = authorizationService;
         _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
     }
 
     /// <summary>
@@ -54,6 +59,7 @@ internal sealed class LocalToolRegistryProvider : IToolRegistryProvider
         var toolDefinitions = _toolDefinitions.Value.Tools;
         var entries = new List<ToolRegistryEntry>();
         var user = _httpContextAccessor.HttpContext?.User;
+        List<string> unauthorizedToolNames = null;
 
         foreach (var toolName in configuredToolNames)
         {
@@ -74,6 +80,8 @@ internal sealed class LocalToolRegistryProvider : IToolRegistryProvider
             if (user is not null &&
                 !await _authorizationService.AuthorizeAsync(user, AIPermissions.AccessAITool, toolName as object))
             {
+                (unauthorizedToolNames ??= []).Add(toolName);
+
                 continue;
             }
 
@@ -87,6 +95,11 @@ internal sealed class LocalToolRegistryProvider : IToolRegistryProvider
                 Source = ToolRegistryEntrySource.Local,
                 CreateAsync = (sp) => ValueTask.FromResult(sp.GetKeyedService<AITool>(name)),
             });
+        }
+
+        if (unauthorizedToolNames is not null)
+        {
+            _logger.LogWarning("The current user is not authorized to use the following AI tools, which were excluded from the request: {ToolNames}. Grant the 'AccessAnyAITool' permission, or the matching per-tool 'AccessAITool_<tool name>' permission, to the roles that require them.", string.Join(", ", unauthorizedToolNames));
         }
 
         return entries;

--- a/src/CrestApps.Docs/docs/ai/tools.md
+++ b/src/CrestApps.Docs/docs/ai/tools.md
@@ -177,6 +177,22 @@ When `createOrUpdateContentItem` is available alongside recipe-backed content sc
 | Save User Memory | Creates or updates a named memory entry for the current user. |
 | Remove User Memory | Removes a saved memory entry when it should be forgotten. |
 
+## Tool permissions
+
+Tool access is authorized separately from profile access. Granting a role permission to query a profile is **not** enough to let that role use the tools the profile is configured with.
+
+| Permission | Description |
+| --- | --- |
+| `QueryAnyAIProfile` (or `QueryAIProfile_{profileName}`) | Allows the identity to query the AI profile. |
+| `AccessAnyAITool` | Allows the identity to use every registered AI function. This permission is security critical and is granted only to the `Administrator` role by default. |
+| `AccessAITool_{toolName}` | Allows the identity to use one specific AI function. |
+
+When the current identity is not authorized for a configured tool, the tool is excluded from the request instead of failing it. The model then answers without that capability, which usually looks like an incomplete or degraded answer. Each excluded tool is reported in the logs with a `Warning` entry that lists the tool names and the permissions to grant, so check the application log first when a profile behaves correctly for an administrator but not for another role.
+
+:::tip
+Custom roles and OpenID applications that query tool-enabled profiles need `AccessAnyAITool`, or the matching `AccessAITool_{toolName}` permission for every tool the profile uses, in addition to the profile query permission.
+:::
+
 ## Invocation Context (AIInvocationScope)
 
 `AIInvocationScope` is the shared per-request context for references, tool state, and other invocation-scoped data. For the framework-level explanation, see the shared Core documentation:

--- a/src/CrestApps.Docs/docs/changelog/v2.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/v2.0.0.md
@@ -82,6 +82,7 @@ At a high level, the platform changes are:
 - The `createOrUpdateContentItem` tool now initializes nested child content items with Orchard Core `NewAsync()` before merge, recursively using recipe contained-part metadata when available and falling back to known container shapes so child handlers run for nested payloads too.
 - Recipe-backed AI content-item validation now evaluates the authored schema as-is, helper-tool dependencies can be declared during tool registration, and the AI tooling automatically includes `getContentItemSchema` and `getOrchardCoreRecipeJsonSchema` where appropriate.
 - The `getContentItemSchema` and `getOrchardCoreRecipeJsonSchema` flows now expose richer schema discovery, preserve the root `steps` array behavior, keep the full step-name enum available, and report valid step names when an unknown step is requested.
+- Tools that are excluded from a request because the current identity lacks the `AccessAnyAITool` or `AccessAITool_{toolName}` permission are now reported with a `Warning` log entry instead of a `Debug` entry, so a degraded answer is no longer silent. The required tool permissions are documented in [AI Tool Management](../ai/tools.md#tool-permissions).
 - See [Artificial Intelligence Suite](../ai/index.md), [AI Agent](../ai/agent.md), and [AI Tool Management](../ai/tools.md).
 
 #### Chat
@@ -387,6 +388,12 @@ At a high level, the platform changes are:
 - Built-in CrestApps recipe-step schemas now provide richer per-property descriptions across steps such as Roles, Workflows, Media, Layers, Placements, Templates, Features, and related admin and import steps.
 - The Recipes documentation now explains when to implement `PartSchemaDefinitionBase`, `FieldSchemaDefinitionBase`, and `IContentSchemaDefinition`, shows both part and field examples, and clarifies how multiple schema contributors for the same part or field name are merged.
 - The Recipe Schema Exporter utility now lives under `utilities\` instead of `tests\`, and the documented build and run commands were updated accordingly.
+
+### SignalR
+
+#### Hub authentication
+
+- SignalR hub requests now honor the Orchard Core `Api` authentication scheme. Headless clients such as single page applications, mobile applications, and service-to-service callers can connect to CrestApps hubs with an OpenID access token, sent either as an `Authorization: Bearer` header or through the standard SignalR `access_token` query string parameter, instead of being limited to cookie authentication. Cookie authenticated and anonymous requests are unaffected. See [SignalR](../modules/signalr#authenticating-with-access-tokens).
 
 ### Telephony
 

--- a/src/CrestApps.Docs/docs/changelog/v2.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/v2.0.0.md
@@ -394,6 +394,7 @@ At a high level, the platform changes are:
 #### Hub authentication
 
 - SignalR hub requests now honor the Orchard Core `Api` authentication scheme. Headless clients such as single page applications, mobile applications, and service-to-service callers can connect to CrestApps hubs with an OpenID access token, sent either as an `Authorization: Bearer` header or through the standard SignalR `access_token` query string parameter, instead of being limited to cookie authentication. Cookie authenticated and anonymous requests are unaffected. See [SignalR](../modules/signalr#authenticating-with-access-tokens).
+- Hubs opt in with the new `AllowApiTokenAuthenticationAttribute`, so hubs declared by Orchard Core or by your own application keep their existing authentication behavior. `AIChatHub`, `ChatInteractionHub`, and `TelephonyHub` opt in out of the box.
 
 ### Telephony
 

--- a/src/CrestApps.Docs/docs/modules/signalr.md
+++ b/src/CrestApps.Docs/docs/modules/signalr.md
@@ -81,7 +81,7 @@ This setup ensures your SignalR hub is properly registered and accessible within
 
 Browser clients that are already signed in are authenticated through the regular authentication cookie, and nothing extra is required.
 
-Headless clients, such as single page applications, mobile applications, and service-to-service callers, authenticate with an access token instead. Enable the **OpenID Token Validation** feature (`OrchardCore.OpenId.Validation`) and send the token when connecting. Hub requests that arrive without an authenticated user and with a bearer token are validated using the same `Api` authentication scheme used by the API endpoints, so the same identity works for both the API and the hubs.
+Headless clients, such as single page applications, mobile applications, and service-to-service callers, authenticate with an access token instead. Enable the **OpenID Token Validation** feature (`OrchardCore.OpenId.Validation`) and send the token when connecting. Requests that arrive at an opted-in hub without an authenticated user and with a bearer token are validated using the same `Api` authentication scheme used by the API endpoints, so the same identity works for both the API and the hubs.
 
 Because browsers cannot set an `Authorization` header on a WebSocket handshake, SignalR clients send the token using the standard `access_token` query string parameter. Both forms are supported:
 
@@ -102,6 +102,30 @@ var connection = new HubConnectionBuilder()
     .Build();
 ```
 
-Requests that already carry an authentication cookie, or that use another authentication scheme, are left untouched. Token validation only runs for hub endpoints, so the rest of the site is unaffected.
+Requests that already carry an authentication cookie, or that use another authentication scheme, are left untouched. Token validation only runs for hubs that opted in, so the rest of the site, including hubs declared by Orchard Core or by your own application, is unaffected.
 
 The token is only authenticated, not authorized. The identity behind the token still needs the permissions each hub requires, such as `QueryAnyAIProfile` and the [AI tool permissions](../ai/tools#tool-permissions) when the profile uses tools.
+
+### Opting a hub in
+
+Hubs are opt-in. Apply `AllowApiTokenAuthenticationAttribute` to the hub class to allow the `Api` scheme to run for its requests:
+
+```csharp
+using CrestApps.OrchardCore.SignalR;
+using Microsoft.AspNetCore.SignalR;
+
+[AllowApiTokenAuthentication]
+public sealed class MyHub : Hub
+{
+}
+```
+
+The following hubs opt in out of the box:
+
+| Hub | Route |
+| --- | --- |
+| `AIChatHub` | `/Communication/Hub/AIChatHub` |
+| `ChatInteractionHub` | `/Communication/Hub/ChatInteractionHub` |
+| `TelephonyHub` | `/Communication/Hub/TelephonyHub` |
+
+The attribute never weakens a hub's authorization requirements. A hub decorated with `[Authorize]` still rejects callers that fail the policy, and a hub that allows anonymous connections still accepts them when no token is supplied. The attribute only allows an otherwise anonymous request that carries a valid bearer token to be associated with the token's user before authorization runs.

--- a/src/CrestApps.Docs/docs/modules/signalr.md
+++ b/src/CrestApps.Docs/docs/modules/signalr.md
@@ -76,3 +76,32 @@ Then, initialize the SignalR connection using JavaScript:
 Note the dependency on the `signalr` script, which is automatically added to the page by the SignalR module.
 
 This setup ensures your SignalR hub is properly registered and accessible within Orchard Core, allowing seamless real-time communication.
+
+## Authenticating with access tokens
+
+Browser clients that are already signed in are authenticated through the regular authentication cookie, and nothing extra is required.
+
+Headless clients, such as single page applications, mobile applications, and service-to-service callers, authenticate with an access token instead. Enable the **OpenID Token Validation** feature (`OrchardCore.OpenId.Validation`) and send the token when connecting. Hub requests that arrive without an authenticated user and with a bearer token are validated using the same `Api` authentication scheme used by the API endpoints, so the same identity works for both the API and the hubs.
+
+Because browsers cannot set an `Authorization` header on a WebSocket handshake, SignalR clients send the token using the standard `access_token` query string parameter. Both forms are supported:
+
+```javascript
+const connection = new signalR.HubConnectionBuilder()
+    .withUrl("/Communication/Hub/AIChatHub", {
+        accessTokenFactory: () => accessToken,
+    })
+    .build();
+```
+
+```csharp
+var connection = new HubConnectionBuilder()
+    .WithUrl("https://www.example.com/Communication/Hub/AIChatHub", options =>
+    {
+        options.AccessTokenProvider = () => Task.FromResult(accessToken);
+    })
+    .Build();
+```
+
+Requests that already carry an authentication cookie, or that use another authentication scheme, are left untouched. Token validation only runs for hub endpoints, so the rest of the site is unaffected.
+
+The token is only authenticated, not authorized. The identity behind the token still needs the permissions each hub requires, such as `QueryAnyAIProfile` and the [AI tool permissions](../ai/tools#tool-permissions) when the profile uses tools.

--- a/src/Modules/CrestApps.OrchardCore.SignalR/Middlewares/HubApiAuthenticationMiddleware.cs
+++ b/src/Modules/CrestApps.OrchardCore.SignalR/Middlewares/HubApiAuthenticationMiddleware.cs
@@ -1,0 +1,122 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+
+namespace CrestApps.OrchardCore.SignalR.Middlewares;
+
+/// <summary>
+/// Authenticates SignalR hub requests using the Orchard Core <c>Api</c> authentication scheme so that
+/// token based clients, such as headless front-ends, mobile applications, and service-to-service callers,
+/// can connect to hubs the same way they call the API endpoints.
+/// </summary>
+/// <remarks>
+/// Cookie authenticated requests are left untouched. The <c>Api</c> scheme is only evaluated when the request
+/// targets a hub endpoint, the caller is still anonymous, and a bearer token was provided. Browsers cannot send
+/// an <c>Authorization</c> header during a WebSocket handshake, so SignalR clients send the token using the
+/// standard <c>access_token</c> query string parameter, which this middleware promotes to an
+/// <c>Authorization</c> header before authenticating.
+/// </remarks>
+public sealed class HubApiAuthenticationMiddleware
+{
+    private const string ApiAuthenticationScheme = "Api";
+
+    private const string AccessTokenQueryParameterName = "access_token";
+
+    private const string BearerPrefix = "Bearer ";
+
+    private readonly RequestDelegate _next;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HubApiAuthenticationMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="logger">The logger.</param>
+    public HubApiAuthenticationMiddleware(
+        RequestDelegate next,
+        ILogger<HubApiAuthenticationMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Processes the request and authenticates anonymous hub requests that carry a bearer token.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (IsAnonymousHubRequest(context))
+        {
+            await AuthenticateAsync(context);
+        }
+
+        await _next(context);
+    }
+
+    private static bool IsAnonymousHubRequest(HttpContext context)
+    {
+        if (context.User?.Identity?.IsAuthenticated == true)
+        {
+            return false;
+        }
+
+        return context.GetEndpoint()?.Metadata.GetMetadata<HubMetadata>() is not null;
+    }
+
+    private async Task AuthenticateAsync(HttpContext context)
+    {
+        var accessToken = GetAccessToken(context.Request);
+
+        if (string.IsNullOrEmpty(accessToken))
+        {
+            return;
+        }
+
+        var schemeProvider = context.RequestServices.GetRequiredService<IAuthenticationSchemeProvider>();
+
+        if (await schemeProvider.GetSchemeAsync(ApiAuthenticationScheme) is null)
+        {
+            return;
+        }
+
+        context.Request.Headers.Authorization = BearerPrefix + accessToken;
+
+        var result = await context.AuthenticateAsync(ApiAuthenticationScheme);
+
+        if (result.Succeeded && result.Principal is not null)
+        {
+            context.User = result.Principal;
+
+            return;
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(result.Failure, "Unable to authenticate the hub request '{Path}' using the '{Scheme}' authentication scheme.", context.Request.Path, ApiAuthenticationScheme);
+        }
+    }
+
+    private static string GetAccessToken(HttpRequest request)
+    {
+        var authorization = request.Headers[HeaderNames.Authorization].ToString();
+
+        if (authorization.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return authorization.Substring(BearerPrefix.Length).Trim();
+        }
+
+        if (!string.IsNullOrEmpty(authorization))
+        {
+            // A different authentication scheme is already in use. Leave the request untouched.
+            return null;
+        }
+
+        return request.Query[AccessTokenQueryParameterName].ToString();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.SignalR/Middlewares/HubApiAuthenticationMiddleware.cs
+++ b/src/Modules/CrestApps.OrchardCore.SignalR/Middlewares/HubApiAuthenticationMiddleware.cs
@@ -52,34 +52,44 @@ public sealed class HubApiAuthenticationMiddleware
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (IsAnonymousOptedInHubRequest(context))
+        if (IsAnonymousOptedInHubRequest(context, out var hubType))
         {
-            await AuthenticateAsync(context);
+            await AuthenticateAsync(context, hubType);
         }
 
         await _next(context);
     }
 
-    private static bool IsAnonymousOptedInHubRequest(HttpContext context)
+    private static bool IsAnonymousOptedInHubRequest(HttpContext context, out Type hubType)
     {
+        hubType = null;
+
         if (context.User?.Identity?.IsAuthenticated == true)
         {
             return false;
         }
 
         var endpoint = context.GetEndpoint();
+        var hubMetadata = endpoint?.Metadata.GetMetadata<HubMetadata>();
 
-        if (endpoint?.Metadata.GetMetadata<HubMetadata>() is null)
+        if (hubMetadata is null)
         {
             return false;
         }
 
         // MapHub copies the hub's class level attributes onto the hub and negotiate endpoints,
         // which makes the opt-in visible here without inspecting the hub type directly.
-        return endpoint.Metadata.GetMetadata<AllowApiTokenAuthenticationAttribute>() is not null;
+        if (endpoint.Metadata.GetMetadata<AllowApiTokenAuthenticationAttribute>() is null)
+        {
+            return false;
+        }
+
+        hubType = hubMetadata.HubType;
+
+        return true;
     }
 
-    private async Task AuthenticateAsync(HttpContext context)
+    private async Task AuthenticateAsync(HttpContext context, Type hubType)
     {
         var accessToken = GetAccessToken(context.Request);
 
@@ -108,7 +118,9 @@ public sealed class HubApiAuthenticationMiddleware
 
         if (_logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug(result.Failure, "Unable to authenticate the hub request '{Path}' using the '{Scheme}' authentication scheme.", context.Request.Path, ApiAuthenticationScheme);
+            // The hub type comes from the endpoint metadata rather than from the request, so nothing
+            // a caller controls is ever written to the log.
+            _logger.LogDebug(result.Failure, "Unable to authenticate a request for the '{Hub}' hub using the '{Scheme}' authentication scheme.", hubType, ApiAuthenticationScheme);
         }
     }
 

--- a/src/Modules/CrestApps.OrchardCore.SignalR/Middlewares/HubApiAuthenticationMiddleware.cs
+++ b/src/Modules/CrestApps.OrchardCore.SignalR/Middlewares/HubApiAuthenticationMiddleware.cs
@@ -13,11 +13,12 @@ namespace CrestApps.OrchardCore.SignalR.Middlewares;
 /// can connect to hubs the same way they call the API endpoints.
 /// </summary>
 /// <remarks>
-/// Cookie authenticated requests are left untouched. The <c>Api</c> scheme is only evaluated when the request
-/// targets a hub endpoint, the caller is still anonymous, and a bearer token was provided. Browsers cannot send
-/// an <c>Authorization</c> header during a WebSocket handshake, so SignalR clients send the token using the
-/// standard <c>access_token</c> query string parameter, which this middleware promotes to an
-/// <c>Authorization</c> header before authenticating.
+/// Hubs opt in by applying <see cref="AllowApiTokenAuthenticationAttribute"/>, so hubs declared by Orchard Core
+/// or by a host application are never affected. Cookie authenticated requests are left untouched. The <c>Api</c>
+/// scheme is only evaluated when the request targets an opted-in hub endpoint, the caller is still anonymous, and
+/// a bearer token was provided. Browsers cannot send an <c>Authorization</c> header during a WebSocket handshake,
+/// so SignalR clients send the token using the standard <c>access_token</c> query string parameter, which this
+/// middleware promotes to an <c>Authorization</c> header before authenticating.
 /// </remarks>
 public sealed class HubApiAuthenticationMiddleware
 {
@@ -51,7 +52,7 @@ public sealed class HubApiAuthenticationMiddleware
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (IsAnonymousHubRequest(context))
+        if (IsAnonymousOptedInHubRequest(context))
         {
             await AuthenticateAsync(context);
         }
@@ -59,14 +60,23 @@ public sealed class HubApiAuthenticationMiddleware
         await _next(context);
     }
 
-    private static bool IsAnonymousHubRequest(HttpContext context)
+    private static bool IsAnonymousOptedInHubRequest(HttpContext context)
     {
         if (context.User?.Identity?.IsAuthenticated == true)
         {
             return false;
         }
 
-        return context.GetEndpoint()?.Metadata.GetMetadata<HubMetadata>() is not null;
+        var endpoint = context.GetEndpoint();
+
+        if (endpoint?.Metadata.GetMetadata<HubMetadata>() is null)
+        {
+            return false;
+        }
+
+        // MapHub copies the hub's class level attributes onto the hub and negotiate endpoints,
+        // which makes the opt-in visible here without inspecting the hub type directly.
+        return endpoint.Metadata.GetMetadata<AllowApiTokenAuthenticationAttribute>() is not null;
     }
 
     private async Task AuthenticateAsync(HttpContext context)

--- a/src/Modules/CrestApps.OrchardCore.SignalR/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.SignalR/Startup.cs
@@ -1,7 +1,11 @@
 ﻿using System.Text.Json;
 using CrestApps.Core.SignalR.Services;
+using CrestApps.OrchardCore.SignalR.Middlewares;
 using CrestApps.OrchardCore.SignalR.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Modules;
 using OrchardCore.Settings;
@@ -13,6 +17,11 @@ namespace CrestApps.OrchardCore.SignalR;
 /// </summary>
 public sealed class Startup : StartupBase
 {
+    // The hub authentication middleware must run after the authentication middleware and
+    // before any module that authorizes endpoints.
+    public override int ConfigureOrder
+        => OrchardCoreConstants.ConfigureOrder.Authentication + 1;
+
     public override void ConfigureServices(IServiceCollection services)
     {
         services.AddScoped(sp =>
@@ -36,5 +45,10 @@ public sealed class Startup : StartupBase
             });
 
         services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
+    }
+
+    public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
+    {
+        app.UseMiddleware<HubApiAuthenticationMiddleware>();
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.Telephony/Hubs/TelephonyHub.cs
+++ b/src/Modules/CrestApps.OrchardCore.Telephony/Hubs/TelephonyHub.cs
@@ -1,3 +1,4 @@
+using CrestApps.OrchardCore.SignalR;
 using CrestApps.OrchardCore.Telephony.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
@@ -16,6 +17,7 @@ namespace CrestApps.OrchardCore.Telephony.Hubs;
 /// OrchardCore shell scope and is authorized against <see cref="TelephonyPermissions.UseSoftPhone"/>.
 /// </summary>
 [Authorize]
+[AllowApiTokenAuthentication]
 public sealed class TelephonyHub : Hub<ITelephonyClient>
 {
     private readonly ILogger _logger;

--- a/tests/CrestApps.OrchardCore.Tests/Core/Orchestration/LocalToolRegistryProviderTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Core/Orchestration/LocalToolRegistryProviderTests.cs
@@ -3,6 +3,7 @@ using CrestApps.Core.AI.Tooling;
 using CrestApps.OrchardCore.AI.Core.Orchestration;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 
@@ -206,6 +207,6 @@ public sealed class LocalToolRegistryProviderTests
         // No HttpContext means no user — permission checks are skipped.
         httpContextAccessor.Setup(x => x.HttpContext).Returns((HttpContext)null);
 
-        return new LocalToolRegistryProvider(Options.Create(options), authService.Object, httpContextAccessor.Object);
+        return new LocalToolRegistryProvider(Options.Create(options), authService.Object, httpContextAccessor.Object, NullLogger<LocalToolRegistryProvider>.Instance);
     }
 }

--- a/tests/CrestApps.OrchardCore.Tests/CrestApps.OrchardCore.Tests.csproj
+++ b/tests/CrestApps.OrchardCore.Tests/CrestApps.OrchardCore.Tests.csproj
@@ -50,6 +50,7 @@
     <ProjectReference Include="../../src/Modules/CrestApps.OrchardCore.ContentFields/CrestApps.OrchardCore.ContentFields.csproj" />
     <ProjectReference Include="../../src/Modules/CrestApps.OrchardCore.OpenAI.Azure/CrestApps.OrchardCore.OpenAI.Azure.csproj" />
     <ProjectReference Include="../../src/Modules/CrestApps.OrchardCore.Roles/CrestApps.OrchardCore.Roles.csproj" />
+    <ProjectReference Include="../../src/Modules/CrestApps.OrchardCore.SignalR/CrestApps.OrchardCore.SignalR.csproj" />
     <ProjectReference Include="../../src/Modules/CrestApps.OrchardCore.ContentAccessControl/CrestApps.OrchardCore.ContentAccessControl.csproj" />
     <ProjectReference Include="../../src/Modules/CrestApps.OrchardCore.TimeZones/CrestApps.OrchardCore.TimeZones.csproj" />
     <ProjectReference Include="../../src/Abstractions/CrestApps.OrchardCore.Telephony.Abstractions/CrestApps.OrchardCore.Telephony.Abstractions.csproj" />

--- a/tests/CrestApps.OrchardCore.Tests/Modules/SignalR/HubApiAuthenticationMiddlewareTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/SignalR/HubApiAuthenticationMiddlewareTests.cs
@@ -1,0 +1,226 @@
+using System.Security.Claims;
+using CrestApps.OrchardCore.SignalR.Middlewares;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Primitives;
+using Moq;
+
+namespace CrestApps.OrchardCore.Tests.Modules.SignalR;
+
+public sealed class HubApiAuthenticationMiddlewareTests
+{
+    private const string ApiScheme = "Api";
+
+    private const string ValidToken = "valid-token";
+
+    [Fact]
+    public async Task InvokeAsync_WhenHubRequestCarriesAccessTokenQueryString_AuthenticatesTheUser()
+    {
+        // Arrange
+        var authenticationService = new TestAuthenticationService();
+        var context = CreateHubContext(authenticationService);
+
+        context.Request.QueryString = QueryString.Create("access_token", ValidToken);
+
+        // Act
+        await CreateMiddleware().InvokeAsync(context);
+
+        // Assert
+        Assert.True(context.User.Identity.IsAuthenticated);
+        Assert.Equal("token-user", context.User.Identity.Name);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenHubRequestCarriesBearerHeader_AuthenticatesTheUser()
+    {
+        // Arrange
+        var authenticationService = new TestAuthenticationService();
+        var context = CreateHubContext(authenticationService);
+
+        context.Request.Headers.Authorization = "Bearer " + ValidToken;
+
+        // Act
+        await CreateMiddleware().InvokeAsync(context);
+
+        // Assert
+        Assert.True(context.User.Identity.IsAuthenticated);
+        Assert.Equal("token-user", context.User.Identity.Name);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenTokenIsInvalid_LeavesTheUserAnonymous()
+    {
+        // Arrange
+        var authenticationService = new TestAuthenticationService();
+        var context = CreateHubContext(authenticationService);
+
+        context.Request.QueryString = QueryString.Create("access_token", "unknown-token");
+
+        // Act
+        await CreateMiddleware().InvokeAsync(context);
+
+        // Assert
+        Assert.False(context.User.Identity.IsAuthenticated);
+        Assert.Equal(1, authenticationService.AuthenticateCallCount);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenEndpointIsNotAHub_DoesNotAuthenticate()
+    {
+        // Arrange
+        var authenticationService = new TestAuthenticationService();
+        var context = CreateHubContext(authenticationService, isHubEndpoint: false);
+
+        context.Request.QueryString = QueryString.Create("access_token", ValidToken);
+
+        // Act
+        await CreateMiddleware().InvokeAsync(context);
+
+        // Assert
+        Assert.False(context.User.Identity.IsAuthenticated);
+        Assert.Equal(0, authenticationService.AuthenticateCallCount);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenUserIsAlreadyAuthenticated_DoesNotAuthenticate()
+    {
+        // Arrange
+        var authenticationService = new TestAuthenticationService();
+        var context = CreateHubContext(authenticationService);
+
+        context.Request.QueryString = QueryString.Create("access_token", ValidToken);
+        context.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "cookie-user")], "Cookies"));
+
+        // Act
+        await CreateMiddleware().InvokeAsync(context);
+
+        // Assert
+        Assert.Equal("cookie-user", context.User.Identity.Name);
+        Assert.Equal(0, authenticationService.AuthenticateCallCount);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenNoTokenIsProvided_DoesNotAuthenticate()
+    {
+        // Arrange
+        var authenticationService = new TestAuthenticationService();
+        var context = CreateHubContext(authenticationService);
+
+        // Act
+        await CreateMiddleware().InvokeAsync(context);
+
+        // Assert
+        Assert.False(context.User.Identity.IsAuthenticated);
+        Assert.Equal(0, authenticationService.AuthenticateCallCount);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenAnotherAuthorizationSchemeIsUsed_DoesNotAuthenticate()
+    {
+        // Arrange
+        var authenticationService = new TestAuthenticationService();
+        var context = CreateHubContext(authenticationService);
+
+        context.Request.Headers.Authorization = "Basic dXNlcjpwYXNzd29yZA==";
+
+        // Act
+        await CreateMiddleware().InvokeAsync(context);
+
+        // Assert
+        Assert.False(context.User.Identity.IsAuthenticated);
+        Assert.Equal(0, authenticationService.AuthenticateCallCount);
+    }
+
+    private static HubApiAuthenticationMiddleware CreateMiddleware()
+        => new(_ => Task.CompletedTask, NullLogger<HubApiAuthenticationMiddleware>.Instance);
+
+    private static DefaultHttpContext CreateHubContext(TestAuthenticationService authenticationService, bool isHubEndpoint = true)
+    {
+        var schemeProvider = new Mock<IAuthenticationSchemeProvider>();
+
+        schemeProvider.Setup(x => x.GetSchemeAsync(ApiScheme))
+            .ReturnsAsync(new AuthenticationScheme(ApiScheme, ApiScheme, typeof(TestAuthenticationHandler)));
+
+        var services = new ServiceCollection()
+            .AddSingleton<IAuthenticationService>(authenticationService)
+            .AddSingleton(schemeProvider.Object)
+            .BuildServiceProvider();
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services,
+        };
+
+        var metadata = isHubEndpoint
+            ? new EndpointMetadataCollection(new HubMetadata(typeof(TestHub)))
+            : EndpointMetadataCollection.Empty;
+
+        context.SetEndpoint(new Endpoint(_ => Task.CompletedTask, metadata, "test"));
+
+        return context;
+    }
+
+    private sealed class TestHub : Hub
+    {
+    }
+
+    private sealed class TestAuthenticationHandler : IAuthenticationHandler
+    {
+        public Task<AuthenticateResult> AuthenticateAsync()
+            => Task.FromResult(AuthenticateResult.NoResult());
+
+        public Task ChallengeAsync(AuthenticationProperties properties)
+            => Task.CompletedTask;
+
+        public Task ForbidAsync(AuthenticationProperties properties)
+            => Task.CompletedTask;
+
+        public Task InitializeAsync(AuthenticationScheme scheme, HttpContext context)
+            => Task.CompletedTask;
+    }
+
+    private sealed class TestAuthenticationService : IAuthenticationService
+    {
+        public int AuthenticateCallCount { get; private set; }
+
+        public Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string scheme)
+        {
+            AuthenticateCallCount++;
+
+            var token = GetBearerToken(context.Request.Headers.Authorization);
+
+            if (token != ValidToken)
+            {
+                return Task.FromResult(AuthenticateResult.Fail("Invalid token."));
+            }
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "token-user")], scheme));
+
+            return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(principal, scheme)));
+        }
+
+        public Task ChallengeAsync(HttpContext context, string scheme, AuthenticationProperties properties)
+            => Task.CompletedTask;
+
+        public Task ForbidAsync(HttpContext context, string scheme, AuthenticationProperties properties)
+            => Task.CompletedTask;
+
+        public Task SignInAsync(HttpContext context, string scheme, ClaimsPrincipal principal, AuthenticationProperties properties)
+            => Task.CompletedTask;
+
+        public Task SignOutAsync(HttpContext context, string scheme, AuthenticationProperties properties)
+            => Task.CompletedTask;
+
+        private static string GetBearerToken(StringValues authorization)
+        {
+            var value = authorization.ToString();
+
+            return value.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                ? value.Substring("Bearer ".Length)
+                : null;
+        }
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Modules/SignalR/HubApiAuthenticationMiddlewareTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/SignalR/HubApiAuthenticationMiddlewareTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using CrestApps.OrchardCore.SignalR;
 using CrestApps.OrchardCore.SignalR.Middlewares;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -103,6 +104,23 @@ public sealed class HubApiAuthenticationMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_WhenHubDidNotOptIn_DoesNotAuthenticate()
+    {
+        // Arrange
+        var authenticationService = new TestAuthenticationService();
+        var context = CreateHubContext(authenticationService, allowsApiToken: false);
+
+        context.Request.QueryString = QueryString.Create("access_token", ValidToken);
+
+        // Act
+        await CreateMiddleware().InvokeAsync(context);
+
+        // Assert
+        Assert.False(context.User.Identity.IsAuthenticated);
+        Assert.Equal(0, authenticationService.AuthenticateCallCount);
+    }
+
+    [Fact]
     public async Task InvokeAsync_WhenNoTokenIsProvided_DoesNotAuthenticate()
     {
         // Arrange
@@ -137,7 +155,10 @@ public sealed class HubApiAuthenticationMiddlewareTests
     private static HubApiAuthenticationMiddleware CreateMiddleware()
         => new(_ => Task.CompletedTask, NullLogger<HubApiAuthenticationMiddleware>.Instance);
 
-    private static DefaultHttpContext CreateHubContext(TestAuthenticationService authenticationService, bool isHubEndpoint = true)
+    private static DefaultHttpContext CreateHubContext(
+        TestAuthenticationService authenticationService,
+        bool isHubEndpoint = true,
+        bool allowsApiToken = true)
     {
         var schemeProvider = new Mock<IAuthenticationSchemeProvider>();
 
@@ -154,15 +175,24 @@ public sealed class HubApiAuthenticationMiddlewareTests
             RequestServices = services,
         };
 
-        var metadata = isHubEndpoint
-            ? new EndpointMetadataCollection(new HubMetadata(typeof(TestHub)))
-            : EndpointMetadataCollection.Empty;
+        var metadata = new List<object>();
 
-        context.SetEndpoint(new Endpoint(_ => Task.CompletedTask, metadata, "test"));
+        if (isHubEndpoint)
+        {
+            metadata.Add(new HubMetadata(typeof(TestHub)));
+        }
+
+        if (allowsApiToken)
+        {
+            metadata.Add(new AllowApiTokenAuthenticationAttribute());
+        }
+
+        context.SetEndpoint(new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(metadata), "test"));
 
         return context;
     }
 
+    [AllowApiTokenAuthentication]
     private sealed class TestHub : Hub
     {
     }


### PR DESCRIPTION
Fix #512

Hubs were never running the `Api` authentication scheme, so a headless client (SPA, mobile app, or service-to-service caller) that holds a valid OpenID Connect access token connected anonymously. Only the cookie scheme ran, which works for a browser session but not for a decoupled front end.

- Add `HubApiAuthenticationMiddleware`, which detects hub endpoints through `HubMetadata` (this also covers the `/negotiate` endpoint), reads the token from the `Authorization` header or the `access_token` query string, and authenticates it with the `Api` scheme. The middleware only augments anonymous requests, so cookie-authenticated users and hubs that allow anonymous connections are unaffected.
- Register the middleware right after authentication so hubs decorated with `[Authorize]` also accept tokens.
- `LocalToolRegistryProvider` now logs a Warning naming the tools that were removed because the user lacks `AccessAnyAITool` or the tool-specific permission, instead of skipping them silently.
- Document the tool permissions and the hub access-token flow.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
