### PR TITLE
Treat report date range as a regular filter and add typed ReportFilter accessors

### DIFF
--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportDateRange.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportDateRange.cs
@@ -1,0 +1,25 @@
+namespace CrestApps.OrchardCore.Reports.Models;
+
+/// <summary>
+/// Represents the resolved reporting period contributed by the built-in date-range filter. The date
+/// range is stored in the report filter like any other filter; a report that does not contribute the
+/// date-range filter leaves these values unset.
+/// </summary>
+public sealed class ReportDateRange
+{
+    /// <summary>
+    /// Gets or sets the inclusive lower UTC bound of the reporting period.
+    /// </summary>
+    public DateTime? FromUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the inclusive upper UTC bound of the reporting period.
+    /// </summary>
+    public DateTime? ToUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the selected date-range preset key (for example <c>today</c>, <c>last30</c>, or
+    /// <c>custom</c>) used to restore the picker's selected option when the report is reloaded.
+    /// </summary>
+    public string Key { get; set; }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportFilter.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportFilter.cs
@@ -3,9 +3,11 @@ using OrchardCore.Entities;
 namespace CrestApps.OrchardCore.Reports.Models;
 
 /// <summary>
-/// Represents the filter applied when running a report. Every report shares the built-in from/to date
-/// range; additional, report-specific filters are contributed through display drivers and stored in the
-/// extensible entity <see cref="Entity.Properties"/> bag.
+/// Represents the filter applied when running a report. A report declares no fixed dimensions of its own;
+/// every filter (including the built-in date range) is contributed through display drivers and stored in
+/// the extensible entity <see cref="Entity.Properties"/> bag, so reports that do not need a given filter
+/// simply do not contribute it. Use the <see cref="ReportFilterExtensions"/> helpers to read and write
+/// typed values.
 /// </summary>
 public sealed class ReportFilter : Entity
 {
@@ -14,20 +16,4 @@ public sealed class ReportFilter : Entity
     /// decide whether they apply to the current report.
     /// </summary>
     public string ReportName { get; set; }
-
-    /// <summary>
-    /// Gets or sets the inclusive lower UTC bound of the reporting period.
-    /// </summary>
-    public DateTime? FromUtc { get; set; }
-
-    /// <summary>
-    /// Gets or sets the inclusive upper UTC bound of the reporting period.
-    /// </summary>
-    public DateTime? ToUtc { get; set; }
-
-    /// <summary>
-    /// Gets or sets the selected date-range preset key (for example <c>today</c>, <c>last30</c>, or
-    /// <c>custom</c>) used to restore the picker's selected option when the report is reloaded.
-    /// </summary>
-    public string DateRangeKey { get; set; }
 }

--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/ReportContext.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/ReportContext.cs
@@ -3,15 +3,15 @@ using CrestApps.OrchardCore.Reports.Models;
 namespace CrestApps.OrchardCore.Reports;
 
 /// <summary>
-/// Provides the context passed to a report when it runs, exposing the resolved reporting period and the
-/// full filter (including any report-specific values contributed by filter display drivers).
+/// Provides the context passed to a report when it runs, exposing the full filter (including any values
+/// contributed by filter display drivers, such as the built-in date range).
 /// </summary>
 public sealed class ReportContext
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ReportContext"/> class.
     /// </summary>
-    /// <param name="filter">The report filter. Its from/to values are guaranteed to be set by the caller.</param>
+    /// <param name="filter">The report filter.</param>
     public ReportContext(ReportFilter filter)
     {
         ArgumentNullException.ThrowIfNull(filter);
@@ -20,31 +20,9 @@ public sealed class ReportContext
     }
 
     /// <summary>
-    /// Gets the report filter, including the extensible property bag of report-specific filter values.
+    /// Gets the report filter, including the extensible property bag of filter values. Read the date
+    /// range with <see cref="ReportFilterExtensions.GetDateRange(ReportFilter)"/> and other filter
+    /// values with the typed <see cref="ReportFilterExtensions"/> helpers.
     /// </summary>
     public ReportFilter Filter { get; }
-
-    /// <summary>
-    /// Gets the inclusive lower UTC bound of the reporting period, as contributed by the built-in
-    /// date-range filter. Returns the default value when the report does not contribute a date range.
-    /// </summary>
-    public DateTime FromUtc
-    {
-        get
-        {
-            return Filter.GetDateRange().FromUtc.GetValueOrDefault();
-        }
-    }
-
-    /// <summary>
-    /// Gets the inclusive upper UTC bound of the reporting period, as contributed by the built-in
-    /// date-range filter. Returns the default value when the report does not contribute a date range.
-    /// </summary>
-    public DateTime ToUtc
-    {
-        get
-        {
-            return Filter.GetDateRange().ToUtc.GetValueOrDefault();
-        }
-    }
 }

--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/ReportContext.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/ReportContext.cs
@@ -25,24 +25,26 @@ public sealed class ReportContext
     public ReportFilter Filter { get; }
 
     /// <summary>
-    /// Gets the inclusive lower UTC bound of the reporting period.
+    /// Gets the inclusive lower UTC bound of the reporting period, as contributed by the built-in
+    /// date-range filter. Returns the default value when the report does not contribute a date range.
     /// </summary>
     public DateTime FromUtc
     {
         get
         {
-            return Filter.FromUtc.GetValueOrDefault();
+            return Filter.GetDateRange().FromUtc.GetValueOrDefault();
         }
     }
 
     /// <summary>
-    /// Gets the inclusive upper UTC bound of the reporting period.
+    /// Gets the inclusive upper UTC bound of the reporting period, as contributed by the built-in
+    /// date-range filter. Returns the default value when the report does not contribute a date range.
     /// </summary>
     public DateTime ToUtc
     {
         get
         {
-            return Filter.ToUtc.GetValueOrDefault();
+            return Filter.GetDateRange().ToUtc.GetValueOrDefault();
         }
     }
 }

