### PR TITLE
Add Contacts menu item to the Interaction Center

### DIFF
--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -15,6 +15,19 @@ This page highlights the changes in the `3.0.0` line.
 
 - The `crestapps-bootstrap-select` style and script have been removed from the `Resource` module. Instead you should use the `bootstrap-select` style and script which are registered by Orchard Core.
 
+### Omnichannel Management
+
+- The `OmnichannelContentTypeProvider` service is now registered as **scoped** instead of **singleton**, and its public query methods are now asynchronous and return `ValueTask`. Update any callers accordingly:
+
+  | Old (synchronous) | New (asynchronous) |
+  |---|---|
+  | `bool IsSubjectContentType(string contentType)` | `ValueTask<bool> IsSubjectContentTypeAsync(string contentType)` |
+  | `bool IsContactContentType(string contentType)` | `ValueTask<bool> IsContactContentTypeAsync(string contentType)` |
+  | `IReadOnlyCollection<string> GetSubjectContentTypes()` | `ValueTask<IReadOnlyCollection<string>> GetSubjectContentTypesAsync()` |
+  | `IReadOnlyCollection<string> GetContactContentType()` | `ValueTask<IReadOnlyCollection<string>> GetContactContentTypesAsync()` |
+
+  The provider now caches its membership sets in a per-tenant `IMemoryCache`, so the initialization is handled internally and callers should simply `await` the query methods.
+
 -----
 
 ## Change Logs

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -26,7 +26,7 @@ This page highlights the changes in the `3.0.0` line.
   | `IReadOnlyCollection<string> GetSubjectContentTypes()` | `ValueTask<IReadOnlyCollection<string>> GetSubjectContentTypesAsync()` |
   | `IReadOnlyCollection<string> GetContactContentType()` | `ValueTask<IReadOnlyCollection<string>> GetContactContentTypesAsync()` |
 
-  The provider now caches its membership sets in a per-tenant `IMemoryCache`, so the initialization is handled internally and callers should simply `await` the query methods.
+  The provider now caches its membership sets in a per-tenant `IMemoryCache`, so the initialization is handled internally and callers should simply `await` the query methods. `OmnichannelContentTypeProvider` no longer implements `IContentDefinitionEventHandler`; cache invalidation on content definition changes is handled by a separate internal handler.
 
 -----
 

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -19,6 +19,16 @@ This page highlights the changes in the `3.0.0` line.
 
 ## Change Logs
 
+### Omnichannel Management
+
+#### Contacts menu in the Interaction Center
+
+The **Interaction Center** admin menu now includes a **Contacts** item. It opens the standard Orchard Core content list restricted to the Omnichannel contact content types by passing every content type that attaches `OmnichannelContactPart` as a comma-separated `contentTypeId` to the content `List` action. The contact types come from the cached content-type provider, so the menu stays in sync as the part is attached or detached. The item is guarded by the **List content** permission.
+
+See [Omnichannel Management](../omnichannel/management) for details.
+
+-----
+
 ### AI Documents
 
 #### File upload security scanning through Orchard Core

--- a/src/CrestApps.Docs/docs/omnichannel/management.md
+++ b/src/CrestApps.Docs/docs/omnichannel/management.md
@@ -310,6 +310,12 @@ The scheduled activities list now includes a **Time zone** filter alongside the 
 
 Users with the **Purge activity** permission see a **Purge** button on each scheduled activity in a contact profile. Purging is irreversible, changes the activity status to `Purged`, records the UTC purge time and current user's identifier and username for auditing, and clears any reservation state while preserving assignment. The same permission is required for the bulk **Purge** action on the Manage Activities page; every activity in one bulk operation records the same purge time and actor, and **Manage activities** implies **Purge activity**.
 
+### Contacts list
+
+The `Interaction Center` → `Contacts` menu item opens the standard Orchard Core content list restricted to your Omnichannel contact content types. It links to the content `List` action and passes every content type that has `OmnichannelContactPart` attached as a comma-separated `contentTypeId`, so the resulting screen only shows contact items and only offers contact types when creating new content.
+
+The contact content types are read from the cached provider that tracks which types attach `OmnichannelContactPart`, so the menu stays in sync as you attach or detach the part without scanning every content definition on each request. The menu item is available to users with the **List content** permission.
+
 ### Phone number search
 
 Phone filters in **Load Inventory**, **Manage Activities**, and Content Admin search the primary **Cell** and **Home** contact methods.

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Drivers/OmnichannelActivityBatchDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Drivers/OmnichannelActivityBatchDisplayDriver.cs
@@ -148,11 +148,11 @@ internal sealed class OmnichannelActivityBatchDisplayDriver : DisplayDriver<Omni
                 subjectContentTypes.Add(new SelectListItem(contentType.DisplayName, contentType.Name));
             }
 
-            await _contentTypeProvider.EnsureInitializedAsync(_contentDefinitionManager);
+            var contactContentTypeNames = await _contentTypeProvider.GetContactContentTypesAsync();
 
             foreach (var contentType in await _contentDefinitionManager.ListTypeDefinitionsAsync())
             {
-                if (_contentTypeProvider.IsContactContentType(contentType.Name))
+                if (contactContentTypeNames.Contains(contentType.Name))
                 {
                     contactContentTypes.Add(new SelectListItem(contentType.DisplayName, contentType.Name));
                 }

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Drivers/OmnichannelActivityDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Drivers/OmnichannelActivityDisplayDriver.cs
@@ -124,11 +124,11 @@ internal sealed class OmnichannelActivityDisplayDriver : DisplayDriver<Omnichann
                 model.SubjectContentType = subjectContentTypes[0].Value;
             }
 
