### PR TITLE
Resolve the AI tool authorization caller through IAIUserAccessor

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrchardCoreVersion>[3.0.0, )</OrchardCoreVersion>
-    <CrestAppsCoreVersion>1.0.0-preview.194</CrestAppsCoreVersion>
+    <CrestAppsCoreVersion>1.0.0-preview.198</CrestAppsCoreVersion>
     <ModelContextProtocolVersion>1.4.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Orchestration/LocalToolRegistryProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Orchestration/LocalToolRegistryProvider.cs
@@ -1,7 +1,7 @@
 using CrestApps.Core.AI.Models;
+using CrestApps.Core.Security;
 using CrestApps.Core.AI.Tooling;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -16,7 +16,7 @@ internal sealed class LocalToolRegistryProvider : IToolRegistryProvider
 {
     private readonly IOptions<AIToolDefinitionOptions> _toolDefinitions;
     private readonly IAuthorizationService _authorizationService;
-    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUserAccessor _userAccessor;
     private readonly ILogger _logger;
 
     /// <summary>
@@ -24,17 +24,17 @@ internal sealed class LocalToolRegistryProvider : IToolRegistryProvider
     /// </summary>
     /// <param name="toolDefinitions">The registered AI tool definitions.</param>
     /// <param name="authorizationService">The authorization service for verifying tool access.</param>
-    /// <param name="httpContextAccessor">The HTTP context accessor for retrieving the current user.</param>
+    /// <param name="userAccessor">The accessor used to resolve the caller that the tools are being resolved for.</param>
     /// <param name="logger">The logger.</param>
     public LocalToolRegistryProvider(
         IOptions<AIToolDefinitionOptions> toolDefinitions,
         IAuthorizationService authorizationService,
-        IHttpContextAccessor httpContextAccessor,
+        IUserAccessor userAccessor,
         ILogger<LocalToolRegistryProvider> logger)
     {
         _toolDefinitions = toolDefinitions;
         _authorizationService = authorizationService;
-        _httpContextAccessor = httpContextAccessor;
+        _userAccessor = userAccessor;
         _logger = logger;
     }
 
@@ -58,7 +58,7 @@ internal sealed class LocalToolRegistryProvider : IToolRegistryProvider
 
         var toolDefinitions = _toolDefinitions.Value.Tools;
         var entries = new List<ToolRegistryEntry>();
-        var user = _httpContextAccessor.HttpContext?.User;
+        var user = _userAccessor.User;
         List<string> unauthorizedToolNames = null;
 
         foreach (var toolName in configuredToolNames)
@@ -75,7 +75,9 @@ internal sealed class LocalToolRegistryProvider : IToolRegistryProvider
                 continue;
             }
 
-            // Verify user has permission to access this tool.
+            // A null user means there is no caller at all, such as a background task or a recipe,
+            // so authorization is skipped. Unauthenticated callers are still evaluated so that
+            // permissions granted to the Anonymous role continue to apply.
 
             if (user is not null &&
                 !await _authorizationService.AuthorizeAsync(user, AIPermissions.AccessAITool, toolName as object))

--- a/src/CrestApps.Docs/docs/ai/tools.md
+++ b/src/CrestApps.Docs/docs/ai/tools.md
@@ -193,6 +193,15 @@ When the current identity is not authorized for a configured tool, the tool is e
 Custom roles and OpenID applications that query tool-enabled profiles need `AccessAnyAITool`, or the matching `AccessAITool_{toolName}` permission for every tool the profile uses, in addition to the profile query permission.
 :::
 
+### How the caller is resolved
+
+The identity used for these checks comes from the framework's `IUserAccessor` rather than from `IHttpContextAccessor`. This matters for SignalR: `HttpContext` is frequently unavailable inside hub invocations on long-lived transports, on backplane-delivered messages, and behind hosted SignalR services, so resolving the caller from the HTTP request could not be relied upon there. The AI chat and chat interaction hubs publish the connection's principal for the duration of every invocation, which means tool permissions are evaluated the same way over SignalR as they are over a regular HTTP request.
+
+Two cases are treated differently:
+
+- **No caller at all**, such as a background task, a workflow, or a recipe. Permission checks are skipped and every configured tool stays available, because trusted server-side code is not a security boundary.
+- **An unauthenticated caller**, such as an anonymous visitor using a public chat widget. The permission check still runs, so whatever you grant the `Anonymous` role continues to apply exactly as it does elsewhere in Orchard Core.
+
 ## Invocation Context (AIInvocationScope)
 
 `AIInvocationScope` is the shared per-request context for references, tool state, and other invocation-scoped data. For the framework-level explanation, see the shared Core documentation:

--- a/src/CrestApps.Docs/docs/changelog/v2.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/v2.0.0.md
@@ -66,6 +66,7 @@ At a high level, the platform changes are:
 - The shared Orchard-facing AI code now uses `IClock` consistently for timestamps, and the Orchard integration now defers to the shared `CrestApps.Core.AI.Handlers.AIProfileHandler` instead of keeping duplicate local profile validation handlers.
 - AI administration is reorganized in the v2 line. Settings, profile flows, and deployment defaults are grouped differently than in `v1.x`, and operator guidance should be updated accordingly.
 - The AI configuration section now uses the nested `OrchardCore:CrestApps:AI` path. The old `CrestApps_AI` paths still work, but they log deprecation warnings and should be treated as transitional.
+- AI tool permission checks now resolve the caller through the framework's `IUserAccessor` instead of `IHttpContextAccessor`. `HttpContext` is frequently unavailable inside SignalR hub invocations, so tools were previously filtered against a missing user and could be dropped from chat-hub requests. Requests with no caller at all, such as background tasks, workflows, and recipes, still skip the permission check, while anonymous callers are evaluated normally so permissions granted to the `Anonymous` role continue to apply.
 
 #### A2A
 