--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/ReportFilterExtensions.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/ReportFilterExtensions.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using CrestApps.OrchardCore.Reports.Models;
+
+namespace CrestApps.OrchardCore.Reports;
+
+/// <summary>
+/// Provides typed read and write helpers over the extensible <see cref="ReportFilter"/> property bag,
+/// including convenience accessors for the built-in date-range filter.
+/// </summary>
+public static class ReportFilterExtensions
+{
+    /// <summary>
+    /// The property key that stores the inclusive lower UTC bound of the reporting period.
+    /// </summary>
+    public const string FromUtcKey = "FromUtc";
+
+    /// <summary>
+    /// The property key that stores the inclusive upper UTC bound of the reporting period.
+    /// </summary>
+    public const string ToUtcKey = "ToUtc";
+
+    /// <summary>
+    /// The property key that stores the selected date-range preset key.
+    /// </summary>
+    public const string DateRangeKey = "DateRangeKey";
+
+    private static readonly JsonSerializerOptions _serializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>
+    /// Attempts to read a typed value from the filter property bag.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize the stored value into.</typeparam>
+    /// <param name="filter">The report filter.</param>
+    /// <param name="key">The property key.</param>
+    /// <param name="value">The deserialized value when the key is present and readable; otherwise the default of <typeparamref name="T"/>.</param>
+    /// <returns><see langword="true"/> when a value for <paramref name="key"/> was found and deserialized; otherwise <see langword="false"/>.</returns>
+    public static bool TryGet<T>(this ReportFilter filter, string key, out T value)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        value = default;
+
+        if (string.IsNullOrEmpty(key) ||
+            filter.Properties is null ||
+            !filter.Properties.TryGetPropertyValue(key, out var node) ||
+            node is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            value = node.Deserialize<T>(_serializerOptions);
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            value = default;
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads a typed value from the filter property bag, returning the default when it is absent.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize the stored value into.</typeparam>
+    /// <param name="filter">The report filter.</param>
+    /// <param name="key">The property key.</param>
+    /// <returns>The deserialized value, or the default of <typeparamref name="T"/> when absent.</returns>
+    public static T Get<T>(this ReportFilter filter, string key)
+    {
+        return filter.TryGet<T>(key, out var value) ? value : default;
+    }
+
+    /// <summary>
+    /// Writes a typed value to the filter property bag, or removes the key when the value is <see langword="null"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of value to serialize.</typeparam>
+    /// <param name="filter">The report filter.</param>
+    /// <param name="key">The property key.</param>
+    /// <param name="value">The value to store, or <see langword="null"/> to remove the key.</param>
+    public static void Set<T>(this ReportFilter filter, string key, T value)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        if (value is null || (value is string text && string.IsNullOrEmpty(text)))
+        {
+            filter.Properties.Remove(key);
+
+            return;
+        }
+
+        filter.Properties[key] = JsonSerializer.SerializeToNode(value, _serializerOptions);
+    }
+
+    /// <summary>
+    /// Removes a value from the filter property bag.
+    /// </summary>
+    /// <param name="filter">The report filter.</param>
+    /// <param name="key">The property key to remove.</param>
+    public static void Remove(this ReportFilter filter, string key)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        filter.Properties?.Remove(key);
+    }
+
+    /// <summary>
+    /// Reads the resolved date range stored by the built-in date-range filter.
+    /// </summary>
+    /// <param name="filter">The report filter.</param>
+    /// <returns>The resolved date range. Its bounds are unset when the date-range filter was not contributed.</returns>
+    public static ReportDateRange GetDateRange(this ReportFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        return new ReportDateRange
+        {
+            FromUtc = filter.TryGet<DateTime>(FromUtcKey, out var from)
+                ? DateTime.SpecifyKind(from, DateTimeKind.Utc)
+                : null,
+            ToUtc = filter.TryGet<DateTime>(ToUtcKey, out var to)
+                ? DateTime.SpecifyKind(to, DateTimeKind.Utc)
+                : null,
+            Key = filter.Get<string>(DateRangeKey),
+        };
+    }
+
+    /// <summary>
+    /// Writes the resolved date range to the filter property bag.
+    /// </summary>
+    /// <param name="filter">The report filter.</param>
+    /// <param name="range">The date range to store.</param>
+    public static void SetDateRange(this ReportFilter filter, ReportDateRange range)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentNullException.ThrowIfNull(range);
+
+        filter.Set(FromUtcKey, range.FromUtc);
+        filter.Set(ToUtcKey, range.ToUtc);
+        filter.Set(DateRangeKey, range.Key);
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/ReportFilterExtensions.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/ReportFilterExtensions.cs
@@ -74,7 +74,7 @@ public static class ReportFilterExtensions
     /// <param name="filter">The report filter.</param>
     /// <param name="key">The property key.</param>
     /// <returns>The deserialized value, or the default of <typeparamref name="T"/> when absent.</returns>
-    public static T Get<T>(this ReportFilter filter, string key)
+    public static T GetOrDefault<T>(this ReportFilter filter, string key)
     {
         return filter.TryGet<T>(key, out var value) ? value : default;
     }
@@ -131,7 +131,7 @@ public static class ReportFilterExtensions
             ToUtc = filter.TryGet<DateTime>(ToUtcKey, out var to)
                 ? DateTime.SpecifyKind(to, DateTimeKind.Utc)
                 : null,
-            Key = filter.Get<string>(DateRangeKey),
+            Key = filter.GetOrDefault<string>(DateRangeKey),
         };
     }
 

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -13,7 +13,7 @@ This page highlights the changes in the `3.0.0` line.
 
 ### Reports
 
-- `ReportFilter` no longer exposes `FromUtc`, `ToUtc`, or `DateRangeKey` as first-class properties. The date range is now contributed and stored like any other filter, so reports that do not need a date selector can omit it. Read and write the period through the new `ReportFilter` helpers (`GetDateRange()` / `SetDateRange()`), and read or write any filter value with the typed `TryGet<T>(string key, out T value)`, `Get<T>(string key)`, and `Set<T>(string key, T value)` extension methods. `ReportContext.FromUtc` and `ReportContext.ToUtc` are unchanged and still expose the resolved bounds.
+- `ReportFilter` no longer exposes `FromUtc`, `ToUtc`, or `DateRangeKey` as first-class properties, and `ReportContext` no longer exposes `FromUtc` or `ToUtc`. The date range is now contributed and stored like any other filter, so reports that do not need a date selector can omit it. Read and write the period through the new `ReportFilter` helpers (`GetDateRange()` / `SetDateRange()` — for example `context.Filter.GetDateRange()` inside a report), and read or write any filter value with the typed `TryGet<T>(string key, out T value)`, `GetOrDefault<T>(string key)`, and `Set<T>(string key, T value)` extension methods.
 
 ### Resource Module
 

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -11,6 +11,10 @@ This page highlights the changes in the `3.0.0` line.
 
 ## Breaking Changes
 