-            await _contentTypeProvider.EnsureInitializedAsync(_contentDefinitionManager);
+            var contactContentTypeNames = await _contentTypeProvider.GetContactContentTypesAsync();
 
             foreach (var contentType in await _contentDefinitionManager.ListTypeDefinitionsAsync())
             {
-                if (_contentTypeProvider.IsContactContentType(contentType.Name))
+                if (contactContentTypeNames.Contains(contentType.Name))
                 {
                     contactContentTypes.Add(new SelectListItem(contentType.DisplayName, contentType.Name));
                 }

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Handlers/OmnichannelContentTypeCacheInvalidator.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Handlers/OmnichannelContentTypeCacheInvalidator.cs
@@ -1,0 +1,115 @@
+using CrestApps.OrchardCore.Omnichannel.Managements.Services;
+using Microsoft.Extensions.Caching.Memory;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentTypes.Events;
+using OrchardCore.Environment.Shell;
+
+namespace CrestApps.OrchardCore.Omnichannel.Managements.Handlers;
+
+/// <summary>
+/// Invalidates the per-tenant omnichannel content type cache maintained by <see cref="OmnichannelContentTypeProvider"/>
+/// whenever a content definition changes, so the next read recomputes fresh subject and contact membership sets.
+/// This handler is intentionally separate from the provider: the provider resolves <c>IContentDefinitionManager</c>,
+/// and registering the provider itself as an <see cref="IContentDefinitionEventHandler"/> would create a circular
+/// dependency because resolving the manager resolves its event handlers.
+/// </summary>
+internal sealed class OmnichannelContentTypeCacheInvalidator : IContentDefinitionEventHandler
+{
+    private readonly IMemoryCache _memoryCache;
+    private readonly string _cacheKey;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OmnichannelContentTypeCacheInvalidator"/> class.
+    /// </summary>
+    /// <param name="memoryCache">The per-tenant memory cache holding the omnichannel content type membership sets.</param>
+    /// <param name="shellSettings">The shell settings used to scope the cache entry to the current tenant.</param>
+    public OmnichannelContentTypeCacheInvalidator(
+        IMemoryCache memoryCache,
+        ShellSettings shellSettings)
+    {
+        _memoryCache = memoryCache;
+        _cacheKey = OmnichannelContentTypeProvider.GetCacheKey(shellSettings);
+    }
+
+    /// <inheritdoc/>
+    public void ContentTypeCreated(ContentTypeCreatedContext context)
+        => Invalidate();
+
+    /// <inheritdoc/>
+    public void ContentTypeUpdated(ContentTypeUpdatedContext context)
+        => Invalidate();
+
+    /// <inheritdoc/>
+    public void ContentTypeImported(ContentTypeImportedContext context)
+        => Invalidate();
+
+    /// <inheritdoc/>
+    public void ContentTypeRemoved(ContentTypeRemovedContext context)
+        => Invalidate();
+
+    /// <inheritdoc/>
+    public void ContentPartAttached(ContentPartAttachedContext context)
+        => Invalidate();
+
+    /// <inheritdoc/>
+    public void ContentPartDetached(ContentPartDetachedContext context)
+        => Invalidate();
+
+    /// <inheritdoc/>
+    public void ContentTypeImporting(ContentTypeImportingContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentPartCreated(ContentPartCreatedContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentPartUpdated(ContentPartUpdatedContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentPartRemoved(ContentPartRemovedContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentPartImporting(ContentPartImportingContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentPartImported(ContentPartImportedContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentTypePartUpdated(ContentTypePartUpdatedContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentFieldAttached(ContentFieldAttachedContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentFieldUpdated(ContentFieldUpdatedContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentFieldDetached(ContentFieldDetachedContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void ContentPartFieldUpdated(ContentPartFieldUpdatedContext context)
+    {
+    }
+
+    private void Invalidate()
+        => _memoryCache.Remove(_cacheKey);
+}

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/OmnichannelActivitiesStartup.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/OmnichannelActivitiesStartup.cs
@@ -92,8 +92,8 @@ public sealed class OmnichannelActivitiesStartup : StartupBase
             .AddScoped<IActivityDispositionService, DefaultActivityDispositionService>()
             .AddScoped<IAutomatedActivityCompletionService, AutomatedActivityCompletionService>();
 
-        services.AddSingleton<OmnichannelContentTypeProvider>();
-        services.AddSingleton<IContentDefinitionEventHandler>(sp => sp.GetRequiredService<OmnichannelContentTypeProvider>());
+        services.AddScoped<OmnichannelContentTypeProvider>();
+        services.AddScoped<IContentDefinitionEventHandler>(sp => sp.GetRequiredService<OmnichannelContentTypeProvider>());
 
         services.AddScoped<ISubjectFlowSettingsService, SubjectFlowSettingsService>();
 

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/OmnichannelActivitiesStartup.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/OmnichannelActivitiesStartup.cs
@@ -93,7 +93,7 @@ public sealed class OmnichannelActivitiesStartup : StartupBase
             .AddScoped<IAutomatedActivityCompletionService, AutomatedActivityCompletionService>();
 
         services.AddScoped<OmnichannelContentTypeProvider>();
-        services.AddScoped<IContentDefinitionEventHandler>(sp => sp.GetRequiredService<OmnichannelContentTypeProvider>());
+        services.AddScoped<IContentDefinitionEventHandler, OmnichannelContentTypeCacheInvalidator>();
 
         services.AddScoped<ISubjectFlowSettingsService, SubjectFlowSettingsService>();
 

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/AdminMenu.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/AdminMenu.cs
@@ -1,7 +1,6 @@
 using CrestApps.OrchardCore.Omnichannel.Core;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Localization;
-using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Contents;
 using OrchardCore.Navigation;
 
@@ -9,7 +8,6 @@ namespace CrestApps.OrchardCore.Omnichannel.Managements.Services;
 
 internal sealed class AdminMenu : AdminNavigationProvider
 {
-    private readonly IContentDefinitionManager _contentDefinitionManager;
     private readonly OmnichannelContentTypeProvider _contentTypeProvider;
 
     internal readonly IStringLocalizer S;
@@ -17,24 +15,19 @@ internal sealed class AdminMenu : AdminNavigationProvider
     /// <summary>
     /// Initializes a new instance of the <see cref="AdminMenu"/> class.
     /// </summary>
-    /// <param name="contentDefinitionManager">The content definition manager used to warm the contact content type cache.</param>
     /// <param name="contentTypeProvider">The provider that exposes the cached omnichannel contact content types.</param>
     /// <param name="stringLocalizer">The string localizer.</param>
     public AdminMenu(
-        IContentDefinitionManager contentDefinitionManager,
         OmnichannelContentTypeProvider contentTypeProvider,
         IStringLocalizer<AdminMenu> stringLocalizer)
     {
-        _contentDefinitionManager = contentDefinitionManager;
         _contentTypeProvider = contentTypeProvider;
         S = stringLocalizer;
     }
 
     protected override async ValueTask BuildAsync(NavigationBuilder builder)
     {
-        await _contentTypeProvider.EnsureInitializedAsync(_contentDefinitionManager);
-
-        var contactContentTypes = _contentTypeProvider.GetContactContentTypes();
+        var contactContentTypes = await _contentTypeProvider.GetContactContentTypesAsync();
 
         builder
             .Add(S["Interaction Center"], "80", interactionCenter => interactionCenter

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/AdminMenu.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/AdminMenu.cs
@@ -1,24 +1,41 @@
 ﻿using CrestApps.OrchardCore.Omnichannel.Core;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Localization;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.Contents;
 using OrchardCore.Navigation;
 
 namespace CrestApps.OrchardCore.Omnichannel.Managements.Services;
 
 internal sealed class AdminMenu : AdminNavigationProvider
 {
+    private readonly IContentDefinitionManager _contentDefinitionManager;
+    private readonly OmnichannelContentTypeProvider _contentTypeProvider;
+
     internal readonly IStringLocalizer S;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AdminMenu"/> class.
     /// </summary>
+    /// <param name="contentDefinitionManager">The content definition manager used to warm the contact content type cache.</param>
+    /// <param name="contentTypeProvider">The provider that exposes the cached omnichannel contact content types.</param>
     /// <param name="stringLocalizer">The string localizer.</param>
-    public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
+    public AdminMenu(
+        IContentDefinitionManager contentDefinitionManager,
+        OmnichannelContentTypeProvider contentTypeProvider,
+        IStringLocalizer<AdminMenu> stringLocalizer)
     {
+        _contentDefinitionManager = contentDefinitionManager;
+        _contentTypeProvider = contentTypeProvider;
         S = stringLocalizer;
     }
 
-    protected override ValueTask BuildAsync(NavigationBuilder builder)
+    protected override async ValueTask BuildAsync(NavigationBuilder builder)
     {
+        await _contentTypeProvider.EnsureInitializedAsync(_contentDefinitionManager);
+
+        var contactContentTypes = _contentTypeProvider.GetContactContentTypes();
+
         builder
             .Add(S["Interaction Center"], "80", interactionCenter => interactionCenter
                 .AddClass("interaction-center")
@@ -30,6 +47,26 @@ internal sealed class AdminMenu : AdminNavigationProvider
                     .Permission(OmnichannelConstants.Permissions.ListActivities)
                     .LocalNav()
                 )
+                .Add(S["Contacts"], "0", contacts =>
+                {
+                    contacts
+                        .AddClass("contacts")
+                        .Id("contacts");
+
+                    if (contactContentTypes.Count > 0)
+                    {
+                        contacts
+                            .Action("List", "Admin", new RouteValueDictionary
+                            {
+                                { "area", "OrchardCore.Contents" },
+                                { "contentTypeId", string.Join(',', contactContentTypes) },
+                            });
+                    }
+
+                    contacts
+                        .Permission(CommonPermissions.ListContent)
+                        .LocalNav();
+                })
                 .Add(S["Management"], "100", management => management
                     .AddClass("interaction-center-management")
                     .Id("interactionCenterManagement")
@@ -76,7 +113,5 @@ internal sealed class AdminMenu : AdminNavigationProvider
                         .Permission(OmnichannelConstants.Permissions.ManageChannelEndpoints)
                         .LocalNav())),
                 priority: 1);
-
-        return ValueTask.CompletedTask;
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/AdminMenu.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/AdminMenu.cs
@@ -1,4 +1,4 @@
-﻿using CrestApps.OrchardCore.Omnichannel.Core;
+using CrestApps.OrchardCore.Omnichannel.Core;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Localization;
 using OrchardCore.ContentManagement.Metadata;
@@ -40,14 +40,14 @@ internal sealed class AdminMenu : AdminNavigationProvider
             .Add(S["Interaction Center"], "80", interactionCenter => interactionCenter
                 .AddClass("interaction-center")
                 .Id("interactionCenter")
-                .Add(S["Activities"], "-1", activities => activities
+                .Add(S["Activities"], S["Activities"].PrefixPosition(), activities => activities
                     .AddClass("activities")
                     .Id("activities")
                     .Action("Activities", "Activities", "CrestApps.OrchardCore.Omnichannel.Managements")
                     .Permission(OmnichannelConstants.Permissions.ListActivities)
                     .LocalNav()
                 )
-                .Add(S["Contacts"], "0", contacts =>
+                .Add(S["Contacts"], S["Contacts"].PrefixPosition(), contacts =>
                 {
                     contacts
                         .AddClass("contacts")
@@ -67,10 +67,10 @@ internal sealed class AdminMenu : AdminNavigationProvider
                         .Permission(CommonPermissions.ListContent)
                         .LocalNav();
                 })
-                .Add(S["Management"], "100", management => management
+                .Add(S["Management"], S["Management"].PrefixPosition(), management => management
                     .AddClass("interaction-center-management")
                     .Id("interactionCenterManagement")
-                    .Add(S["Manage Activities"], S["Manage Activities"].PrefixPosition("3"), manageActivities => manageActivities
+                    .Add(S["Manage Activities"], S["Manage Activities"].PrefixPosition(), manageActivities => manageActivities
                         .AddClass("manage-activities")
                         .Id("manageActivities")
                         .Action("ManageActivities", "Activities", "CrestApps.OrchardCore.Omnichannel.Managements")
@@ -111,7 +111,9 @@ internal sealed class AdminMenu : AdminNavigationProvider
                         .Id("channelEndpoints")
                         .Action("Index", "ChannelEndpoints", "CrestApps.OrchardCore.Omnichannel.Managements")
                         .Permission(OmnichannelConstants.Permissions.ManageChannelEndpoints)
-                        .LocalNav())),
+                        .LocalNav()
+                    )
+                ),
                 priority: 1);
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeProvider.cs
@@ -14,7 +14,7 @@ namespace CrestApps.OrchardCore.Omnichannel.Managements.Services;
 /// </summary>
 public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHandler
 {
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     private volatile HashSet<string> _subjectContentTypes;
     private volatile HashSet<string> _contactContentTypes;
@@ -40,14 +40,14 @@ public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHand
     /// </summary>
     /// <returns>A read-only snapshot of the subject content type names.</returns>
     public IReadOnlyCollection<string> GetSubjectContentTypes()
-        => _subjectContentTypes ?? (IReadOnlyCollection<string>)Array.Empty<string>();
+        => _subjectContentTypes ?? (IReadOnlyCollection<string>)[];
 
     /// <summary>
     /// Gets the technical names of the content types that have the <c>OmnichannelContactPart</c> attached.
     /// </summary>
     /// <returns>A read-only snapshot of the contact content type names.</returns>
     public IReadOnlyCollection<string> GetContactContentTypes()
-        => _contactContentTypes ?? (IReadOnlyCollection<string>)Array.Empty<string>();
+        => _contactContentTypes ?? (IReadOnlyCollection<string>)[];
 
     /// <summary>
     /// Warms the cached sets from the current content definitions the first time they are requested. Subsequent

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeProvider.cs
@@ -1,8 +1,5 @@
-using CrestApps.OrchardCore.Omnichannel.Core;
 using Microsoft.Extensions.Caching.Memory;
 using OrchardCore.ContentManagement.Metadata;
-using OrchardCore.ContentManagement.Metadata.Models;
-using OrchardCore.ContentTypes.Events;
 using OrchardCore.Environment.Shell;
 
 namespace CrestApps.OrchardCore.Omnichannel.Managements.Services;
@@ -11,13 +8,12 @@ namespace CrestApps.OrchardCore.Omnichannel.Managements.Services;
 /// Reports the content types that have the <c>OmnichannelSubjectPart</c> or the <c>OmnichannelContactPart</c>
 /// attached, so callers can answer that question and build subject and contact content type drop downs without
 /// scanning every content type definition on each request. The membership sets are computed once and cached in
-/// the per-tenant <see cref="IMemoryCache"/>, then kept current through the <see cref="IContentDefinitionEventHandler"/>
-/// notifications so they always reflect the latest definitions without repeated enumeration.
+/// the per-tenant <see cref="IMemoryCache"/>. The cache entry is invalidated by
+/// <c>OmnichannelContentTypeCacheInvalidator</c> when a content definition changes, so the next read recomputes
+/// fresh sets that reflect the latest definitions.
 /// </summary>
-public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHandler
+public sealed class OmnichannelContentTypeProvider
 {
-    private static readonly Lock _lock = new();
-
     private readonly IContentDefinitionManager _contentDefinitionManager;
     private readonly IMemoryCache _memoryCache;
     private readonly string _cacheKey;
@@ -136,168 +132,9 @@ public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHand
 
         var set = new OmnichannelContentTypeSet(subjectContentTypes, contactContentTypes);
 
-        lock (_lock)
-        {
-            if (_memoryCache.TryGetValue<OmnichannelContentTypeSet>(_cacheKey, out var existing) && existing is not null)
-            {
-                set = existing;
-            }
-            else
-            {
-                _memoryCache.Set(_cacheKey, set);
-            }
-        }
-
+        _memoryCache.Set(_cacheKey, set);
         _set = set;
 
         return set;
     }
-
-    /// <inheritdoc/>
-    public void ContentTypeCreated(ContentTypeCreatedContext context)
-        => Apply(context.ContentTypeDefinition);
-
-    /// <inheritdoc/>
-    public void ContentTypeUpdated(ContentTypeUpdatedContext context)
-        => Apply(context.ContentTypeDefinition);
-
-    /// <inheritdoc/>
-    public void ContentTypeImported(ContentTypeImportedContext context)
-        => Apply(context.ContentTypeDefinition);
-
-    /// <inheritdoc/>
-    public void ContentTypeRemoved(ContentTypeRemovedContext context)
-    {
-        var contentType = context.ContentTypeDefinition?.Name;
-
-        SetMembership(subject: true, contentType, isMember: false);
-        SetMembership(subject: false, contentType, isMember: false);
-    }
-
-    /// <inheritdoc/>
-    public void ContentPartAttached(ContentPartAttachedContext context)
-    {
-        if (IsSubjectPart(context.ContentPartName))
-        {
-            SetMembership(subject: true, context.ContentTypeName, isMember: true);
-        }
-        else if (IsContactPart(context.ContentPartName))
-        {
-            SetMembership(subject: false, context.ContentTypeName, isMember: true);
-        }
-    }
-
-    /// <inheritdoc/>
-    public void ContentPartDetached(ContentPartDetachedContext context)
-    {
-        if (IsSubjectPart(context.ContentPartName))
-        {
-            SetMembership(subject: true, context.ContentTypeName, isMember: false);
-        }
-        else if (IsContactPart(context.ContentPartName))
-        {
-            SetMembership(subject: false, context.ContentTypeName, isMember: false);
-        }
-    }
-
-    /// <inheritdoc/>
-    public void ContentTypeImporting(ContentTypeImportingContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentPartCreated(ContentPartCreatedContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentPartUpdated(ContentPartUpdatedContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentPartRemoved(ContentPartRemovedContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentPartImporting(ContentPartImportingContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentPartImported(ContentPartImportedContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentTypePartUpdated(ContentTypePartUpdatedContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentFieldAttached(ContentFieldAttachedContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentFieldUpdated(ContentFieldUpdatedContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentFieldDetached(ContentFieldDetachedContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void ContentPartFieldUpdated(ContentPartFieldUpdatedContext context)
-    {
-    }
-
-    private void Apply(ContentTypeDefinition contentTypeDefinition)
-    {
-        if (contentTypeDefinition is null)
-        {
-            return;
-        }
-
-        SetMembership(subject: true, contentTypeDefinition.Name, OmnichannelSubjectDefinitionService.HasOmnichannelSubjectPart(contentTypeDefinition));
-        SetMembership(subject: false, contentTypeDefinition.Name, OmnichannelContactDefinitionService.HasOmnichannelContactPart(contentTypeDefinition));
-    }
-
-    private void SetMembership(bool subject, string contentType, bool isMember)
-    {
-        if (string.IsNullOrEmpty(contentType))
-        {
-            return;
-        }
-
-        lock (_lock)
-        {
-            // Skip incremental updates until the set has been warmed; the initial warm reads the current
-            // definitions and therefore already reflects any change that happened before it ran.
-            if (!_memoryCache.TryGetValue<OmnichannelContentTypeSet>(_cacheKey, out var current) || current is null)
-            {
-                _set = null;
-
-                return;
-            }
-
-            var updated = current.With(subject, contentType, isMember);
-
-            if (!ReferenceEquals(updated, current))
-            {
-                _memoryCache.Set(_cacheKey, updated);
-            }
-
-            _set = updated;
-        }
-    }
-
-    private static bool IsSubjectPart(string partName)
-        => string.Equals(partName, OmnichannelConstants.ContentParts.OmnichannelSubject, StringComparison.Ordinal);
-
-    private static bool IsContactPart(string partName)
-        => string.Equals(partName, OmnichannelConstants.ContentParts.OmnichannelContact, StringComparison.Ordinal);
 }

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeProvider.cs
@@ -1,72 +1,127 @@
 using CrestApps.OrchardCore.Omnichannel.Core;
+using Microsoft.Extensions.Caching.Memory;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Events;
+using OrchardCore.Environment.Shell;
 
 namespace CrestApps.OrchardCore.Omnichannel.Managements.Services;
 
 /// <summary>
-/// Maintains in-memory sets of the content types that have the <c>OmnichannelSubjectPart</c> or the
-/// <c>OmnichannelContactPart</c> attached so callers can answer that question, and build subject and contact
-/// content type drop downs, without scanning every content type definition on each request. The sets are warmed
-/// once from the content definitions and then kept in sync through the <see cref="IContentDefinitionEventHandler"/>
-/// notifications, so they always reflect the latest definitions without repeated enumeration.
+/// Reports the content types that have the <c>OmnichannelSubjectPart</c> or the <c>OmnichannelContactPart</c>
+/// attached, so callers can answer that question and build subject and contact content type drop downs without
+/// scanning every content type definition on each request. The membership sets are computed once and cached in
+/// the per-tenant <see cref="IMemoryCache"/>, then kept current through the <see cref="IContentDefinitionEventHandler"/>
+/// notifications so they always reflect the latest definitions without repeated enumeration.
 /// </summary>
 public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHandler
 {
-    private readonly Lock _lock = new();
+    private static readonly Lock _lock = new();
 
-    private volatile HashSet<string> _subjectContentTypes;
-    private volatile HashSet<string> _contactContentTypes;
+    private readonly IContentDefinitionManager _contentDefinitionManager;
+    private readonly IMemoryCache _memoryCache;
+    private readonly string _cacheKey;
+
+    private OmnichannelContentTypeSet _set;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OmnichannelContentTypeProvider"/> class.
+    /// </summary>
+    /// <param name="contentDefinitionManager">The content definition manager used to read the type definitions.</param>
+    /// <param name="memoryCache">The per-tenant memory cache used to store the membership sets.</param>
+    /// <param name="shellSettings">The shell settings used to scope the cache entry to the current tenant.</param>
+    public OmnichannelContentTypeProvider(
+        IContentDefinitionManager contentDefinitionManager,
+        IMemoryCache memoryCache,
+        ShellSettings shellSettings)
+    {
+        _contentDefinitionManager = contentDefinitionManager;
+        _memoryCache = memoryCache;
+        _cacheKey = GetCacheKey(shellSettings);
+    }
+
+    /// <summary>
+    /// Builds the per-tenant memory cache key used to store the omnichannel content type membership sets.
+    /// </summary>
+    /// <param name="shellSettings">The shell settings whose <see cref="ShellSettings.Name"/> scopes the entry.</param>
+    /// <returns>The cache key for the tenant.</returns>
+    internal static string GetCacheKey(ShellSettings shellSettings)
+        => $"OmnichannelContentTypes:{shellSettings.Name}";
 
     /// <summary>
     /// Determines whether the specified content type has the <c>OmnichannelSubjectPart</c> attached.
     /// </summary>
     /// <param name="contentType">The technical name of the content type to test.</param>
     /// <returns><see langword="true"/> when the content type is a subject; otherwise, <see langword="false"/>.</returns>
-    public bool IsSubjectContentType(string contentType)
-        => Contains(_subjectContentTypes, contentType);
+    public async ValueTask<bool> IsSubjectContentTypeAsync(string contentType)
+    {
+        if (string.IsNullOrEmpty(contentType))
+        {
+            return false;
+        }
+
+        var set = await EnsureInitializedAsync();
+
+        return set.SubjectContentTypes.Contains(contentType);
+    }
 
     /// <summary>
     /// Determines whether the specified content type has the <c>OmnichannelContactPart</c> attached.
     /// </summary>
     /// <param name="contentType">The technical name of the content type to test.</param>
     /// <returns><see langword="true"/> when the content type is a contact; otherwise, <see langword="false"/>.</returns>
-    public bool IsContactContentType(string contentType)
-        => Contains(_contactContentTypes, contentType);
+    public async ValueTask<bool> IsContactContentTypeAsync(string contentType)
+    {
+        if (string.IsNullOrEmpty(contentType))
+        {
+            return false;
+        }
+
+        var set = await EnsureInitializedAsync();
+
+        return set.ContactContentTypes.Contains(contentType);
+    }
 
     /// <summary>
     /// Gets the technical names of the content types that have the <c>OmnichannelSubjectPart</c> attached.
     /// </summary>
     /// <returns>A read-only snapshot of the subject content type names.</returns>
-    public IReadOnlyCollection<string> GetSubjectContentTypes()
-        => _subjectContentTypes ?? (IReadOnlyCollection<string>)[];
+    public async ValueTask<IReadOnlyCollection<string>> GetSubjectContentTypesAsync()
+    {
+        var set = await EnsureInitializedAsync();
+
+        return set.SubjectContentTypes;
+    }
 
     /// <summary>
     /// Gets the technical names of the content types that have the <c>OmnichannelContactPart</c> attached.
     /// </summary>
     /// <returns>A read-only snapshot of the contact content type names.</returns>
-    public IReadOnlyCollection<string> GetContactContentTypes()
-        => _contactContentTypes ?? (IReadOnlyCollection<string>)[];
-
-    /// <summary>
-    /// Warms the cached sets from the current content definitions the first time they are requested. Subsequent
-    /// calls are a no-op because the sets are afterward kept current through the content definition notifications.
-    /// </summary>
-    /// <param name="contentDefinitionManager">The content definition manager used to read the type definitions.</param>
-    public async Task EnsureInitializedAsync(IContentDefinitionManager contentDefinitionManager)
+    public async ValueTask<IReadOnlyCollection<string>> GetContactContentTypesAsync()
     {
-        if (_subjectContentTypes is not null && _contactContentTypes is not null)
+        var set = await EnsureInitializedAsync();
+
+        return set.ContactContentTypes;
+    }
+
+    private async ValueTask<OmnichannelContentTypeSet> EnsureInitializedAsync()
+    {
+        if (_set is not null)
         {
-            return;
+            return _set;
         }
 
-        var definitions = await contentDefinitionManager.ListTypeDefinitionsAsync();
+        if (_memoryCache.TryGetValue<OmnichannelContentTypeSet>(_cacheKey, out var cached) && cached is not null)
+        {
+            _set = cached;
+
+            return cached;
+        }
 
         var subjectContentTypes = new HashSet<string>(StringComparer.Ordinal);
         var contactContentTypes = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var definition in definitions)
+        foreach (var definition in await _contentDefinitionManager.ListTypeDefinitionsAsync())
         {
             if (OmnichannelSubjectDefinitionService.HasOmnichannelSubjectPart(definition))
             {
@@ -79,11 +134,23 @@ public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHand
             }
         }
 
+        var set = new OmnichannelContentTypeSet(subjectContentTypes, contactContentTypes);
+
         lock (_lock)
         {
-            _subjectContentTypes ??= subjectContentTypes;
-            _contactContentTypes ??= contactContentTypes;
+            if (_memoryCache.TryGetValue<OmnichannelContentTypeSet>(_cacheKey, out var existing) && existing is not null)
+            {
+                set = existing;
+            }
+            else
+            {
+                _memoryCache.Set(_cacheKey, set);
+            }
         }
+
+        _set = set;
+
+        return set;
     }
 
     /// <inheritdoc/>
@@ -103,8 +170,8 @@ public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHand
     {
         var contentType = context.ContentTypeDefinition?.Name;
 
-        SetSubjectMembership(contentType, isMember: false);
-        SetContactMembership(contentType, isMember: false);
+        SetMembership(subject: true, contentType, isMember: false);
+        SetMembership(subject: false, contentType, isMember: false);
     }
 
     /// <inheritdoc/>
@@ -112,11 +179,11 @@ public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHand
     {
         if (IsSubjectPart(context.ContentPartName))
         {
-            SetSubjectMembership(context.ContentTypeName, isMember: true);
+            SetMembership(subject: true, context.ContentTypeName, isMember: true);
         }
         else if (IsContactPart(context.ContentPartName))
         {
-            SetContactMembership(context.ContentTypeName, isMember: true);
+            SetMembership(subject: false, context.ContentTypeName, isMember: true);
         }
     }
 
@@ -125,11 +192,11 @@ public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHand
     {
         if (IsSubjectPart(context.ContentPartName))
         {
-            SetSubjectMembership(context.ContentTypeName, isMember: false);
+            SetMembership(subject: true, context.ContentTypeName, isMember: false);
         }
         else if (IsContactPart(context.ContentPartName))
         {
-            SetContactMembership(context.ContentTypeName, isMember: false);
+            SetMembership(subject: false, context.ContentTypeName, isMember: false);
         }
     }
 
@@ -195,11 +262,11 @@ public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHand
             return;
         }
 
-        SetSubjectMembership(contentTypeDefinition.Name, OmnichannelSubjectDefinitionService.HasOmnichannelSubjectPart(contentTypeDefinition));
-        SetContactMembership(contentTypeDefinition.Name, OmnichannelContactDefinitionService.HasOmnichannelContactPart(contentTypeDefinition));
+        SetMembership(subject: true, contentTypeDefinition.Name, OmnichannelSubjectDefinitionService.HasOmnichannelSubjectPart(contentTypeDefinition));
+        SetMembership(subject: false, contentTypeDefinition.Name, OmnichannelContactDefinitionService.HasOmnichannelContactPart(contentTypeDefinition));
     }
 
-    private void SetSubjectMembership(string contentType, bool isMember)
+    private void SetMembership(bool subject, string contentType, bool isMember)
     {
         if (string.IsNullOrEmpty(contentType))
         {
@@ -208,59 +275,24 @@ public sealed class OmnichannelContentTypeProvider : IContentDefinitionEventHand
 
         lock (_lock)
         {
-            _subjectContentTypes = WithMembership(_subjectContentTypes, contentType, isMember);
+            // Skip incremental updates until the set has been warmed; the initial warm reads the current
+            // definitions and therefore already reflects any change that happened before it ran.
+            if (!_memoryCache.TryGetValue<OmnichannelContentTypeSet>(_cacheKey, out var current) || current is null)
+            {
+                _set = null;
+
+                return;
+            }
+
+            var updated = current.With(subject, contentType, isMember);
+
+            if (!ReferenceEquals(updated, current))
+            {
+                _memoryCache.Set(_cacheKey, updated);
+            }
+
+            _set = updated;
         }
-    }
-
-    private void SetContactMembership(string contentType, bool isMember)
-    {
-        if (string.IsNullOrEmpty(contentType))
-        {
-            return;
-        }
-
-        lock (_lock)
-        {
-            _contactContentTypes = WithMembership(_contactContentTypes, contentType, isMember);
-        }
-    }
-
-    private static HashSet<string> WithMembership(HashSet<string> contentTypes, string contentType, bool isMember)
-    {
-        // Skip incremental updates until the set has been warmed; the initial warm reads the current
-        // definitions and therefore already reflects any change that happened before it ran.
-        if (contentTypes is null)
-        {
-            return null;
-        }
-
-        if (isMember == contentTypes.Contains(contentType))
-        {
-            return contentTypes;
-        }
-
-        var updated = new HashSet<string>(contentTypes, StringComparer.Ordinal);
-
-        if (isMember)
-        {
-            updated.Add(contentType);
-        }
-        else
-        {
-            updated.Remove(contentType);
-        }
-
-        return updated;
-    }
-
-    private static bool Contains(HashSet<string> contentTypes, string contentType)
-    {
-        if (string.IsNullOrEmpty(contentType))
-        {
-            return false;
-        }
-
-        return contentTypes is not null && contentTypes.Contains(contentType);
     }
 
     private static bool IsSubjectPart(string partName)

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeSet.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeSet.cs
@@ -2,8 +2,8 @@ namespace CrestApps.OrchardCore.Omnichannel.Managements.Services;
 
 /// <summary>
 /// Represents an immutable snapshot of the content types that have the omnichannel subject or contact part
-/// attached. The snapshot is stored in the per-tenant memory cache and replaced through copy-on-write so that
-/// readers that captured a reference keep observing a consistent set while it is being updated.
+/// attached. The snapshot is stored in the per-tenant memory cache and replaced wholesale when the cache entry is
+/// invalidated after a content definition change.
 /// </summary>
 internal sealed class OmnichannelContentTypeSet
 {
@@ -29,37 +29,4 @@ internal sealed class OmnichannelContentTypeSet
     /// Gets the technical names of the content types that attach the omnichannel contact part.
     /// </summary>
     public HashSet<string> ContactContentTypes { get; }
-
-    /// <summary>
-    /// Produces a new snapshot with the membership of the specified content type applied, or returns the current
-    /// snapshot unchanged when the membership already matches.
-    /// </summary>
-    /// <param name="subject"><see langword="true"/> to update the subject set; <see langword="false"/> to update the contact set.</param>
-    /// <param name="contentType">The technical name of the content type whose membership is changing.</param>
-    /// <param name="isMember"><see langword="true"/> when the content type should be a member; otherwise, <see langword="false"/>.</param>
-    /// <returns>A new <see cref="OmnichannelContentTypeSet"/> reflecting the change, or the same instance when nothing changed.</returns>
-    public OmnichannelContentTypeSet With(bool subject, string contentType, bool isMember)
-    {
-        var target = subject ? SubjectContentTypes : ContactContentTypes;
-
-        if (isMember == target.Contains(contentType))
-        {
-            return this;
-        }
-
-        var updated = new HashSet<string>(target, StringComparer.Ordinal);
-
-        if (isMember)
-        {
-            updated.Add(contentType);
-        }
-        else
-        {
-            updated.Remove(contentType);
-        }
-
-        return subject
-            ? new OmnichannelContentTypeSet(updated, ContactContentTypes)
-            : new OmnichannelContentTypeSet(SubjectContentTypes, updated);
-    }
 }

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeSet.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelContentTypeSet.cs
@@ -1,0 +1,65 @@
+namespace CrestApps.OrchardCore.Omnichannel.Managements.Services;
+
+/// <summary>
+/// Represents an immutable snapshot of the content types that have the omnichannel subject or contact part
+/// attached. The snapshot is stored in the per-tenant memory cache and replaced through copy-on-write so that
+/// readers that captured a reference keep observing a consistent set while it is being updated.
+/// </summary>
+internal sealed class OmnichannelContentTypeSet
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OmnichannelContentTypeSet"/> class.
+    /// </summary>
+    /// <param name="subjectContentTypes">The technical names of the content types that attach the subject part.</param>
+    /// <param name="contactContentTypes">The technical names of the content types that attach the contact part.</param>
+    public OmnichannelContentTypeSet(
+        HashSet<string> subjectContentTypes,
+        HashSet<string> contactContentTypes)
+    {
+        SubjectContentTypes = subjectContentTypes;
+        ContactContentTypes = contactContentTypes;
+    }
+
+    /// <summary>
+    /// Gets the technical names of the content types that attach the omnichannel subject part.
+    /// </summary>
+    public HashSet<string> SubjectContentTypes { get; }
+
+    /// <summary>
+    /// Gets the technical names of the content types that attach the omnichannel contact part.
+    /// </summary>
+    public HashSet<string> ContactContentTypes { get; }
+
+    /// <summary>
+    /// Produces a new snapshot with the membership of the specified content type applied, or returns the current
+    /// snapshot unchanged when the membership already matches.
+    /// </summary>
+    /// <param name="subject"><see langword="true"/> to update the subject set; <see langword="false"/> to update the contact set.</param>
+    /// <param name="contentType">The technical name of the content type whose membership is changing.</param>
+    /// <param name="isMember"><see langword="true"/> when the content type should be a member; otherwise, <see langword="false"/>.</param>
+    /// <returns>A new <see cref="OmnichannelContentTypeSet"/> reflecting the change, or the same instance when nothing changed.</returns>
+    public OmnichannelContentTypeSet With(bool subject, string contentType, bool isMember)
+    {
+        var target = subject ? SubjectContentTypes : ContactContentTypes;
+
+        if (isMember == target.Contains(contentType))
+        {
+            return this;
+        }
+
+        var updated = new HashSet<string>(target, StringComparer.Ordinal);
+
+        if (isMember)
+        {
+            updated.Add(contentType);
+        }
+        else
+        {
+            updated.Remove(contentType);
+        }
+
+        return subject
+            ? new OmnichannelContentTypeSet(updated, ContactContentTypes)
+            : new OmnichannelContentTypeSet(SubjectContentTypes, updated);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelSubjectButtonsShapeTableProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Services/OmnichannelSubjectButtonsShapeTableProvider.cs
@@ -1,7 +1,8 @@
+using Microsoft.Extensions.Caching.Memory;
 using OrchardCore.ContentManagement;
-using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.Environment.Shell;
 
 namespace CrestApps.OrchardCore.Omnichannel.Managements.Services;
 
@@ -21,43 +22,53 @@ internal sealed class OmnichannelSubjectButtonsShapeTableProvider : IShapeTableP
         "ContentPreview_Button",
     ];
 
-    private readonly IContentDefinitionManager _contentDefinitionManager;
     private readonly OmnichannelContentTypeProvider _contentTypeProvider;
+    private readonly IMemoryCache _memoryCache;
+    private readonly string _cacheKey;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OmnichannelSubjectButtonsShapeTableProvider"/> class.
     /// </summary>
-    /// <param name="contentDefinitionManager">The content definition manager used to warm the omnichannel content type cache.</param>
     /// <param name="contentTypeProvider">The provider that reports whether a content type is an omnichannel subject.</param>
+    /// <param name="memoryCache">The per-tenant memory cache the placement delegate reads the subject content types from.</param>
+    /// <param name="shellSettings">The shell settings used to scope the cache entry to the current tenant.</param>
     public OmnichannelSubjectButtonsShapeTableProvider(
-        IContentDefinitionManager contentDefinitionManager,
-        OmnichannelContentTypeProvider contentTypeProvider)
+        OmnichannelContentTypeProvider contentTypeProvider,
+        IMemoryCache memoryCache,
+        ShellSettings shellSettings)
     {
-        _contentDefinitionManager = contentDefinitionManager;
         _contentTypeProvider = contentTypeProvider;
+        _memoryCache = memoryCache;
+        _cacheKey = OmnichannelContentTypeProvider.GetCacheKey(shellSettings);
     }
 
     /// <inheritdoc/>
     public async ValueTask DiscoverAsync(ShapeTableBuilder builder)
     {
-        await _contentTypeProvider.EnsureInitializedAsync(_contentDefinitionManager);
+        // Warm the per-tenant cache so the synchronous placement delegate below can read the current subject
+        // content types. The shape table is cached for the tenant's lifetime, so the delegate reads the live
+        // cache entry - kept current through the content definition notifications - rather than a snapshot.
+        await _contentTypeProvider.GetSubjectContentTypesAsync();
 
-        var contentTypeProvider = _contentTypeProvider;
+        var memoryCache = _memoryCache;
+        var cacheKey = _cacheKey;
 
         foreach (var shapeType in _shapeTypes)
         {
             builder.Describe(shapeType)
-                .Placement(context => IsSubjectEditor(context, contentTypeProvider), _hidden);
+                .Placement(context => IsSubjectEditor(context, memoryCache, cacheKey), _hidden);
         }
     }
 
-    private static bool IsSubjectEditor(ShapePlacementContext context, OmnichannelContentTypeProvider contentTypeProvider)
+    private static bool IsSubjectEditor(ShapePlacementContext context, IMemoryCache memoryCache, string cacheKey)
     {
         if (context.ZoneShape is not null &&
             context.ZoneShape.TryGetProperty<ContentItem>("ContentItem", out var contentItem) &&
-            contentItem is not null)
+            contentItem is not null &&
+            memoryCache.TryGetValue<OmnichannelContentTypeSet>(cacheKey, out var set) &&
+            set is not null)
         {
-            return contentTypeProvider.IsSubjectContentType(contentItem.ContentType);
+            return set.SubjectContentTypes.Contains(contentItem.ContentType);
         }
 
         return false;


### PR DESCRIPTION
Adds a Contacts item under the Interaction Center admin menu that opens the Orchard Core content list restricted to the Omnichannel contact content types. It links to the Contents List action, passing every content type that attaches OmnichannelContactPart (read from the cached OmnichannelContentTypeProvider) as a comma-separated contentTypeId, and is guarded by the List content permission.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