--- a/tests/CrestApps.OrchardCore.Tests/Core/Orchestration/LocalToolRegistryProviderTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Core/Orchestration/LocalToolRegistryProviderTests.cs
@@ -1,8 +1,9 @@
+using System.Security.Claims;
 using CrestApps.Core.AI.Models;
+using CrestApps.Core.Security;
 using CrestApps.Core.AI.Tooling;
 using CrestApps.OrchardCore.AI.Core.Orchestration;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -199,14 +200,110 @@ public sealed class LocalToolRegistryProviderTests
         return CreateProviderWithOptions(options);
     }
 
+    [Fact]
+    public async Task GetToolsAsync_WhenThereIsNoCaller_SkipsAuthorization()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        var provider = CreateProviderWithUser(authService.Object, user: null, ("tool1", "Tool 1", "First tool"));
+
+        var result = await provider.GetToolsAsync(new AICompletionContext { ToolNames = ["tool1"] }, TestContext.Current.CancellationToken);
+
+        Assert.Single(result);
+        authService.Verify(
+            x => x.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<IEnumerable<IAuthorizationRequirement>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetToolsAsync_WhenCallerIsAuthorized_ReturnsTheTool()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        authService
+            .Setup(x => x.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
+            .ReturnsAsync(AuthorizationResult.Success());
+
+        var provider = CreateProviderWithUser(authService.Object, CreateUser(), ("tool1", "Tool 1", "First tool"));
+
+        var result = await provider.GetToolsAsync(new AICompletionContext { ToolNames = ["tool1"] }, TestContext.Current.CancellationToken);
+
+        Assert.Single(result);
+        Assert.Equal("tool1", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetToolsAsync_WhenCallerIsNotAuthorized_ExcludesTheTool()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        authService
+            .Setup(x => x.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
+            .ReturnsAsync(AuthorizationResult.Failed());
+
+        var provider = CreateProviderWithUser(authService.Object, CreateUser(), ("tool1", "Tool 1", "First tool"));
+
+        var result = await provider.GetToolsAsync(new AICompletionContext { ToolNames = ["tool1"] }, TestContext.Current.CancellationToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetToolsAsync_WhenCallerIsAnonymous_StillEvaluatesAuthorization()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        authService
+            .Setup(x => x.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
+            .ReturnsAsync(AuthorizationResult.Failed());
+
+        var anonymousUser = new ClaimsPrincipal(new ClaimsIdentity());
+        var provider = CreateProviderWithUser(authService.Object, anonymousUser, ("tool1", "Tool 1", "First tool"));
+
+        var result = await provider.GetToolsAsync(new AICompletionContext { ToolNames = ["tool1"] }, TestContext.Current.CancellationToken);
+
+        Assert.Empty(result);
+        authService.Verify(
+            x => x.AuthorizeAsync(anonymousUser, It.IsAny<object>(), It.IsAny<IEnumerable<IAuthorizationRequirement>>()),
+            Times.Once);
+    }
+
+    private static ClaimsPrincipal CreateUser()
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "test-user")], "Test"));
+    }
+
+    private static LocalToolRegistryProvider CreateProviderWithUser(
+        IAuthorizationService authorizationService,
+        ClaimsPrincipal user,
+        params (string Name, string Title, string Description)[] tools)
+    {
+        var options = new AIToolDefinitionOptions();
+
+        foreach (var (name, title, description) in tools)
+        {
+            options.SetTool(name, new AIToolDefinitionEntry(typeof(Microsoft.Extensions.AI.AIFunction))
+            {
+                Name = name,
+                Title = title,
+                Description = description,
+            });
+        }
+
+        return CreateProviderWithOptions(options, authorizationService, user);
+    }
+
     private static LocalToolRegistryProvider CreateProviderWithOptions(AIToolDefinitionOptions options)
     {
         var authService = new Mock<IAuthorizationService>();
-        var httpContextAccessor = new Mock<IHttpContextAccessor>();
 
-        // No HttpContext means no user — permission checks are skipped.
-        httpContextAccessor.Setup(x => x.HttpContext).Returns((HttpContext)null);
+        return CreateProviderWithOptions(options, authService.Object, user: null);
+    }
 
-        return new LocalToolRegistryProvider(Options.Create(options), authService.Object, httpContextAccessor.Object, NullLogger<LocalToolRegistryProvider>.Instance);
+    private static LocalToolRegistryProvider CreateProviderWithOptions(
+        AIToolDefinitionOptions options,
+        IAuthorizationService authorizationService,
+        ClaimsPrincipal user)
+    {
+        var userAccessor = new Mock<IUserAccessor>();
+        userAccessor.Setup(x => x.User).Returns(user);
+
+        return new LocalToolRegistryProvider(Options.Create(options), authorizationService, userAccessor.Object, NullLogger<LocalToolRegistryProvider>.Instance);
     }
 }


### PR DESCRIPTION
LocalToolRegistryProvider filtered tools by reading the current user from IHttpContextAccessor. HttpContext is frequently unavailable inside SignalR hub invocations, so chat-hub requests evaluated tool permissions against a missing user.

Switch to the framework's IAIUserAccessor, which the AI chat and chat interaction hubs populate with the connection principal for the duration of every invocation. The null policy is unchanged and now matches the framework: no caller at all, such as a background task, a workflow, or a recipe, skips the permission check, while anonymous callers are still evaluated so permissions granted to the Anonymous role keep applying.

Requires a CrestApps.Core package that includes IAIUserAccessor.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