+### Reports
+
+- `ReportFilter` no longer exposes `FromUtc`, `ToUtc`, or `DateRangeKey` as first-class properties. The date range is now contributed and stored like any other filter, so reports that do not need a date selector can omit it. Read and write the period through the new `ReportFilter` helpers (`GetDateRange()` / `SetDateRange()`), and read or write any filter value with the typed `TryGet<T>(string key, out T value)`, `Get<T>(string key)`, and `Set<T>(string key, T value)` extension methods. `ReportContext.FromUtc` and `ReportContext.ToUtc` are unchanged and still expose the resolved bounds.
+
 ### Resource Module
 
 - The `crestapps-bootstrap-select` style and script have been removed from the `Resource` module. Instead you should use the `bootstrap-select` style and script which are registered by Orchard Core.

--- a/src/CrestApps.Docs/docs/modules/reports.md
+++ b/src/CrestApps.Docs/docs/modules/reports.md
@@ -29,7 +29,7 @@ The implementation is split into three layers:
 ## Concepts
 
 - **`IReport`** — a report definition. It declares a technical `Name`, a `DisplayName`, a `Description`, a `Category` (used to group reports in the menu), a `Permission`, and a `RunAsync` method that returns a `ReportDocument` for a given `ReportContext`.
-- **`ReportFilter`** — the filter applied when a report runs. A report declares no fixed dimensions of its own: every filter is contributed with a display driver and stored in the extensible `ReportFilter.Properties` bag. The built-in tenant-local from/to date range is contributed the same way — it is just a filter — so a report that does not need a date selector can omit it. Use the `TryGet<T>`, `Get<T>`, and `Set<T>` helpers to read and write typed values, and `GetDateRange()` / `SetDateRange()` for the resolved period.
+- **`ReportFilter`** — the filter applied when a report runs. A report declares no fixed dimensions of its own: every filter is contributed with a display driver and stored in the extensible `ReportFilter.Properties` bag. The built-in tenant-local from/to date range is contributed the same way — it is just a filter — so a report that does not need a date selector can omit it. Use the `TryGet<T>`, `GetOrDefault<T>`, and `Set<T>` helpers to read and write typed values, and `GetDateRange()` / `SetDateRange()` for the resolved period.
 - **`ReportDocument`** — the uniform result. It is an ordered list of **sections**, where each section is a set of metric cards, a table (with optional emphasized totals rows for aggregated reports), horizontal bars, or a responsive Chart.js line, bar, stacked-bar, or doughnut chart. The same document is rendered in the browser and serialized by every exporter; chart exports use a label-and-dataset table so the underlying values remain portable.
 - **`IReportExportFormat`** — an export format. CSV ships in the box; the optional **Reports (OpenXml)** add-on adds Excel (`.xlsx`); and any module can add more formats by registering another implementation.
 
@@ -65,7 +65,7 @@ public sealed class MyQueueFilterDisplayDriver : DisplayDriver<ReportFilter>
 
         return Initialize<MyQueueFilterViewModel>("MyQueueFilter_Edit", model =>
         {
-            model.QueueId = filter.Get<string>("QueueId");
+            model.QueueId = filter.GetOrDefault<string>("QueueId");
         }).Location("Content:2");
     }
 
@@ -88,9 +88,9 @@ public sealed class MyQueueFilterDisplayDriver : DisplayDriver<ReportFilter>
 Read and write filter values with the typed `ReportFilter` helpers instead of touching the property bag directly:
 
 - `bool TryGet<T>(string key, out T value)` — reads a value when present (also parses enums stored as strings).
-- `T Get<T>(string key)` — reads a value or returns the default when absent.
+- `T GetOrDefault<T>(string key)` — reads a value or returns the default when absent.
 - `void Set<T>(string key, T value)` — writes a value, or removes the key when the value is `null` or an empty string.
-- `ReportDateRange GetDateRange()` / `void SetDateRange(ReportDateRange range)` — read or write the built-in date-range filter; `context.FromUtc` and `context.ToUtc` expose the resolved bounds.
+- `ReportDateRange GetDateRange()` / `void SetDateRange(ReportDateRange range)` — read or write the built-in date-range filter. The date range is stored like any other filter, so read it from `context.Filter.GetDateRange()` when the report runs.
 
 The report reads the bound values when it runs. Because browser display and export use the same filter-building path, custom filter values are applied consistently in both outputs.
 
@@ -102,7 +102,7 @@ Implement `IReport` and register it as a scoped service:
 services.AddScoped<IReport, MyReport>();
 ```
 
-`RunAsync` builds a `ReportDocument` from the resolved period (`context.FromUtc` / `context.ToUtc`) and any report-specific filter values. Use `ReportSection.ForMetrics`, `ReportSection.ForTable`, `ReportSection.ForBars`, and `ReportSection.ForChart` to compose the document, and `ReportFormat` to format numbers, durations, and percentages consistently. Charts accept ordered labels plus one or more numeric datasets; `Width` places sections on the shared responsive twelve-column layout.
+`RunAsync` builds a `ReportDocument` from the resolved period (`context.Filter.GetDateRange()`) and any report-specific filter values. Use `ReportSection.ForMetrics`, `ReportSection.ForTable`, `ReportSection.ForBars`, and `ReportSection.ForChart` to compose the document, and `ReportFormat` to format numbers, durations, and percentages consistently. Charts accept ordered labels plus one or more numeric datasets; `Width` places sections on the shared responsive twelve-column layout.
 
 ## Enable via recipe
 

--- a/src/CrestApps.Docs/docs/modules/reports.md
+++ b/src/CrestApps.Docs/docs/modules/reports.md
@@ -29,7 +29,7 @@ The implementation is split into three layers:
 ## Concepts
 
 - **`IReport`** — a report definition. It declares a technical `Name`, a `DisplayName`, a `Description`, a `Category` (used to group reports in the menu), a `Permission`, and a `RunAsync` method that returns a `ReportDocument` for a given `ReportContext`.
-- **`ReportFilter`** — the filter applied when a report runs. Every report shares a tenant-local from/to date and time range; additional, report-specific filters are contributed with display drivers and flow through exports unchanged.
+- **`ReportFilter`** — the filter applied when a report runs. A report declares no fixed dimensions of its own: every filter is contributed with a display driver and stored in the extensible `ReportFilter.Properties` bag. The built-in tenant-local from/to date range is contributed the same way — it is just a filter — so a report that does not need a date selector can omit it. Use the `TryGet<T>`, `Get<T>`, and `Set<T>` helpers to read and write typed values, and `GetDateRange()` / `SetDateRange()` for the resolved period.
 - **`ReportDocument`** — the uniform result. It is an ordered list of **sections**, where each section is a set of metric cards, a table (with optional emphasized totals rows for aggregated reports), horizontal bars, or a responsive Chart.js line, bar, stacked-bar, or doughnut chart. The same document is rendered in the browser and serialized by every exporter; chart exports use a label-and-dataset table so the underlying values remain portable.
 - **`IReportExportFormat`** — an export format. CSV ships in the box; the optional **Reports (OpenXml)** add-on adds Excel (`.xlsx`); and any module can add more formats by registering another implementation.
 
@@ -39,7 +39,9 @@ Enabling the feature adds a top-level **Reports** item to the admin menu. Report
 
 ## Date range filter
 
-Every report shares a single tenant-local **Date range** control rendered by the built-in filter. Instead of two separate date inputs, it is a dropdown that offers common presets grouped into **Relative days** (**Today**, **Yesterday**, **Last 7 Days**, **Last 30 Days**, **Last 90 Days**), **Calendar periods** (**This Week**, **Last Week**, **This Month**, **Last Month**, **This Quarter**, **Last Quarter**, **This Year**, **Last Year**), and **Rolling months** (**Last 3 Months**, **Last 6 Months**, **Last 12 Months**) — plus:
+The built-in **Date range** filter is contributed by the `ReportDateRangeFilterDisplayDriver`, which is registered for `ReportFilter` and therefore renders for every report by default. It is an ordinary filter: it stores the resolved from/to bounds and the selected preset key in the report filter property bag (through `SetDateRange`), so a report that does not need a date selector can be built without one. The driver also applies the default period (the last 30 days) and swaps the bounds when they are inverted.
+
+Every report shares this single tenant-local **Date range** control. Instead of two separate date inputs, it is a dropdown that offers common presets grouped into **Relative days** (**Today**, **Yesterday**, **Last 7 Days**, **Last 30 Days**, **Last 90 Days**), **Calendar periods** (**This Week**, **Last Week**, **This Month**, **Last Month**, **This Quarter**, **Last Quarter**, **This Year**, **Last Year**), and **Rolling months** (**Last 3 Months**, **Last 6 Months**, **Last 12 Months**) — plus:
 
 - **Custom Range** — two date-time inputs (from and to) editable with [Flatpickr](https://flatpickr.js.org/).
 - **On or before** — a single date-time picker that sets only the upper bound, leaving the start open.
@@ -49,7 +51,7 @@ The dropdown button always shows the current selection as readable text (for exa
 
 ## Extensible filters
 
-Every report automatically gets the shared date range described above, converted to UTC before execution. To add a report-specific filter (for example a queue, campaign, or channel selector), register a display driver for `ReportFilter` and gate it to your report by checking `filter.ReportName`:
+Every filter — including the built-in date range — is contributed with a display driver for `ReportFilter`, so a report gets only the filters it needs. To add a report-specific filter (for example a queue, campaign, or channel selector), register a display driver for `ReportFilter` and gate it to your report by checking `filter.ReportName`:
 
 ```csharp
 public sealed class MyQueueFilterDisplayDriver : DisplayDriver<ReportFilter>
@@ -61,8 +63,10 @@ public sealed class MyQueueFilterDisplayDriver : DisplayDriver<ReportFilter>
             return null;
         }
 
-        return Initialize<MyQueueFilterViewModel>("MyQueueFilter_Edit", model => { /* ... */ })
-            .Location("Content:2");
+        return Initialize<MyQueueFilterViewModel>("MyQueueFilter_Edit", model =>
+        {
+            model.QueueId = filter.Get<string>("QueueId");
+        }).Location("Content:2");
     }
 
     public override async Task<IDisplayResult> UpdateAsync(ReportFilter filter, UpdateEditorContext context)
@@ -74,14 +78,21 @@ public sealed class MyQueueFilterDisplayDriver : DisplayDriver<ReportFilter>
 
         var model = new MyQueueFilterViewModel();
         await context.Updater.TryUpdateModelAsync(model, Prefix);
-        filter.Properties["QueueId"] = model.QueueId;
+        filter.Set("QueueId", model.QueueId);
 
         return Edit(filter, context);
     }
 }
 ```
 
-The report reads the bound value from `context.Filter.Properties` when it runs. Because browser display and export use the same filter-building path, custom filter values must be applied consistently in both outputs.
+Read and write filter values with the typed `ReportFilter` helpers instead of touching the property bag directly:
+
+- `bool TryGet<T>(string key, out T value)` — reads a value when present (also parses enums stored as strings).
+- `T Get<T>(string key)` — reads a value or returns the default when absent.
+- `void Set<T>(string key, T value)` — writes a value, or removes the key when the value is `null` or an empty string.
+- `ReportDateRange GetDateRange()` / `void SetDateRange(ReportDateRange range)` — read or write the built-in date-range filter; `context.FromUtc` and `context.ToUtc` expose the resolved bounds.
+
+The report reads the bound values when it runs. Because browser display and export use the same filter-building path, custom filter values are applied consistently in both outputs.
 
 ## Contributing a report
 

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Drivers/OmnichannelReportFilterDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Drivers/OmnichannelReportFilterDisplayDriver.cs
@@ -74,11 +74,11 @@ public sealed class OmnichannelReportFilterDisplayDriver : DisplayDriver<ReportF
 
     private async Task PopulateAsync(OmnichannelReportFilterViewModel model, ReportFilter filter)
     {
-        model.CampaignId = filter.Get<string>(OmnichannelReportFilter.CampaignId);
-        model.CampaignGroupId = filter.Get<string>(OmnichannelReportFilter.CampaignGroupId);
-        model.Channel = filter.Get<string>(OmnichannelReportFilter.Channel);
-        model.Source = filter.Get<string>(OmnichannelReportFilter.Source);
-        model.Status = filter.Get<string>(OmnichannelReportFilter.Status);
+        model.CampaignId = filter.GetOrDefault<string>(OmnichannelReportFilter.CampaignId);
+        model.CampaignGroupId = filter.GetOrDefault<string>(OmnichannelReportFilter.CampaignGroupId);
+        model.Channel = filter.GetOrDefault<string>(OmnichannelReportFilter.Channel);
+        model.Source = filter.GetOrDefault<string>(OmnichannelReportFilter.Source);
+        model.Status = filter.GetOrDefault<string>(OmnichannelReportFilter.Status);
 
         var campaigns = await _campaignManager.GetAllAsync();
 

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Drivers/OmnichannelReportFilterDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Drivers/OmnichannelReportFilterDisplayDriver.cs
@@ -3,6 +3,7 @@ using CrestApps.OrchardCore.Omnichannel.Core;
 using CrestApps.OrchardCore.Omnichannel.Core.Models;
 using CrestApps.OrchardCore.Omnichannel.Managements.Reports;
 using CrestApps.OrchardCore.Omnichannel.Managements.ViewModels;
+using CrestApps.OrchardCore.Reports;
 using CrestApps.OrchardCore.Reports.Models;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Localization;
@@ -62,22 +63,22 @@ public sealed class OmnichannelReportFilterDisplayDriver : DisplayDriver<ReportF
         var model = new OmnichannelReportFilterViewModel();
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-        OmnichannelReportFilter.SetString(filter, OmnichannelReportFilter.CampaignId, model.CampaignId);
-        OmnichannelReportFilter.SetString(filter, OmnichannelReportFilter.CampaignGroupId, model.CampaignGroupId);
-        OmnichannelReportFilter.SetString(filter, OmnichannelReportFilter.Channel, model.Channel);
-        OmnichannelReportFilter.SetString(filter, OmnichannelReportFilter.Source, model.Source);
-        OmnichannelReportFilter.SetString(filter, OmnichannelReportFilter.Status, model.Status);
+        filter.Set(OmnichannelReportFilter.CampaignId, model.CampaignId);
+        filter.Set(OmnichannelReportFilter.CampaignGroupId, model.CampaignGroupId);
+        filter.Set(OmnichannelReportFilter.Channel, model.Channel);
+        filter.Set(OmnichannelReportFilter.Source, model.Source);
+        filter.Set(OmnichannelReportFilter.Status, model.Status);
 
         return Edit(filter, context);
     }
 
     private async Task PopulateAsync(OmnichannelReportFilterViewModel model, ReportFilter filter)
     {
-        model.CampaignId = OmnichannelReportFilter.GetString(filter, OmnichannelReportFilter.CampaignId);
-        model.CampaignGroupId = OmnichannelReportFilter.GetString(filter, OmnichannelReportFilter.CampaignGroupId);
-        model.Channel = OmnichannelReportFilter.GetString(filter, OmnichannelReportFilter.Channel);
-        model.Source = OmnichannelReportFilter.GetString(filter, OmnichannelReportFilter.Source);
-        model.Status = OmnichannelReportFilter.GetString(filter, OmnichannelReportFilter.Status);
+        model.CampaignId = filter.Get<string>(OmnichannelReportFilter.CampaignId);
+        model.CampaignGroupId = filter.Get<string>(OmnichannelReportFilter.CampaignGroupId);
+        model.Channel = filter.Get<string>(OmnichannelReportFilter.Channel);
+        model.Source = filter.Get<string>(OmnichannelReportFilter.Source);
+        model.Status = filter.Get<string>(OmnichannelReportFilter.Status);
 
         var campaigns = await _campaignManager.GetAllAsync();
 

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/ActivitySummaryReportProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/ActivitySummaryReportProvider.cs
@@ -49,10 +49,11 @@ public sealed class ActivitySummaryReportProvider : OmnichannelReportBase
     /// <inheritdoc/>
     public override async Task<ReportDocument> RunAsync(ReportContext context, CancellationToken cancellationToken = default)
     {
+        var range = context.Filter.GetDateRange();
         var activities = await OmnichannelReportQuery.GetCreatedAsync(
             _session,
-            context.FromUtc,
-            context.ToUtc,
+            range.FromUtc.GetValueOrDefault(),
+            range.ToUtc.GetValueOrDefault(),
             await OmnichannelReportFilter.GetCriteriaAsync(context.Filter, _campaignManager, cancellationToken),
             cancellationToken);
         var data = OmnichannelReportAggregator.BuildActivitySummary(activities);

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/CampaignPerformanceReportProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/CampaignPerformanceReportProvider.cs
@@ -48,10 +48,11 @@ public sealed class CampaignPerformanceReportProvider : OmnichannelReportBase
     /// <inheritdoc/>
     public override async Task<ReportDocument> RunAsync(ReportContext context, CancellationToken cancellationToken = default)
     {
+        var range = context.Filter.GetDateRange();
         var activities = await OmnichannelReportQuery.GetCreatedAsync(
             _session,
-            context.FromUtc,
-            context.ToUtc,
+            range.FromUtc.GetValueOrDefault(),
+            range.ToUtc.GetValueOrDefault(),
             await OmnichannelReportFilter.GetCriteriaAsync(context.Filter, _campaignManager, cancellationToken),
             cancellationToken);
         var data = OmnichannelReportAggregator.BuildCampaignPerformance(activities);

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/DispositionBreakdownReportProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/DispositionBreakdownReportProvider.cs
@@ -51,10 +51,11 @@ public sealed class DispositionBreakdownReportProvider : OmnichannelReportBase
     /// <inheritdoc/>
     public override async Task<ReportDocument> RunAsync(ReportContext context, CancellationToken cancellationToken = default)
     {
+        var range = context.Filter.GetDateRange();
         var completed = await OmnichannelReportQuery.GetCompletedAsync(
             _session,
-            context.FromUtc,
-            context.ToUtc,
+            range.FromUtc.GetValueOrDefault(),
+            range.ToUtc.GetValueOrDefault(),
             await OmnichannelReportFilter.GetCriteriaAsync(context.Filter, _campaignManager, cancellationToken),
             cancellationToken);
         var counts = OmnichannelReportAggregator.CountByDisposition(completed);

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/EnterpriseActivityReportProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/EnterpriseActivityReportProvider.cs
@@ -52,12 +52,14 @@ internal sealed class EnterpriseActivityReportProvider : IReport
 
     public async Task<ReportDocument> RunAsync(ReportContext context, CancellationToken cancellationToken = default)
     {
+        var range = context.Filter.GetDateRange();
+        var toUtc = range.ToUtc.GetValueOrDefault();
         var fromUtc = _definition.Kind is EnterpriseActivityReportKind.Backlog or EnterpriseActivityReportKind.Aging
             ? DateTime.MinValue
-            : context.FromUtc;
+            : range.FromUtc.GetValueOrDefault();
 
         var activities = (await _session.QueryIndex<OmnichannelActivityIndex>(
-            index => index.CreatedUtc >= fromUtc && index.CreatedUtc <= context.ToUtc,
+            index => index.CreatedUtc >= fromUtc && index.CreatedUtc <= toUtc,
             collection: OmnichannelConstants.CollectionName)
             .ListAsync(cancellationToken))
             .ToArray();
@@ -86,8 +88,8 @@ internal sealed class EnterpriseActivityReportProvider : IReport
 
         return _definition.Kind switch
         {
-            EnterpriseActivityReportKind.Backlog => BuildBacklog(filteredActivities, context.ToUtc),
-            EnterpriseActivityReportKind.Aging => BuildAging(filteredActivities, context.ToUtc),
+            EnterpriseActivityReportKind.Backlog => BuildBacklog(filteredActivities, toUtc),
+            EnterpriseActivityReportKind.Aging => BuildAging(filteredActivities, toUtc),
             EnterpriseActivityReportKind.SourcePerformance => BuildProgress(filteredActivities, S["Source"].Value, activity => Display(activity.Source)),
             EnterpriseActivityReportKind.ChannelPerformance => BuildProgress(filteredActivities, S["Channel"].Value, activity => Display(activity.Channel)),
             EnterpriseActivityReportKind.KindPerformance => BuildProgress(filteredActivities, S["Activity kind"].Value, activity => activity.Kind.ToString()),
@@ -149,7 +151,7 @@ internal sealed class EnterpriseActivityReportProvider : IReport
                 activity => Math.Max(0, activity.Attempts).ToString(CultureInfo.InvariantCulture)),
             EnterpriseActivityReportKind.OverdueByUser => BuildOverdueByDimension(
                 filteredActivities,
-                context.ToUtc,
+                toUtc,
                 S["Assigned user"].Value,
                 activity => activity.AssignedToId,
                 activity => ResolveUser(activity.AssignedToId, userNames)),

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/OmnichannelReportFilter.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/OmnichannelReportFilter.cs
@@ -20,10 +20,10 @@ internal static class OmnichannelReportFilter
     {
         var criteria = new OmnichannelReportCriteria
         {
-            CampaignId = filter.Get<string>(CampaignId),
-            CampaignGroupId = filter.Get<string>(CampaignGroupId),
-            Channel = filter.Get<string>(Channel),
-            Source = filter.Get<string>(Source),
+            CampaignId = filter.GetOrDefault<string>(CampaignId),
+            CampaignGroupId = filter.GetOrDefault<string>(CampaignGroupId),
+            Channel = filter.GetOrDefault<string>(Channel),
+            Source = filter.GetOrDefault<string>(Source),
             Status = filter.TryGet<ActivityStatus>(Status, out var status) ? status : null,
         };
 

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/OmnichannelReportFilter.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Reports/OmnichannelReportFilter.cs
@@ -1,6 +1,6 @@
 using CrestApps.Core.Services;
-using System.Text.Json.Nodes;
 using CrestApps.OrchardCore.Omnichannel.Core.Models;
+using CrestApps.OrchardCore.Reports;
 using CrestApps.OrchardCore.Reports.Models;
 
 namespace CrestApps.OrchardCore.Omnichannel.Managements.Reports;
@@ -20,11 +20,11 @@ internal static class OmnichannelReportFilter
     {
         var criteria = new OmnichannelReportCriteria
         {
-            CampaignId = GetString(filter, CampaignId),
-            CampaignGroupId = GetString(filter, CampaignGroupId),
-            Channel = GetString(filter, Channel),
-            Source = GetString(filter, Source),
-            Status = GetStatus(filter),
+            CampaignId = filter.Get<string>(CampaignId),
+            CampaignGroupId = filter.Get<string>(CampaignGroupId),
+            Channel = filter.Get<string>(Channel),
+            Source = filter.Get<string>(Source),
+            Status = filter.TryGet<ActivityStatus>(Status, out var status) ? status : null,
         };
 
         if (!string.IsNullOrEmpty(criteria.CampaignGroupId))
@@ -36,34 +36,6 @@ internal static class OmnichannelReportFilter
         }
 
         return criteria;
-    }
-
-    public static string GetString(ReportFilter filter, string key)
-    {
-        return filter.Properties.TryGetPropertyValue(key, out var value)
-            ? value?.GetValue<string>()
-            : null;
-    }
-
-    public static void SetString(ReportFilter filter, string key, string value)
-    {
-        if (string.IsNullOrEmpty(value))
-        {
-            filter.Properties.Remove(key);
-
-            return;
-        }
-
-        filter.Properties[key] = JsonValue.Create(value);
-    }
-
-    private static ActivityStatus? GetStatus(ReportFilter filter)
-    {
-        var value = GetString(filter, Status);
-
-        return Enum.TryParse<ActivityStatus>(value, ignoreCase: true, out var status)
-            ? status
-            : null;
     }
 }
 

--- a/src/Modules/CrestApps.OrchardCore.Reports/Controllers/ReportsController.cs
+++ b/src/Modules/CrestApps.OrchardCore.Reports/Controllers/ReportsController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Admin;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.ModelBinding;
-using OrchardCore.Modules;
 
 namespace CrestApps.OrchardCore.Reports.Controllers;
 
@@ -16,16 +15,12 @@ namespace CrestApps.OrchardCore.Reports.Controllers;
 [Admin]
 public sealed class ReportsController : Controller
 {
-    private const int DefaultRangeDays = 30;
-
     private readonly IReportManager _reportManager;
     private readonly IReportExportManager _exportManager;
     private readonly IDisplayManager<ReportFilter> _filterDisplayManager;
     private readonly IAuthorizationService _authorizationService;
     private readonly IUpdateModelAccessor _updateModelAccessor;
     private readonly ReportDisplayValueResolver _displayValueResolver;
-    private readonly IClock _clock;
-    private readonly ILocalClock _localClock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReportsController"/> class.
@@ -36,17 +31,13 @@ public sealed class ReportsController : Controller
     /// <param name="authorizationService">The authorization service.</param>
     /// <param name="updateModelAccessor">The update model accessor used to bind the filter from the request.</param>
     /// <param name="displayValueResolver">The resolver for typed report values.</param>
-    /// <param name="clock">The clock used to compute the default reporting period.</param>
-    /// <param name="localClock">The tenant local clock used to resolve default date boundaries.</param>
     public ReportsController(
         IReportManager reportManager,
         IReportExportManager exportManager,
         IDisplayManager<ReportFilter> filterDisplayManager,
         IAuthorizationService authorizationService,
         IUpdateModelAccessor updateModelAccessor,
-        ReportDisplayValueResolver displayValueResolver,
-        IClock clock,
-        ILocalClock localClock)
+        ReportDisplayValueResolver displayValueResolver)
     {
         _reportManager = reportManager;
         _exportManager = exportManager;
@@ -54,8 +45,6 @@ public sealed class ReportsController : Controller
         _authorizationService = authorizationService;
         _updateModelAccessor = updateModelAccessor;
         _displayValueResolver = displayValueResolver;
-        _clock = clock;
-        _localClock = localClock;
     }
 
     /// <summary>
@@ -114,8 +103,6 @@ public sealed class ReportsController : Controller
             ExportFormats = _exportManager.ListFormats(),
             FilterShape = filterShape,
             Document = document,
-            FromUtc = filter.FromUtc.GetValueOrDefault(),
-            ToUtc = filter.ToUtc.GetValueOrDefault(),
         });
     }
 
@@ -153,7 +140,8 @@ public sealed class ReportsController : Controller
 
         await _displayValueResolver.ResolveAsync(document);
         var content = exportFormat.Serialize(document);
-        var fileName = $"{id}-{filter.FromUtc:yyyyMMdd}-to-{filter.ToUtc:yyyyMMdd}.{exportFormat.FileExtension}";
+        var range = filter.GetDateRange();
+        var fileName = $"{id}-{range.FromUtc:yyyyMMdd}-to-{range.ToUtc:yyyyMMdd}.{exportFormat.FileExtension}";
 
         return File(content, exportFormat.ContentType, fileName);
     }
@@ -167,28 +155,6 @@ public sealed class ReportsController : Controller
 
         await _filterDisplayManager.UpdateEditorAsync(filter, _updateModelAccessor.ModelUpdater, false);
 
-        await NormalizeRangeAsync(filter);
-
         return filter;
-    }
-
-    private async Task NormalizeRangeAsync(ReportFilter filter)
-    {
-        var localNow = await _localClock.ConvertToLocalAsync(_clock.UtcNow);
-        var localDate = localNow.Date;
-        var defaultFromLocal = DateTime.SpecifyKind(localDate.AddDays(-(DefaultRangeDays - 1)), DateTimeKind.Unspecified);
-        var defaultToLocal = DateTime.SpecifyKind(localDate.AddDays(1).AddTicks(-1), DateTimeKind.Unspecified);
-        var defaultFromUtc = await _localClock.ConvertToUtcAsync(defaultFromLocal);
-        var defaultToUtc = await _localClock.ConvertToUtcAsync(defaultToLocal);
-        var to = filter.ToUtc ?? defaultToUtc;
-        var from = filter.FromUtc ?? defaultFromUtc;
-
-        if (from > to)
-        {
-            (from, to) = (to, from);
-        }
-
-        filter.FromUtc = DateTime.SpecifyKind(from, DateTimeKind.Utc);
-        filter.ToUtc = DateTime.SpecifyKind(to, DateTimeKind.Utc);
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.Reports/Drivers/ReportDateRangeFilterDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Reports/Drivers/ReportDateRangeFilterDisplayDriver.cs
@@ -8,18 +8,27 @@ namespace CrestApps.OrchardCore.Reports.Drivers;
 
 /// <summary>
 /// Contributes the built-in from/to date-range filter to every report. Because it declares no group, it
-/// renders for all reports; report-specific filters restrict themselves to their report's group.
+/// renders for all reports; report-specific filters restrict themselves to their report's group. The
+/// resolved period is stored in the report filter property bag like any other filter, so a report that
+/// does not need a date range can be built without one.
 /// </summary>
 public sealed class ReportDateRangeFilterDisplayDriver : DisplayDriver<ReportFilter>
 {
+    private const int DefaultRangeDays = 30;
+
+    private readonly IClock _clock;
     private readonly ILocalClock _localClock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReportDateRangeFilterDisplayDriver"/> class.
     /// </summary>
+    /// <param name="clock">The clock used to compute the default reporting period.</param>
     /// <param name="localClock">The tenant local clock.</param>
-    public ReportDateRangeFilterDisplayDriver(ILocalClock localClock)
+    public ReportDateRangeFilterDisplayDriver(
+        IClock clock,
+        ILocalClock localClock)
     {
+        _clock = clock;
         _localClock = localClock;
     }
 
@@ -28,13 +37,15 @@ public sealed class ReportDateRangeFilterDisplayDriver : DisplayDriver<ReportFil
     {
         return Initialize<ReportDateRangeFilterViewModel>("ReportDateRangeFilter_Edit", async model =>
         {
-            model.From = filter.FromUtc.HasValue
-                ? (await _localClock.ConvertToLocalAsync(filter.FromUtc.Value)).DateTime
+            var range = filter.GetDateRange();
+
+            model.From = range.FromUtc.HasValue
+                ? (await _localClock.ConvertToLocalAsync(range.FromUtc.Value)).DateTime
                 : null;
-            model.To = filter.ToUtc.HasValue
-                ? (await _localClock.ConvertToLocalAsync(filter.ToUtc.Value)).DateTime
+            model.To = range.ToUtc.HasValue
+                ? (await _localClock.ConvertToLocalAsync(range.ToUtc.Value)).DateTime
                 : null;
-            model.Range = filter.DateRangeKey;
+            model.Range = range.Key;
         }).Location("Content:1");
     }
 
@@ -45,14 +56,41 @@ public sealed class ReportDateRangeFilterDisplayDriver : DisplayDriver<ReportFil
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-        filter.FromUtc = model.From.HasValue
+        var fromUtc = model.From.HasValue
             ? await _localClock.ConvertToUtcAsync(DateTime.SpecifyKind(model.From.Value, DateTimeKind.Unspecified))
-            : null;
-        filter.ToUtc = model.To.HasValue
+            : (DateTime?)null;
+        var toUtc = model.To.HasValue
             ? await _localClock.ConvertToUtcAsync(DateTime.SpecifyKind(model.To.Value, DateTimeKind.Unspecified))
-            : null;
-        filter.DateRangeKey = model.Range;
+            : (DateTime?)null;
+
+        var range = await NormalizeAsync(fromUtc, toUtc, model.Range);
+
+        filter.SetDateRange(range);
 
         return Edit(filter, context);
+    }
+
+    private async Task<ReportDateRange> NormalizeAsync(DateTime? fromUtc, DateTime? toUtc, string key)
+    {
+        var localNow = await _localClock.ConvertToLocalAsync(_clock.UtcNow);
+        var localDate = localNow.Date;
+        var defaultFromLocal = DateTime.SpecifyKind(localDate.AddDays(-(DefaultRangeDays - 1)), DateTimeKind.Unspecified);
+        var defaultToLocal = DateTime.SpecifyKind(localDate.AddDays(1).AddTicks(-1), DateTimeKind.Unspecified);
+        var defaultFromUtc = await _localClock.ConvertToUtcAsync(defaultFromLocal);
+        var defaultToUtc = await _localClock.ConvertToUtcAsync(defaultToLocal);
+        var to = toUtc ?? defaultToUtc;
+        var from = fromUtc ?? defaultFromUtc;
+
+        if (from > to)
+        {
+            (from, to) = (to, from);
+        }
+
+        return new ReportDateRange
+        {
+            FromUtc = DateTime.SpecifyKind(from, DateTimeKind.Utc),
+            ToUtc = DateTime.SpecifyKind(to, DateTimeKind.Utc),
+            Key = key,
+        };
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.Reports/ViewModels/ReportDisplayViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.Reports/ViewModels/ReportDisplayViewModel.cs
@@ -28,14 +28,4 @@ public sealed class ReportDisplayViewModel
     /// Gets or sets the report document to render.
     /// </summary>
     public ReportDocument Document { get; set; }
-
-    /// <summary>
-    /// Gets or sets the resolved inclusive lower UTC bound of the reporting period.
-    /// </summary>
-    public DateTime FromUtc { get; set; }
-
-    /// <summary>
-    /// Gets or sets the resolved inclusive upper UTC bound of the reporting period.
-    /// </summary>
-    public DateTime ToUtc { get; set; }
 }

--- a/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportFilterExtensionsTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportFilterExtensionsTests.cs
@@ -1,0 +1,140 @@
+using CrestApps.OrchardCore.Reports;
+using CrestApps.OrchardCore.Reports.Models;
+
+namespace CrestApps.OrchardCore.Tests.Modules.Reports;
+
+public sealed class ReportFilterExtensionsTests
+{
+    private enum SampleStatus
+    {
+        None,
+        Active,
+        Closed,
+    }
+
+    [Fact]
+    public void TryGet_WhenKeyIsMissing_ShouldReturnFalse()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+
+        // Act
+        var found = filter.TryGet<string>("Missing", out var value);
+
+        // Assert
+        Assert.False(found);
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void SetThenTryGet_WithString_ShouldRoundTrip()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+
+        // Act
+        filter.Set("CampaignId", "abc123");
+        var found = filter.TryGet<string>("CampaignId", out var value);
+
+        // Assert
+        Assert.True(found);
+        Assert.Equal("abc123", value);
+    }
+
+    [Fact]
+    public void SetThenTryGet_WithInteger_ShouldRoundTrip()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+
+        // Act
+        filter.Set("Take", 25);
+        var found = filter.TryGet<int>("Take", out var value);
+
+        // Assert
+        Assert.True(found);
+        Assert.Equal(25, value);
+    }
+
+    [Fact]
+    public void SetThenTryGet_WithEnumStoredAsString_ShouldParseEnum()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+
+        // Act
+        filter.Set("Status", "Active");
+        var found = filter.TryGet<SampleStatus>("Status", out var value);
+
+        // Assert
+        Assert.True(found);
+        Assert.Equal(SampleStatus.Active, value);
+    }
+
+    [Fact]
+    public void Set_WithNullValue_ShouldRemoveKey()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+        filter.Set("Channel", "phone");
+
+        // Act
+        filter.Set<string>("Channel", null);
+
+        // Assert
+        Assert.False(filter.TryGet<string>("Channel", out _));
+    }
+
+    [Fact]
+    public void Set_WithEmptyString_ShouldRemoveKey()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+        filter.Set("Channel", "phone");
+
+        // Act
+        filter.Set("Channel", string.Empty);
+
+        // Assert
+        Assert.False(filter.TryGet<string>("Channel", out _));
+    }
+
+    [Fact]
+    public void SetDateRange_ThenGetDateRange_ShouldRoundTripAsUtc()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+        var range = new ReportDateRange
+        {
+            FromUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ToUtc = new DateTime(2026, 1, 31, 23, 59, 59, DateTimeKind.Utc),
+            Key = "last30",
+        };
+
+        // Act
+        filter.SetDateRange(range);
+        var resolved = filter.GetDateRange();
+
+        // Assert
+        Assert.Equal(range.FromUtc, resolved.FromUtc);
+        Assert.Equal(range.ToUtc, resolved.ToUtc);
+        Assert.Equal(DateTimeKind.Utc, resolved.FromUtc.Value.Kind);
+        Assert.Equal(DateTimeKind.Utc, resolved.ToUtc.Value.Kind);
+        Assert.Equal("last30", resolved.Key);
+    }
+
+    [Fact]
+    public void GetDateRange_WhenNotContributed_ShouldReturnUnsetBounds()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+
+        // Act
+        var resolved = filter.GetDateRange();
+
+        // Assert
+        Assert.Null(resolved.FromUtc);
+        Assert.Null(resolved.ToUtc);
+        Assert.Null(resolved.Key);
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportFilterExtensionsTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportFilterExtensionsTests.cs
@@ -42,6 +42,33 @@ public sealed class ReportFilterExtensionsTests
     }
 
     [Fact]
+    public void GetOrDefault_WhenKeyIsMissing_ShouldReturnDefault()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+
+        // Act
+        var value = filter.GetOrDefault<string>("Missing");
+
+        // Assert
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void GetOrDefault_WhenKeyIsPresent_ShouldReturnValue()
+    {
+        // Arrange
+        var filter = new ReportFilter();
+        filter.Set("Take", 25);
+
+        // Act
+        var value = filter.GetOrDefault<int>("Take");
+
+        // Assert
+        Assert.Equal(25, value);
+    }
+
+    [Fact]
     public void SetThenTryGet_WithInteger_ShouldRoundTrip()
     {
         // Arrange


### PR DESCRIPTION
Remove FromUtc, ToUtc, and DateRangeKey as first-class properties on ReportFilter so the date range is contributed and stored like any other filter, letting reports omit it when a date selector is not needed.

- Add ReportFilterExtensions with typed TryGet<T>/Get<T>/Set<T>/Remove and GetDateRange()/SetDateRange() helpers, plus a ReportDateRange model.
- Move date-range default/normalization into ReportDateRangeFilterDisplayDriver.
- Update ReportContext, ReportsController, and the Omnichannel report filter to use the new helpers.
- Update Reports docs and add a 3.0.0 breaking-change note.
- Add ReportFilterExtensions unit tests.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
