### PR TITLE
Make MCP server tool exposure opt-in via site settings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrchardCoreVersion>4.0.0-preview-19102</OrchardCoreVersion>
-    <CrestAppsCoreVersion>1.1.0-preview.213</CrestAppsCoreVersion>
+    <CrestAppsCoreVersion>1.1.0-preview.214</CrestAppsCoreVersion>
     <ModelContextProtocolVersion>2.0.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrchardCoreVersion>4.0.0-preview-19102</OrchardCoreVersion>
-    <CrestAppsCoreVersion>1.1.0-preview.212</CrestAppsCoreVersion>
+    <CrestAppsCoreVersion>1.1.0-preview.213</CrestAppsCoreVersion>
     <ModelContextProtocolVersion>2.0.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrchardCoreVersion>4.0.0-preview-19102</OrchardCoreVersion>
-    <CrestAppsCoreVersion>1.1.0-preview.205</CrestAppsCoreVersion>
+    <CrestAppsCoreVersion>1.1.0-preview.212</CrestAppsCoreVersion>
     <ModelContextProtocolVersion>2.0.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/CrestApps.Docs/docs/ai/mcp/server.md
+++ b/src/CrestApps.Docs/docs/ai/mcp/server.md
@@ -26,10 +26,41 @@ The MCP server exposes the following capabilities:
 
 | Capability | Description |
 |-----------|-------------|
-| **Tools** | All registered AI tools in Orchard Core are exposed as MCP tools that clients can discover and invoke |
+| **Tools** | AI tools and configured [tool instances](../tool-instances.md) that you explicitly opt in are exposed as MCP tools that clients can discover and invoke. Nothing is exposed by default. |
 | **Prompts** | MCP prompts registered in Orchard Core are exposed so clients can list and invoke prompts via `ListPrompts` and `GetPrompt`. Prompts can be added and managed via the admin UI. |
 | **Resources** | MCP resources registered in Orchard Core are exposed, allowing clients to access various data sources. Resources can be added and managed via the admin UI. |
 | **Templated Resources** | Resources with URI variable placeholders (e.g., `{fileName}`, `{contentType}`) that resolve dynamically based on client requests |
+
+## Tool exposure
+
+Tool exposure is **opt-in**. Nothing is listed or callable by default: the server only exposes the AI tools and configured [tool instances](../tool-instances.md) that you explicitly allow. The allow-list is enforced by both the list and the call handlers, so a tool that is not exposed can neither be discovered nor invoked.
+
+You configure the exposed tools from the **Settings → Artificial Intelligence** page, on the **MCP Server** card. The card has two ways to control exposure:
+
+- **Expose all tools** — when enabled, every non-hidden tool and every configured tool instance is exposed and the selection below is ignored. Use this only when you trust every client of the server.
+- **Tools** and **Tool instances** selectors — when **Expose all tools** is disabled (the default), only the tools and tool instances you select are exposed. The selectors list only the tools and instances the current user is allowed to access, exactly like the AI Profile editor.
+
+Both code-registered tools and stored tool instances participate in the same allow-list, so you can, for example, expose a documentation search instance without exposing any content-editing tools.
+
+The settings are stored as site settings, so a change takes effect after the tenant reloads — the settings page shows a reload warning when you save.
+
+### Usage case: expose documentation sites to MCP clients
+
+A common reason to run an MCP server is to let an external AI agent answer questions from your documentation. The [documentation search sources](../tool-instances.md#the-documentation-search-sources) let you declare a documentation site as a tool instance and scan it on demand, and the MCP server then exposes only the instances you choose.
+
+The following steps expose three documentation sites — [core.crestapps.com](https://core.crestapps.com), [orchardcore.crestapps.com](https://orchardcore.crestapps.com), and [docs.orchardcore.net](https://docs.orchardcore.net) — to MCP clients:
+
+1. Enable the **AI Tool Instances** feature (`CrestApps.OrchardCore.AI.ToolInstances`). This registers the built-in documentation search sources alongside the HTTP API request source.
+2. Navigate to **Artificial Intelligence → Tool Instances** and add one instance per site. All three sites are Docusaurus sites that publish a standard `sitemap.xml`, so use the **Documentation search (sitemap)** source for each:
+   - **Name** `crestapps-core-docs`, **Description** "Search the CrestApps Core documentation.", **Base URL** `https://core.crestapps.com`.
+   - **Name** `crestapps-orchardcore-docs`, **Description** "Search the CrestApps OrchardCore documentation.", **Base URL** `https://orchardcore.crestapps.com`.
+   - **Name** `orchardcore-docs`, **Description** "Search the Orchard Core framework documentation.", **Base URL** `https://docs.orchardcore.net`.
+3. Enable the **MCP Server** feature and configure its authentication.
+4. Navigate to **Settings → Artificial Intelligence**, open the **MCP Server** card, leave **Expose all tools** disabled, and select the three documentation instances under **Tool instances**. Save.
+
+MCP clients now discover exactly three tools — one per documentation site — and can search each site on demand, while every other tool and instance stays private.
+
+Because the sites are public, no headers, API keys, or credentials are involved. The first search of a site crawls it and caches the corpus, and later searches reuse the cache until the instance settings change.
 
 ## Authentication and authorization
 
@@ -45,7 +76,9 @@ When `OpenId` is used, you can also require the `AccessMcpServer` permission for
 
 ## Configuration
 
-Configure the MCP server in `appsettings.json`:
+You can configure the MCP server from the admin **Settings → Artificial Intelligence** page (on the **MCP Server** card) without redeploying. The stored site settings are also the source of the [tool exposure](#tool-exposure) allow-list.
+
+For deployment scenarios, the same options can be set in `appsettings.json`, which overrides the stored site settings:
 
 ```json
 {
@@ -69,6 +102,8 @@ Configure the MCP server in `appsettings.json`:
 | `AuthenticationType` | `string` | `OpenId` | Authentication type: `OpenId`, `ApiKey`, or `None` |
 | `ApiKey` | `string` | `null` | API key for `ApiKey` authentication |
 | `RequireAccessPermission` | `bool` | `true` | Whether to require the `AccessMcpServer` permission in `OpenId` mode |
+| `ExposeAllTools` | `bool` | `false` | When `true`, every non-hidden tool and tool instance is exposed and the `Tools` allow-list is ignored |
+| `Tools` | `string[]` | `[]` | The allow-list of tool and tool instance names exposed when `ExposeAllTools` is `false`. Matching is case-insensitive |
 
 ### Authentication types
 
@@ -133,7 +168,8 @@ Use only for local development and testing.
 1. Enable **Model Context Protocol (MCP) Server** under **Tools -> Features**.
 2. Choose and configure an authentication mode.
 3. Grant the `AccessMcpServer` permission when you use `OpenId` with access checks enabled.
-4. Connect an MCP client to the SSE endpoint.
+4. Opt in the tools and tool instances to expose from **Settings → Artificial Intelligence** on the **MCP Server** card. Nothing is exposed until you select it (or enable **Expose all tools**).
+5. Connect an MCP client to the server endpoint.
 
 ## MCP endpoint
 
@@ -371,6 +407,8 @@ The screencast below shows the admin chat UI interacting with content and tools 
 
 - Verify the required Orchard Core and CrestApps features are enabled.
 - Check that the expected AI tools, prompts, or resources are registered.
+- Confirm the tool or tool instance is opted in on the **MCP Server** card under **Settings → Artificial Intelligence** (or that **Expose all tools** is enabled). Tools are not exposed until you select them.
+- Confirm the calling identity is authorized for the tool, because exposed tools still respect Orchard Core permissions.
 
 ### Configuration does not apply
 

--- a/src/CrestApps.Docs/docs/ai/mcp/server.md
+++ b/src/CrestApps.Docs/docs/ai/mcp/server.md
@@ -37,7 +37,7 @@ Tool exposure is **opt-in**. Nothing is listed or callable by default: the serve
 
 You configure the exposed tools from the **Settings → Artificial Intelligence** page, on the **MCP Server** card. The card has two ways to control exposure:
 
-- **Expose all tools** — when enabled, every non-hidden tool and every configured tool instance is exposed and the selection below is ignored. Use this only when you trust every client of the server.
+- **Expose all tools** — when enabled, every non-hidden tool and every configured tool instance is exposed and the selection below is ignored. Enabling it hides the **Tools** and **Tool instances** selectors, because the selection no longer applies. Use this only when you trust every client of the server.
 - **Tools** and **Tool instances** selectors — when **Expose all tools** is disabled (the default), only the tools and tool instances you select are exposed. The selectors list only the tools and instances the current user is allowed to access, exactly like the AI Profile editor.
 
 Both code-registered tools and stored tool instances participate in the same allow-list, so you can, for example, expose a documentation search instance without exposing any content-editing tools.

--- a/src/CrestApps.Docs/docs/ai/mcp/server.md
+++ b/src/CrestApps.Docs/docs/ai/mcp/server.md
@@ -37,7 +37,7 @@ Tool exposure is **opt-in**. Nothing is listed or callable by default: the serve
 
 You configure the exposed tools from the **Settings → Artificial Intelligence** page, on the **MCP Server** card. The card has two ways to control exposure:
 
-- **Expose all tools** — when enabled, every non-hidden tool and every configured tool instance is exposed and the selection below is ignored. Enabling it hides the **Tools** and **Tool instances** selectors, because the selection no longer applies. Use this only when you trust every client of the server.
+- **Expose all tools** — when enabled, every *selectable* tool and every configured tool instance is exposed and the selection below is ignored. System tools and hidden tools are never exposed, even in this mode. Enabling it hides the **Tools** and **Tool instances** selectors, because the selection no longer applies. Use this only when you trust every client of the server.
 - **Tools** and **Tool instances** selectors — when **Expose all tools** is disabled (the default), only the tools and tool instances you select are exposed. The selectors list only the tools and instances the current user is allowed to access, exactly like the AI Profile editor.
 
 Both code-registered tools and stored tool instances participate in the same allow-list, so you can, for example, expose a documentation search instance without exposing any content-editing tools.

--- a/src/CrestApps.Docs/docs/ai/tool-instances.md
+++ b/src/CrestApps.Docs/docs/ai/tool-instances.md
@@ -51,6 +51,28 @@ The feature always registers the built-in `http-api-request` source, so a usable
 
 All secrets (API key, token, password, and client secret) are encrypted with ASP.NET Core data protection before they are stored. When you edit an existing instance, leaving a secret field empty keeps the previously stored value.
 
+## The documentation search sources
+
+The feature also registers three built-in sources that turn a public documentation site into a searchable tool instance, so the AI model can answer questions from product or framework documentation without indexing it into a vector store. Each configured instance binds one site and is exposed to the model as its own function, so you can offer "search the CrestApps docs" and "search the Orchard Core docs" as two distinct tools.
+
+Pick the source that matches how the site publishes its content:
+
+| Source | Best for | How it works |
+| --- | --- | --- |
+| **Documentation search (sitemap)** (`sitemap-documentation`) | Any site that publishes a `sitemap.xml`, such as Docusaurus, MkDocs, and most static sites. | Crawls pages, strips the HTML, and ranks passages locally with keyword scoring. |
+| **Documentation search (search index)** (`search-index-documentation`) | MkDocs Material and other sites that publish a fetchable `search_index.json`. | Downloads the prebuilt index once and ranks its entries locally. |
+| **Documentation search (Algolia)** (`algolia-documentation`) | Docusaurus sites (and others) wired to hosted Algolia DocSearch. | Forwards the query to Algolia, which performs the ranking. |
+
+All three sources carry the **Knowledgebase** category. Each source captures its own fields:
+
+- **Sitemap** — a **Base URL** (the site root, for example `https://core.crestapps.com`), an optional **Sitemap URL** (defaults to `{BaseUrl}/sitemap.xml`), an optional **Maximum results**, and an optional **Maximum pages**.
+- **Search index** — a **Base URL** (used to resolve relative links and the default index URL), an optional **Index URL** (defaults to `{BaseUrl}/search/search_index.json`), and an optional **Maximum results**.
+- **Algolia** — an **Application id**, a **search-only API key** (never a write key), an **Index name**, and an optional **Maximum results**.
+
+The first search materializes the corpus (the crawled pages or the downloaded index) and caches it. Later searches reuse the cache until the instance settings change.
+
+These instances are usable anywhere tool instances are — on a profile, a chat interaction, or exposed to external clients through the [MCP server](mcp/server#tool-exposure).
+
 ## Assigning instances to a profile
 
 Open an **AI Profile** (or an **AI Profile Template** of the *Profile* source) and go to the **Capabilities** tab. The **Tool Instances** section lists every instance the current user is allowed to access. Selected instances are passed to the AI model alongside the profile's regular tools.

--- a/src/CrestApps.Docs/docs/ai/tool-instances.md
+++ b/src/CrestApps.Docs/docs/ai/tool-instances.md
@@ -67,7 +67,7 @@ All three sources carry the **Knowledgebase** category. Each source captures its
 
 - **Sitemap** — a **Base URL** (the site root, for example `https://core.crestapps.com`), an optional **Sitemap URL** (defaults to `{BaseUrl}/sitemap.xml`), an optional **Maximum results**, and an optional **Maximum pages**.
 - **Search index** — a **Base URL** (used to resolve relative links and the default index URL), an optional **Index URL** (defaults to `{BaseUrl}/search/search_index.json`), and an optional **Maximum results**.
-- **Algolia** — an **Application id**, a **search-only API key** (never a write key), an **Index name**, and an optional **Maximum results**.
+- **Algolia** — an **Application id**, a **search-only API key** (never a write key), an **Index name**, and an optional **Maximum results**. The API key is encrypted with ASP.NET Core data protection before it is stored; when you edit an existing instance, leaving the API key field empty keeps the previously stored key.
 
 The first search materializes the corpus (the crawled pages or the downloaded index) and caches it. Later searches reuse the cache until the instance settings change.
 

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -81,9 +81,9 @@ The **MCP Server** feature now exposes tools on an opt-in basis (see [Breaking C
 Highlights:
 
 - A new **MCP Server** card on the **Settings → Artificial Intelligence** page configures the authentication mode and selects which tools and tool instances are exposed, using the same selector as the AI Profile editor.
-- An **Expose all tools** switch restores the previous "expose everything" behavior when it is explicitly enabled.
+- An **Expose all tools** switch restores the previous "expose everything" behavior when it is explicitly enabled. Enabling it hides the **Tools** and **Tool instances** selectors, because the selection no longer applies.
 - The settings are stored as site settings (`McpServerSettings`) and loaded into `McpServerOptions`; the existing `OrchardCore:CrestApps:AI:McpServer` configuration still overrides them for deployment scenarios.
-- The **AI Tool Instances** feature now registers the built-in documentation search sources (sitemap crawl, prebuilt search index, and Algolia DocSearch), so a public documentation site can be declared as a tool instance and exposed to MCP clients on demand.
+- The **AI Tool Instances** feature now registers the built-in documentation search sources (sitemap crawl, prebuilt search index, and Algolia DocSearch), so a public documentation site can be declared as a tool instance and exposed to MCP clients on demand. The Algolia search-only API key is now encrypted with ASP.NET Core data protection at rest.
 
 See [MCP Server](../ai/mcp/server#tool-exposure) and [AI Tool Instances](../ai/tool-instances#the-documentation-search-sources) for details.
 

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -13,7 +13,7 @@ This page highlights the changes in the `3.0.0` line.
 
 ### AI
 
-- **The MCP Server no longer exposes tools by default.** Previously every registered AI tool was listed and callable by any connected MCP client. Tool exposure is now **opt-in**: nothing is listed or callable until you either select the tools and tool instances on the new **MCP Server** card under **Settings → Artificial Intelligence**, add their names to `McpServerOptions.Tools`, or set `McpServerOptions.ExposeAllTools` to `true`. Deployments that relied on the previous "expose everything" behavior must enable **Expose all tools** (or populate the allow-list) to keep exposing their tools. Prompts and resources are unaffected. See [MCP Server](../ai/mcp/server#tool-exposure) for details.
+- **The MCP Server no longer exposes tools by default.** Previously every registered AI tool was listed and callable by any connected MCP client. Tool exposure is now **opt-in**: nothing is listed or callable until you either select the tools and tool instances on the new **MCP Server** card under **Settings → Artificial Intelligence**, add their names to `McpServerOptions.Tools`, or set `McpServerOptions.ExposeAllTools` to `true`. **Expose all tools** now exposes only *selectable* tools; system tools and hidden tools are never exposed, even when it is enabled. Deployments that relied on the previous "expose everything" behavior must enable **Expose all tools** (or populate the allow-list) to keep exposing their tools. Prompts and resources are unaffected. See [MCP Server](../ai/mcp/server#tool-exposure) for details.
 
 ### Reports
 
@@ -81,7 +81,7 @@ The **MCP Server** feature now exposes tools on an opt-in basis (see [Breaking C
 Highlights:
 
 - A new **MCP Server** card on the **Settings → Artificial Intelligence** page configures the authentication mode and selects which tools and tool instances are exposed, using the same selector as the AI Profile editor.
-- An **Expose all tools** switch restores the previous "expose everything" behavior when it is explicitly enabled. Enabling it hides the **Tools** and **Tool instances** selectors, because the selection no longer applies.
+- An **Expose all tools** switch restores the previous "expose everything" behavior when it is explicitly enabled. It exposes only *selectable* tools, so system and hidden tools are never listed or callable even in this mode. Enabling it hides the **Tools** and **Tool instances** selectors, because the selection no longer applies.
 - The settings are stored as site settings (`McpServerSettings`) and loaded into `McpServerOptions`; the existing `OrchardCore:CrestApps:AI:McpServer` configuration still overrides them for deployment scenarios.
 - The **AI Tool Instances** feature now registers the built-in documentation search sources (sitemap crawl, prebuilt search index, and Algolia DocSearch), so a public documentation site can be declared as a tool instance and exposed to MCP clients on demand. The Algolia search-only API key is now encrypted with ASP.NET Core data protection at rest.
 

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -68,6 +68,23 @@ See [AI Documents](../ai/documents) for details.
 
 -----
 
+### AI
+
+#### Opt-in tool exposure for the MCP server
+
+The **MCP Server** feature no longer exposes every registered AI tool by default. Tool exposure is now **opt-in**: the server exposes only the AI tools and configured tool instances you explicitly allow, and the allow-list is enforced by both the list and the call handlers, so a tool that is not exposed can neither be discovered nor invoked.
+
+Highlights:
+
+- A new **MCP Server** card on the **Settings → Artificial Intelligence** page configures the authentication mode and selects which tools and tool instances are exposed, using the same selector as the AI Profile editor.
+- An **Expose all tools** switch restores the previous "expose everything" behavior when it is explicitly enabled.
+- The settings are stored as site settings (`McpServerSettings`) and loaded into `McpServerOptions`; the existing `OrchardCore:CrestApps:AI:McpServer` configuration still overrides them for deployment scenarios.
+- The **AI Tool Instances** feature now registers the built-in documentation search sources (sitemap crawl, prebuilt search index, and Algolia DocSearch), so a public documentation site can be declared as a tool instance and exposed to MCP clients on demand.
+
+See [MCP Server](../ai/mcp/server#tool-exposure) and [AI Tool Instances](../ai/tool-instances#the-documentation-search-sources) for details.
+
+-----
+
 ### SignalR
 
 #### Redis backplane extracted into its own module

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -11,6 +11,10 @@ This page highlights the changes in the `3.0.0` line.
 
 ## Breaking Changes
 
+### AI
+
+- **The MCP Server no longer exposes tools by default.** Previously every registered AI tool was listed and callable by any connected MCP client. Tool exposure is now **opt-in**: nothing is listed or callable until you either select the tools and tool instances on the new **MCP Server** card under **Settings → Artificial Intelligence**, add their names to `McpServerOptions.Tools`, or set `McpServerOptions.ExposeAllTools` to `true`. Deployments that relied on the previous "expose everything" behavior must enable **Expose all tools** (or populate the allow-list) to keep exposing their tools. Prompts and resources are unaffected. See [MCP Server](../ai/mcp/server#tool-exposure) for details.
+
 ### Reports
 
 - `ReportFilter` no longer exposes `FromUtc`, `ToUtc`, or `DateRangeKey` as first-class properties, and `ReportContext` no longer exposes `FromUtc` or `ToUtc`. The date range is now contributed and stored like any other filter, so reports that do not need a date selector can omit it. Read and write the period through the new `ReportFilter` helpers (`GetDateRange()` / `SetDateRange()` — for example `context.Filter.GetDateRange()` inside a report), and read or write any filter value with the typed `TryGet<T>(string key, out T value)`, `GetOrDefault<T>(string key)`, and `Set<T>(string key, T value)` extension methods.
@@ -72,7 +76,7 @@ See [AI Documents](../ai/documents) for details.
 
 #### Opt-in tool exposure for the MCP server
 
-The **MCP Server** feature no longer exposes every registered AI tool by default. Tool exposure is now **opt-in**: the server exposes only the AI tools and configured tool instances you explicitly allow, and the allow-list is enforced by both the list and the call handlers, so a tool that is not exposed can neither be discovered nor invoked.
+The **MCP Server** feature now exposes tools on an opt-in basis (see [Breaking Changes](#ai)). The server exposes only the AI tools and configured tool instances you explicitly allow, and the allow-list is enforced by both the list and the call handlers, so a tool that is not exposed can neither be discovered nor invoked.
 
 Highlights:
 

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Drivers/McpServerSettingsDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Drivers/McpServerSettingsDisplayDriver.cs
@@ -1,0 +1,220 @@
+using CrestApps.Core;
+using CrestApps.Core.AI.Mcp.Models;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Tooling;
+using CrestApps.OrchardCore.AI.Core;
+using CrestApps.OrchardCore.AI.Mcp.Models;
+using CrestApps.OrchardCore.AI.Mcp.Services;
+using CrestApps.OrchardCore.AI.Mcp.ViewModels;
+using CrestApps.OrchardCore.AI.Tools.Services;
+using CrestApps.OrchardCore.AI.ViewModels;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.DisplayManagement.Entities;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Mvc.ModelBinding;
+using OrchardCore.Settings;
+
+namespace CrestApps.OrchardCore.AI.Mcp.Drivers;
+
+/// <summary>
+/// Display driver that renders the MCP server settings on the site settings page, including the
+/// authentication configuration and the opt-in selection of tools and tool instances exposed to MCP clients.
+/// </summary>
+public sealed class McpServerSettingsDisplayDriver : SiteDisplayDriver<McpServerSettings>
+{
+    private readonly AIToolDefinitionOptions _toolDefinitions;
+    private readonly IAIToolInstanceAccessor _instanceAccessor;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IShellReleaseManager _shellReleaseManager;
+
+    internal readonly IStringLocalizer S;
+
+    protected override string SettingsGroupId => AIConstants.AISettingsGroupId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="McpServerSettingsDisplayDriver"/> class.
+    /// </summary>
+    /// <param name="toolDefinitions">The registered AI tool definitions.</param>
+    /// <param name="instanceAccessor">The accessor that resolves the tool instances the current user may assign.</param>
+    /// <param name="authorizationService">The authorization service.</param>
+    /// <param name="httpContextAccessor">The HTTP context accessor.</param>
+    /// <param name="shellReleaseManager">The shell release manager.</param>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public McpServerSettingsDisplayDriver(
+        IOptions<AIToolDefinitionOptions> toolDefinitions,
+        IAIToolInstanceAccessor instanceAccessor,
+        IAuthorizationService authorizationService,
+        IHttpContextAccessor httpContextAccessor,
+        IShellReleaseManager shellReleaseManager,
+        IStringLocalizer<McpServerSettingsDisplayDriver> stringLocalizer)
+    {
+        _toolDefinitions = toolDefinitions.Value;
+        _instanceAccessor = instanceAccessor;
+        _authorizationService = authorizationService;
+        _httpContextAccessor = httpContextAccessor;
+        _shellReleaseManager = shellReleaseManager;
+        S = stringLocalizer;
+    }
+
+    public override async Task<IDisplayResult> EditAsync(ISite site, McpServerSettings settings, BuildEditorContext context)
+    {
+        if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, McpServerPermissionsProvider.ManageMcpServerSettings))
+        {
+            return null;
+        }
+
+        context.AddTenantReloadWarningWrapper();
+
+        var accessibleTools = await GetAccessibleToolsAsync();
+        var accessibleInstances = await _instanceAccessor.GetAccessibleInstancesAsync();
+
+        var results = new List<IDisplayResult>
+        {
+            Initialize<McpServerSettingsViewModel>("McpServerSettings_Edit", model =>
+            {
+                model.AuthenticationType = settings.AuthenticationType;
+                model.RequireAccessPermission = settings.RequireAccessPermission;
+                model.ExposeAllTools = settings.ExposeAllTools;
+                model.HasApiKey = !string.IsNullOrEmpty(settings.ApiKey);
+                model.AuthenticationTypes =
+                [
+                    new SelectListItem(S["OpenID Connect"], nameof(McpServerAuthenticationType.OpenId)),
+                    new SelectListItem(S["API key"], nameof(McpServerAuthenticationType.ApiKey)),
+                    new SelectListItem(S["None (development only)"], nameof(McpServerAuthenticationType.None)),
+                ];
+            }).Location("Content:1%MCP Server;1")
+            .OnGroup(SettingsGroupId),
+        };
+
+        if (accessibleTools.Count > 0)
+        {
+            results.Add(Initialize<EditProfileToolsViewModel>("EditProfileTools_Edit", model =>
+            {
+                var selected = settings.Tools ?? [];
+
+                model.Tools = accessibleTools
+                    .GroupBy(tool => tool.Value.Category ?? S["Miscellaneous"])
+                    .OrderBy(group => group.Key)
+                    .ToDictionary(group => group.Key, group => group.Select(entry => new ToolEntry
+                    {
+                        ItemId = entry.Key,
+                        DisplayText = entry.Value.Title,
+                        Description = entry.Value.Description,
+                        IsSelected = selected.Contains(entry.Key),
+                    }).OrderBy(entry => entry.DisplayText).ToArray());
+            }).Location("Content:1%MCP Server;5")
+            .OnGroup(SettingsGroupId));
+        }
+
+        if (accessibleInstances.Count > 0)
+        {
+            results.Add(Initialize<EditToolInstancesViewModel>("EditToolInstances_Edit", model =>
+            {
+                var selected = settings.Tools ?? [];
+
+                model.Instances = accessibleInstances
+                    .Select(instance => new ToolInstanceEntry
+                    {
+                        Name = instance.Name,
+                        Description = instance.Description,
+                        IsSelected = selected.Contains(instance.Name, StringComparer.OrdinalIgnoreCase),
+                    })
+                    .OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+            }).Location("Content:1%MCP Server;10")
+            .OnGroup(SettingsGroupId));
+        }
+
+        return Combine([.. results]);
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(ISite site, McpServerSettings settings, UpdateEditorContext context)
+    {
+        if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, McpServerPermissionsProvider.ManageMcpServerSettings))
+        {
+            return null;
+        }
+
+        var model = new McpServerSettingsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        var toolsModel = new EditProfileToolsViewModel();
+        var instancesModel = new EditToolInstancesViewModel();
+
+        await context.Updater.TryUpdateModelAsync(toolsModel, Prefix);
+        await context.Updater.TryUpdateModelAsync(instancesModel, Prefix);
+
+        if (model.AuthenticationType == McpServerAuthenticationType.ApiKey && string.IsNullOrWhiteSpace(model.ApiKey) && string.IsNullOrEmpty(settings.ApiKey))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.ApiKey), S["The API key is required when the API key authentication type is selected."]);
+        }
+
+        if (!context.Updater.ModelState.IsValid)
+        {
+            return await EditAsync(site, settings, context);
+        }
+
+        var accessibleTools = await GetAccessibleToolsAsync();
+        var accessibleInstances = await _instanceAccessor.GetAccessibleInstancesAsync();
+
+        var selectedToolKeys = toolsModel.Tools?.Values?
+            .SelectMany(entries => entries)
+            .Where(entry => entry.IsSelected)
+            .Select(entry => entry.ItemId) ?? [];
+
+        var selectedInstanceNames = instancesModel.Instances?
+            .Where(entry => entry.IsSelected)
+            .Select(entry => entry.Name) ?? [];
+
+        var tools = new List<string>();
+
+        tools.AddRange(accessibleTools.Keys.Intersect(selectedToolKeys, StringComparer.Ordinal));
+        tools.AddRange(accessibleInstances
+            .Select(instance => instance.Name)
+            .Intersect(selectedInstanceNames, StringComparer.OrdinalIgnoreCase));
+
+        var apiKey = string.IsNullOrWhiteSpace(model.ApiKey)
+            ? settings.ApiKey
+            : model.ApiKey.Trim();
+
+        settings.AuthenticationType = model.AuthenticationType;
+        settings.ApiKey = apiKey;
+        settings.RequireAccessPermission = model.RequireAccessPermission;
+        settings.ExposeAllTools = model.ExposeAllTools;
+        settings.Tools = tools;
+
+        _shellReleaseManager.RequestRelease();
+
+        return await EditAsync(site, settings, context);
+    }
+
+    private async Task<Dictionary<string, AIToolDefinitionEntry>> GetAccessibleToolsAsync()
+    {
+        var accessibleTools = new Dictionary<string, AIToolDefinitionEntry>();
+
+        if (_toolDefinitions.Tools.Count == 0)
+        {
+            return accessibleTools;
+        }
+
+        var user = _httpContextAccessor.HttpContext.User;
+
+        foreach (var tool in _toolDefinitions.GetSelectableTools())
+        {
+            if (await _authorizationService.AuthorizeAsync(user, AIPermissions.AccessAITool, tool.Key as object))
+            {
+                accessibleTools[tool.Key] = tool.Value;
+            }
+        }
+
+        return accessibleTools;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Models/McpServerSettings.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Models/McpServerSettings.cs
@@ -1,0 +1,41 @@
+using CrestApps.Core.AI.Mcp.Models;
+
+namespace CrestApps.OrchardCore.AI.Mcp.Models;
+
+/// <summary>
+/// The site settings that configure the MCP server feature. The values are loaded into
+/// <see cref="McpServerOptions"/> by <see cref="Services.McpServerOptionsConfiguration"/>, so an operator can
+/// configure authentication and control which tools are exposed to MCP clients from the admin UI.
+/// </summary>
+public sealed class McpServerSettings
+{
+    /// <summary>
+    /// Gets or sets the authentication type used by the MCP server.
+    /// </summary>
+    public McpServerAuthenticationType AuthenticationType { get; set; } = McpServerAuthenticationType.OpenId;
+
+    /// <summary>
+    /// Gets or sets the API key required when <see cref="AuthenticationType"/> is
+    /// <see cref="McpServerAuthenticationType.ApiKey"/>.
+    /// </summary>
+    public string ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the <c>AccessMcpServer</c> permission is required. Applies
+    /// only when <see cref="AuthenticationType"/> is <see cref="McpServerAuthenticationType.OpenId"/>.
+    /// </summary>
+    public bool RequireAccessPermission { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether every non-hidden tool and configured tool instance is exposed
+    /// to MCP clients. When <c>false</c> (the default), only the tools listed in <see cref="Tools"/> are
+    /// exposed. When <c>true</c>, <see cref="Tools"/> is ignored and everything is exposed.
+    /// </summary>
+    public bool ExposeAllTools { get; set; }
+
+    /// <summary>
+    /// Gets or sets the allow-list of tool names and tool instance names exposed to MCP clients when
+    /// <see cref="ExposeAllTools"/> is <c>false</c>.
+    /// </summary>
+    public IList<string> Tools { get; set; } = [];
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Services/McpServerOptionsConfiguration.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Services/McpServerOptionsConfiguration.cs
@@ -1,39 +1,52 @@
 using CrestApps.Core.AI.Mcp.Models;
+using CrestApps.OrchardCore.AI.Mcp.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell.Configuration;
+using OrchardCore.Settings;
 
 namespace CrestApps.OrchardCore.AI.Mcp.Services;
 
 internal sealed class McpServerOptionsConfiguration : IConfigureOptions<McpServerOptions>
 {
+    private readonly ISiteService _siteService;
     private readonly IShellConfiguration _shellConfiguration;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="McpServerOptionsConfiguration"/> class.
     /// </summary>
+    /// <param name="siteService">The site service.</param>
     /// <param name="shellConfiguration">The shell configuration.</param>
-    public McpServerOptionsConfiguration(IShellConfiguration shellConfiguration)
+    public McpServerOptionsConfiguration(
+        ISiteService siteService,
+        IShellConfiguration shellConfiguration)
     {
+        _siteService = siteService;
         _shellConfiguration = shellConfiguration;
     }
 
     /// <summary>
-    /// Configures the <see cref="McpServerOptions"/>.
+    /// Configures the <see cref="McpServerOptions"/> from the stored site settings, then lets the shell
+    /// configuration (for example <c>appsettings.json</c>) override the values for deployment scenarios.
     /// </summary>
     /// <param name="options">The options.</param>
     public void Configure(McpServerOptions options)
     {
+        var settings = _siteService.GetSettings<McpServerSettings>();
+
+        options.AuthenticationType = settings.AuthenticationType;
+        options.ApiKey = settings.ApiKey;
+        options.RequireAccessPermission = settings.RequireAccessPermission;
+        options.ExposeAllTools = settings.ExposeAllTools;
+        options.Tools = settings.Tools is null
+            ? []
+            : [.. settings.Tools];
+
+        // Preserve backward compatibility by allowing the shell configuration to override the settings.
         var deprecatedSection = _shellConfiguration.GetSection("CrestApps:McpServer");
         var section = _shellConfiguration.GetSection("CrestApps:AI:McpServer");
 
         deprecatedSection.Bind(options);
         section.Bind(options);
-
-        if (string.IsNullOrWhiteSpace(section[nameof(McpServerOptions.AuthenticationType)]) &&
-            string.IsNullOrWhiteSpace(deprecatedSection[nameof(McpServerOptions.AuthenticationType)]))
-        {
-            options.AuthenticationType = McpServerAuthenticationType.OpenId;
-        }
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Services/McpServerPermissionsProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Services/McpServerPermissionsProvider.cs
@@ -1,4 +1,5 @@
-﻿using OrchardCore.Security.Permissions;
+﻿using OrchardCore;
+using OrchardCore.Security.Permissions;
 
 namespace CrestApps.OrchardCore.AI.Mcp.Services;
 
@@ -9,9 +10,12 @@ public sealed class McpServerPermissionsProvider : IPermissionProvider
 {
     public static readonly Permission AccessMcpServer = new("AccessMcpServer", "Access the MCP Server", isSecurityCritical: true);
 
+    public static readonly Permission ManageMcpServerSettings = new("ManageMcpServerSettings", "Manage the MCP Server settings", isSecurityCritical: true);
+
     private readonly IEnumerable<Permission> _allPermissions =
     [
         AccessMcpServer,
+        ManageMcpServerSettings,
     ];
 
     /// <summary>
@@ -23,6 +27,12 @@ public sealed class McpServerPermissionsProvider : IPermissionProvider
     /// <summary>
     /// Retrieves the default stereotypes.
     /// </summary>
-    public IEnumerable<PermissionStereotype> GetDefaultStereotypes()
-        => [];
+    public IEnumerable<PermissionStereotype> GetDefaultStereotypes() =>
+    [
+        new PermissionStereotype
+        {
+            Name = OrchardCoreConstants.Roles.Administrator,
+            Permissions = [ManageMcpServerSettings],
+        },
+    ];
 }

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Startup.cs
@@ -14,6 +14,7 @@ using CrestApps.OrchardCore.AI.Mcp.Handlers;
 using CrestApps.OrchardCore.AI.Mcp.Migrations;
 using CrestApps.OrchardCore.AI.Mcp.Recipes;
 using CrestApps.OrchardCore.AI.Mcp.Services;
+using CrestApps.OrchardCore.AI.Services;
 using CrestApps.OrchardCore.AI.Workflows.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -148,6 +149,11 @@ public sealed class McpServerStartup : StartupBase
         // so the shared WithCrestAppsHandlers() can resolve them.
         services.AddTransient<IConfigureOptions<McpServerOptions>, McpServerOptionsConfiguration>();
         services.AddPermissionProvider<McpServerPermissionsProvider>();
+
+        // Register the MCP server site settings editor so operators can configure authentication and
+        // opt in the tools and tool instances exposed to MCP clients.
+        services.AddSiteDisplayDriver<McpServerSettingsDisplayDriver>()
+            .AddNavigationProvider<AISiteSettingsAdminMenu>();
 
         // Register the authorization handler for MCP server.
         services.AddScoped<IAuthorizationHandler, McpServerAuthorizationHandler>();

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/ViewModels/McpServerSettingsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/ViewModels/McpServerSettingsViewModel.cs
@@ -1,0 +1,42 @@
+using CrestApps.Core.AI.Mcp.Models;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CrestApps.OrchardCore.AI.Mcp.ViewModels;
+
+/// <summary>
+/// Represents the editable MCP server settings shown on the site settings page.
+/// </summary>
+public class McpServerSettingsViewModel
+{
+    /// <summary>
+    /// Gets or sets the authentication type used by the MCP server.
+    /// </summary>
+    public McpServerAuthenticationType AuthenticationType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the API key used when the authentication type is <c>ApiKey</c>.
+    /// </summary>
+    public string ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the <c>AccessMcpServer</c> permission is required.
+    /// </summary>
+    public bool RequireAccessPermission { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether every non-hidden tool and tool instance is exposed to clients.
+    /// </summary>
+    public bool ExposeAllTools { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an API key is already stored.
+    /// </summary>
+    public bool HasApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the selectable authentication types.
+    /// </summary>
+    [BindNever]
+    public IEnumerable<SelectListItem> AuthenticationTypes { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpServerSettings.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpServerSettings.Edit.cshtml
@@ -45,17 +45,34 @@
 <script at="Foot">
     document.addEventListener('DOMContentLoaded', () => {
         const authSelect = document.querySelector('[name$="AuthenticationType"]');
-        if (!authSelect) return;
 
-        function toggleAuthSections() {
-            const value = authSelect.value;
+        if (authSelect) {
+            function toggleAuthSections() {
+                const value = authSelect.value;
 
-            document.querySelectorAll('[data-auth-section]').forEach(section => {
-                section.classList.toggle('d-none', section.dataset.authSection !== value);
-            });
+                document.querySelectorAll('[data-auth-section]').forEach(section => {
+                    section.classList.toggle('d-none', section.dataset.authSection !== value);
+                });
+            }
+
+            authSelect.addEventListener('change', toggleAuthSections);
+            toggleAuthSections();
         }
 
-        authSelect.addEventListener('change', toggleAuthSections);
-        toggleAuthSections();
+        const exposeAllTools = document.getElementById('mcpServerExposeAllTools');
+
+        if (exposeAllTools) {
+            const toolSelectors = [
+                document.querySelector('.tool-groups-container')?.closest('.ocat-wrapper'),
+                document.querySelector('[id^="tool-instance-"]')?.closest('.ocat-wrapper'),
+            ].filter(Boolean);
+
+            function toggleToolSelectors() {
+                toolSelectors.forEach(section => section.classList.toggle('d-none', exposeAllTools.checked));
+            }
+
+            exposeAllTools.addEventListener('change', toggleToolSelectors);
+            toggleToolSelectors();
+        }
     });
 </script>

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpServerSettings.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpServerSettings.Edit.cshtml
@@ -30,7 +30,7 @@
     </div>
 </div>
 
-<div class="ocat-wrapper border-bottom pb-2">
+<div class="ocat-wrapper">
     <div class="ocat-end-offset">
         <div class="form-check">
             <input type="checkbox" class="form-check-input" asp-for="ExposeAllTools" id="mcpServerExposeAllTools" />

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpServerSettings.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpServerSettings.Edit.cshtml
@@ -1,0 +1,61 @@
+@using CrestApps.OrchardCore.AI.Mcp.ViewModels
+
+@model McpServerSettingsViewModel
+
+<div class="ocat-wrapper">
+    <label asp-for="AuthenticationType" class="ocat-label">@T["Authentication type"]</label>
+    <div class="ocat-end">
+        <select asp-for="AuthenticationType" asp-items="Model.AuthenticationTypes" class="form-select"></select>
+        <span class="hint">@T["Controls how MCP clients authenticate with the server. Use OpenID Connect or API key in production, and None only for local development."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper" data-auth-section="ApiKey">
+    <label asp-for="ApiKey" class="ocat-label">@T["API key"]</label>
+    <div class="ocat-end">
+        <input asp-for="ApiKey" class="form-control" autocomplete="off" placeholder="@(Model.HasApiKey ? T["Leave blank to keep the current API key."] : T["Enter an API key."])" />
+        <span class="hint">@T["The API key MCP clients must send in the Authorization header. Required when the API key authentication type is selected."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper" data-auth-section="OpenId">
+    <div class="ocat-end-offset">
+        <div class="form-check">
+            <input type="checkbox" class="form-check-input" asp-for="RequireAccessPermission" />
+            <label class="form-check-label" asp-for="RequireAccessPermission">
+                @T["Require access permission"]
+            </label>
+            <span class="hint dashed">@T["When enabled, authenticated callers must also hold the Access the MCP Server permission. Applies only to OpenID Connect authentication."]</span>
+        </div>
+    </div>
+</div>
+
+<div class="ocat-wrapper border-bottom pb-2">
+    <div class="ocat-end-offset">
+        <div class="form-check">
+            <input type="checkbox" class="form-check-input" asp-for="ExposeAllTools" id="mcpServerExposeAllTools" />
+            <label class="form-check-label" asp-for="ExposeAllTools">
+                @T["Expose all tools"]
+            </label>
+            <span class="hint dashed">@T["When enabled, every non-hidden tool and configured tool instance is exposed to MCP clients and the selection below is ignored. Leave disabled to expose only the tools you select."]</span>
+        </div>
+    </div>
+</div>
+
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', () => {
+        const authSelect = document.querySelector('[name$="AuthenticationType"]');
+        if (!authSelect) return;
+
+        function toggleAuthSections() {
+            const value = authSelect.value;
+
+            document.querySelectorAll('[data-auth-section]').forEach(section => {
+                section.classList.toggle('d-none', section.dataset.authSection !== value);
+            });
+        }
+
+        authSelect.addEventListener('change', toggleAuthSections);
+        toggleAuthSections();
+    });
+</script>

--- a/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
@@ -7,6 +7,7 @@ using CrestApps.Core.AI.Profiles;
 using CrestApps.Core.AI.Services;
 using CrestApps.Core.AI.Tooling;
 using CrestApps.Core.AI.Tooling.Instances;
+using CrestApps.Core.AI.Tooling.Instances.Documentation;
 using CrestApps.Core.Data.YesSql;
 using CrestApps.Core.Data.YesSql.Indexes.AIChat;
 using CrestApps.Core.Data.YesSql.Services;
@@ -388,6 +389,7 @@ public sealed class ToolInstancesStartup : StartupBase
             .AddAISuite(ai => ai
                 .AddToolInstances(toolInstances => toolInstances
                     .AddHttpApiRequestSource()
+                    .AddDocumentationSearchSources()
                     .AddYesSqlStores(),
                     useDefaultRegistry: false)
             )
@@ -399,6 +401,9 @@ public sealed class ToolInstancesStartup : StartupBase
             .AddDataMigration<AIToolInstanceIndexMigrations>()
             .AddDisplayDriver<AIToolInstance, AIToolInstanceDisplayDriver>()
             .AddDisplayDriver<AIToolInstance, HttpApiRequestToolInstanceDisplayDriver>()
+            .AddDisplayDriver<AIToolInstance, SitemapDocumentationToolInstanceDisplayDriver>()
+            .AddDisplayDriver<AIToolInstance, SearchIndexDocumentationToolInstanceDisplayDriver>()
+            .AddDisplayDriver<AIToolInstance, AlgoliaDocumentationToolInstanceDisplayDriver>()
             .AddDisplayDriver<AIProfile, AIProfileToolInstancesDisplayDriver>()
             .AddDisplayDriver<AIProfileTemplate, AIProfileTemplateToolInstancesDisplayDriver>()
             .AddNavigationProvider<AIToolInstanceAdminMenu>()

--- a/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/AlgoliaDocumentationToolInstanceDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/AlgoliaDocumentationToolInstanceDisplayDriver.cs
@@ -38,9 +38,9 @@ internal sealed class AlgoliaDocumentationToolInstanceDisplayDriver : DisplayDri
             var settings = instance.GetOrCreate<AlgoliaDocumentationToolSettings>();
 
             model.ApplicationId = settings.ApplicationId;
-            model.ApiKey = settings.ApiKey;
             model.IndexName = settings.IndexName;
             model.MaxResults = settings.MaxResults;
+            model.HasApiKey = !string.IsNullOrEmpty(settings.ApiKey);
         }).Location("Content:5");
     }
 
@@ -55,12 +55,14 @@ internal sealed class AlgoliaDocumentationToolInstanceDisplayDriver : DisplayDri
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
+        var existing = instance.GetOrCreate<AlgoliaDocumentationToolSettings>();
+
         if (string.IsNullOrWhiteSpace(model.ApplicationId))
         {
             context.Updater.ModelState.AddModelError(Prefix, nameof(model.ApplicationId), S["The application id is required."]);
         }
 
-        if (string.IsNullOrWhiteSpace(model.ApiKey))
+        if (string.IsNullOrWhiteSpace(model.ApiKey) && string.IsNullOrEmpty(existing.ApiKey))
         {
             context.Updater.ModelState.AddModelError(Prefix, nameof(model.ApiKey), S["The search-only API key is required."]);
         }
@@ -75,10 +77,14 @@ internal sealed class AlgoliaDocumentationToolInstanceDisplayDriver : DisplayDri
             context.Updater.ModelState.AddModelError(Prefix, nameof(model.MaxResults), S["The maximum results must be greater than zero."]);
         }
 
+        var apiKey = string.IsNullOrWhiteSpace(model.ApiKey)
+            ? existing.ApiKey
+            : model.ApiKey.Trim();
+
         instance.Put(new AlgoliaDocumentationToolSettings
         {
             ApplicationId = model.ApplicationId?.Trim(),
-            ApiKey = model.ApiKey?.Trim(),
+            ApiKey = apiKey,
             IndexName = model.IndexName?.Trim(),
             MaxResults = model.MaxResults,
         });

--- a/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/AlgoliaDocumentationToolInstanceDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/AlgoliaDocumentationToolInstanceDisplayDriver.cs
@@ -2,6 +2,7 @@ using CrestApps.Core;
 using CrestApps.Core.AI.Tooling;
 using CrestApps.Core.AI.Tooling.Instances.Documentation;
 using CrestApps.OrchardCore.AI.ViewModels;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Localization;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -15,14 +16,20 @@ namespace CrestApps.OrchardCore.AI.Tools.Drivers;
 /// </summary>
 internal sealed class AlgoliaDocumentationToolInstanceDisplayDriver : DisplayDriver<AIToolInstance>
 {
+    private readonly IDataProtectionProvider _dataProtectionProvider;
+
     internal readonly IStringLocalizer S;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AlgoliaDocumentationToolInstanceDisplayDriver"/> class.
     /// </summary>
+    /// <param name="dataProtectionProvider">The data protection provider used to protect the stored API key.</param>
     /// <param name="stringLocalizer">The string localizer.</param>
-    public AlgoliaDocumentationToolInstanceDisplayDriver(IStringLocalizer<AlgoliaDocumentationToolInstanceDisplayDriver> stringLocalizer)
+    public AlgoliaDocumentationToolInstanceDisplayDriver(
+        IDataProtectionProvider dataProtectionProvider,
+        IStringLocalizer<AlgoliaDocumentationToolInstanceDisplayDriver> stringLocalizer)
     {
+        _dataProtectionProvider = dataProtectionProvider;
         S = stringLocalizer;
     }
 
@@ -79,7 +86,9 @@ internal sealed class AlgoliaDocumentationToolInstanceDisplayDriver : DisplayDri
 
         var apiKey = string.IsNullOrWhiteSpace(model.ApiKey)
             ? existing.ApiKey
-            : model.ApiKey.Trim();
+            : _dataProtectionProvider
+                .CreateProtector(DocumentationToolConstants.AlgoliaDataProtectionPurpose)
+                .Protect(model.ApiKey.Trim());
 
         instance.Put(new AlgoliaDocumentationToolSettings
         {

--- a/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/AlgoliaDocumentationToolInstanceDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/AlgoliaDocumentationToolInstanceDisplayDriver.cs
@@ -1,0 +1,91 @@
+using CrestApps.Core;
+using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.AI.Tooling.Instances.Documentation;
+using CrestApps.OrchardCore.AI.ViewModels;
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Mvc.ModelBinding;
+
+namespace CrestApps.OrchardCore.AI.Tools.Drivers;
+
+/// <summary>
+/// Display driver that captures the settings for the built-in Algolia DocSearch documentation search tool
+/// instance source, such as the application identifier, the search-only API key, and the index name.
+/// </summary>
+internal sealed class AlgoliaDocumentationToolInstanceDisplayDriver : DisplayDriver<AIToolInstance>
+{
+    internal readonly IStringLocalizer S;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AlgoliaDocumentationToolInstanceDisplayDriver"/> class.
+    /// </summary>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public AlgoliaDocumentationToolInstanceDisplayDriver(IStringLocalizer<AlgoliaDocumentationToolInstanceDisplayDriver> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    public override IDisplayResult Edit(AIToolInstance instance, BuildEditorContext context)
+    {
+        if (!IsSource(instance))
+        {
+            return null;
+        }
+
+        return Initialize<AlgoliaDocumentationToolInstanceViewModel>("AlgoliaDocumentationToolInstance_Edit", model =>
+        {
+            var settings = instance.GetOrCreate<AlgoliaDocumentationToolSettings>();
+
+            model.ApplicationId = settings.ApplicationId;
+            model.ApiKey = settings.ApiKey;
+            model.IndexName = settings.IndexName;
+            model.MaxResults = settings.MaxResults;
+        }).Location("Content:5");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(AIToolInstance instance, UpdateEditorContext context)
+    {
+        if (!IsSource(instance))
+        {
+            return null;
+        }
+
+        var model = new AlgoliaDocumentationToolInstanceViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (string.IsNullOrWhiteSpace(model.ApplicationId))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.ApplicationId), S["The application id is required."]);
+        }
+
+        if (string.IsNullOrWhiteSpace(model.ApiKey))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.ApiKey), S["The search-only API key is required."]);
+        }
+
+        if (string.IsNullOrWhiteSpace(model.IndexName))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.IndexName), S["The index name is required."]);
+        }
+
+        if (model.MaxResults.HasValue && model.MaxResults.Value <= 0)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.MaxResults), S["The maximum results must be greater than zero."]);
+        }
+
+        instance.Put(new AlgoliaDocumentationToolSettings
+        {
+            ApplicationId = model.ApplicationId?.Trim(),
+            ApiKey = model.ApiKey?.Trim(),
+            IndexName = model.IndexName?.Trim(),
+            MaxResults = model.MaxResults,
+        });
+
+        return Edit(instance, context);
+    }
+
+    private static bool IsSource(AIToolInstance instance)
+        => string.Equals(instance.Source, DocumentationToolConstants.AlgoliaSourceName, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/SearchIndexDocumentationToolInstanceDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/SearchIndexDocumentationToolInstanceDisplayDriver.cs
@@ -1,0 +1,91 @@
+using CrestApps.Core;
+using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.AI.Tooling.Instances.Documentation;
+using CrestApps.OrchardCore.AI.ViewModels;
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Mvc.ModelBinding;
+
+namespace CrestApps.OrchardCore.AI.Tools.Drivers;
+
+/// <summary>
+/// Display driver that captures the settings for the built-in prebuilt search index documentation search
+/// tool instance source, such as the base URL and the optional explicit index URL.
+/// </summary>
+internal sealed class SearchIndexDocumentationToolInstanceDisplayDriver : DisplayDriver<AIToolInstance>
+{
+    internal readonly IStringLocalizer S;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SearchIndexDocumentationToolInstanceDisplayDriver"/> class.
+    /// </summary>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public SearchIndexDocumentationToolInstanceDisplayDriver(IStringLocalizer<SearchIndexDocumentationToolInstanceDisplayDriver> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    public override IDisplayResult Edit(AIToolInstance instance, BuildEditorContext context)
+    {
+        if (!IsSource(instance))
+        {
+            return null;
+        }
+
+        return Initialize<SearchIndexDocumentationToolInstanceViewModel>("SearchIndexDocumentationToolInstance_Edit", model =>
+        {
+            var settings = instance.GetOrCreate<SearchIndexDocumentationToolSettings>();
+
+            model.BaseUrl = settings.BaseUrl;
+            model.IndexUrl = settings.IndexUrl;
+            model.MaxResults = settings.MaxResults;
+        }).Location("Content:5");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(AIToolInstance instance, UpdateEditorContext context)
+    {
+        if (!IsSource(instance))
+        {
+            return null;
+        }
+
+        var model = new SearchIndexDocumentationToolInstanceViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (string.IsNullOrWhiteSpace(model.BaseUrl))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.BaseUrl), S["The base URL is required."]);
+        }
+        else if (!Uri.TryCreate(model.BaseUrl.Trim(), UriKind.Absolute, out var baseUrl) ||
+            (baseUrl.Scheme != Uri.UriSchemeHttp && baseUrl.Scheme != Uri.UriSchemeHttps))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.BaseUrl), S["The base URL must be an absolute HTTP or HTTPS URL."]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(model.IndexUrl) &&
+            (!Uri.TryCreate(model.IndexUrl.Trim(), UriKind.Absolute, out var indexUrl) ||
+            (indexUrl.Scheme != Uri.UriSchemeHttp && indexUrl.Scheme != Uri.UriSchemeHttps)))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.IndexUrl), S["The index URL must be an absolute HTTP or HTTPS URL."]);
+        }
+
+        if (model.MaxResults.HasValue && model.MaxResults.Value <= 0)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.MaxResults), S["The maximum results must be greater than zero."]);
+        }
+
+        instance.Put(new SearchIndexDocumentationToolSettings
+        {
+            BaseUrl = model.BaseUrl?.Trim(),
+            IndexUrl = string.IsNullOrWhiteSpace(model.IndexUrl) ? null : model.IndexUrl.Trim(),
+            MaxResults = model.MaxResults,
+        });
+
+        return Edit(instance, context);
+    }
+
+    private static bool IsSource(AIToolInstance instance)
+        => string.Equals(instance.Source, DocumentationToolConstants.SearchIndexSourceName, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/SitemapDocumentationToolInstanceDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Tools/Drivers/SitemapDocumentationToolInstanceDisplayDriver.cs
@@ -1,0 +1,98 @@
+using CrestApps.Core;
+using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.AI.Tooling.Instances.Documentation;
+using CrestApps.OrchardCore.AI.ViewModels;
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Mvc.ModelBinding;
+
+namespace CrestApps.OrchardCore.AI.Tools.Drivers;
+
+/// <summary>
+/// Display driver that captures the settings for the built-in sitemap crawling documentation search tool
+/// instance source, such as the base URL of the documentation site and the crawl limits.
+/// </summary>
+internal sealed class SitemapDocumentationToolInstanceDisplayDriver : DisplayDriver<AIToolInstance>
+{
+    internal readonly IStringLocalizer S;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SitemapDocumentationToolInstanceDisplayDriver"/> class.
+    /// </summary>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public SitemapDocumentationToolInstanceDisplayDriver(IStringLocalizer<SitemapDocumentationToolInstanceDisplayDriver> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    public override IDisplayResult Edit(AIToolInstance instance, BuildEditorContext context)
+    {
+        if (!IsSource(instance))
+        {
+            return null;
+        }
+
+        return Initialize<SitemapDocumentationToolInstanceViewModel>("SitemapDocumentationToolInstance_Edit", model =>
+        {
+            var settings = instance.GetOrCreate<SitemapDocumentationToolSettings>();
+
+            model.BaseUrl = settings.BaseUrl;
+            model.SitemapUrl = settings.SitemapUrl;
+            model.MaxResults = settings.MaxResults;
+            model.MaxPages = settings.MaxPages;
+        }).Location("Content:5");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(AIToolInstance instance, UpdateEditorContext context)
+    {
+        if (!IsSource(instance))
+        {
+            return null;
+        }
+
+        var model = new SitemapDocumentationToolInstanceViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (string.IsNullOrWhiteSpace(model.BaseUrl))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.BaseUrl), S["The base URL is required."]);
+        }
+        else if (!Uri.TryCreate(model.BaseUrl.Trim(), UriKind.Absolute, out var baseUrl) ||
+            (baseUrl.Scheme != Uri.UriSchemeHttp && baseUrl.Scheme != Uri.UriSchemeHttps))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.BaseUrl), S["The base URL must be an absolute HTTP or HTTPS URL."]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(model.SitemapUrl) &&
+            (!Uri.TryCreate(model.SitemapUrl.Trim(), UriKind.Absolute, out var sitemapUrl) ||
+            (sitemapUrl.Scheme != Uri.UriSchemeHttp && sitemapUrl.Scheme != Uri.UriSchemeHttps)))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.SitemapUrl), S["The sitemap URL must be an absolute HTTP or HTTPS URL."]);
+        }
+
+        if (model.MaxResults.HasValue && model.MaxResults.Value <= 0)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.MaxResults), S["The maximum results must be greater than zero."]);
+        }
+
+        if (model.MaxPages.HasValue && model.MaxPages.Value <= 0)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.MaxPages), S["The maximum pages must be greater than zero."]);
+        }
+
+        instance.Put(new SitemapDocumentationToolSettings
+        {
+            BaseUrl = model.BaseUrl?.Trim(),
+            SitemapUrl = string.IsNullOrWhiteSpace(model.SitemapUrl) ? null : model.SitemapUrl.Trim(),
+            MaxResults = model.MaxResults,
+            MaxPages = model.MaxPages,
+        });
+
+        return Edit(instance, context);
+    }
+
+    private static bool IsSource(AIToolInstance instance)
+        => string.Equals(instance.Source, DocumentationToolConstants.SitemapSourceName, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/AlgoliaDocumentationToolInstanceViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/AlgoliaDocumentationToolInstanceViewModel.cs
@@ -1,0 +1,27 @@
+namespace CrestApps.OrchardCore.AI.ViewModels;
+
+/// <summary>
+/// Represents the source specific fields captured for an Algolia DocSearch documentation search tool instance.
+/// </summary>
+public class AlgoliaDocumentationToolInstanceViewModel
+{
+    /// <summary>
+    /// Gets or sets the Algolia application identifier.
+    /// </summary>
+    public string ApplicationId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Algolia search-only API key.
+    /// </summary>
+    public string ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Algolia index name to query.
+    /// </summary>
+    public string IndexName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of results returned for a single search.
+    /// </summary>
+    public int? MaxResults { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/AlgoliaDocumentationToolInstanceViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/AlgoliaDocumentationToolInstanceViewModel.cs
@@ -16,6 +16,11 @@ public class AlgoliaDocumentationToolInstanceViewModel
     public string ApiKey { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether an API key is already stored for the instance.
+    /// </summary>
+    public bool HasApiKey { get; set; }
+
+    /// <summary>
     /// Gets or sets the Algolia index name to query.
     /// </summary>
     public string IndexName { get; set; }

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/SearchIndexDocumentationToolInstanceViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/SearchIndexDocumentationToolInstanceViewModel.cs
@@ -1,0 +1,22 @@
+namespace CrestApps.OrchardCore.AI.ViewModels;
+
+/// <summary>
+/// Represents the source specific fields captured for a prebuilt search index documentation search tool instance.
+/// </summary>
+public class SearchIndexDocumentationToolInstanceViewModel
+{
+    /// <summary>
+    /// Gets or sets the base URL of the documentation site.
+    /// </summary>
+    public string BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the explicit search index URL. When empty, it is derived from the base URL.
+    /// </summary>
+    public string IndexUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of results returned for a single search.
+    /// </summary>
+    public int? MaxResults { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/ViewModels/SitemapDocumentationToolInstanceViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/ViewModels/SitemapDocumentationToolInstanceViewModel.cs
@@ -1,0 +1,27 @@
+namespace CrestApps.OrchardCore.AI.ViewModels;
+
+/// <summary>
+/// Represents the source specific fields captured for a sitemap crawling documentation search tool instance.
+/// </summary>
+public class SitemapDocumentationToolInstanceViewModel
+{
+    /// <summary>
+    /// Gets or sets the base URL of the documentation site.
+    /// </summary>
+    public string BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the explicit sitemap URL. When empty, it is derived from the base URL.
+    /// </summary>
+    public string SitemapUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of results returned for a single search.
+    /// </summary>
+    public int? MaxResults { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of pages the crawler indexes.
+    /// </summary>
+    public int? MaxPages { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/AlgoliaDocumentationToolInstance.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/AlgoliaDocumentationToolInstance.Edit.cshtml
@@ -14,9 +14,18 @@
 <div class="ocat-wrapper">
     <label asp-for="ApiKey" class="ocat-label">@T["Search-only API key"]</label>
     <div class="ocat-end">
-        <input asp-for="ApiKey" class="form-control" autocomplete="off" />
+        <input asp-for="ApiKey" type="password" class="form-control" autocomplete="new-password" />
         <span asp-validation-for="ApiKey" class="text-danger"></span>
-        <span class="hint">@T["The public search-only API key. Do not use an admin API key."]</span>
+        <span class="hint">
+            @if (Model.HasApiKey)
+            {
+                @T["An API key is securely stored. Enter a new value to replace it, or leave it blank to keep the current one."]
+            }
+            else
+            {
+                @T["The public search-only API key. Do not use an admin API key."]
+            }
+        </span>
     </div>
 </div>
 

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/AlgoliaDocumentationToolInstance.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/AlgoliaDocumentationToolInstance.Edit.cshtml
@@ -1,0 +1,39 @@
+@using CrestApps.OrchardCore.AI.ViewModels
+
+@model AlgoliaDocumentationToolInstanceViewModel
+
+<div class="ocat-wrapper">
+    <label asp-for="ApplicationId" class="ocat-label">@T["Application id"]</label>
+    <div class="ocat-end">
+        <input asp-for="ApplicationId" class="form-control" autocomplete="off" />
+        <span asp-validation-for="ApplicationId" class="text-danger"></span>
+        <span class="hint">@T["The Algolia application id that hosts the DocSearch index."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="ApiKey" class="ocat-label">@T["Search-only API key"]</label>
+    <div class="ocat-end">
+        <input asp-for="ApiKey" class="form-control" autocomplete="off" />
+        <span asp-validation-for="ApiKey" class="text-danger"></span>
+        <span class="hint">@T["The public search-only API key. Do not use an admin API key."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="IndexName" class="ocat-label">@T["Index name"]</label>
+    <div class="ocat-end">
+        <input asp-for="IndexName" class="form-control" autocomplete="off" />
+        <span asp-validation-for="IndexName" class="text-danger"></span>
+        <span class="hint">@T["The Algolia index queried for documentation results."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="MaxResults" class="ocat-label">@T["Maximum results"]</label>
+    <div class="ocat-end">
+        <input asp-for="MaxResults" type="number" min="1" class="form-control" />
+        <span asp-validation-for="MaxResults" class="text-danger"></span>
+        <span class="hint">@T["The maximum number of passages returned for a single search. Leave it empty to use the default."]</span>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/SearchIndexDocumentationToolInstance.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/SearchIndexDocumentationToolInstance.Edit.cshtml
@@ -1,0 +1,30 @@
+@using CrestApps.OrchardCore.AI.ViewModels
+
+@model SearchIndexDocumentationToolInstanceViewModel
+
+<div class="ocat-wrapper">
+    <label asp-for="BaseUrl" class="ocat-label">@T["Base URL"]</label>
+    <div class="ocat-end">
+        <input asp-for="BaseUrl" class="form-control" placeholder="https://docs.orchardcore.net" />
+        <span asp-validation-for="BaseUrl" class="text-danger"></span>
+        <span class="hint">@T["The root URL of the documentation site. It is used to resolve the returned passages into absolute links."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="IndexUrl" class="ocat-label">@T["Index URL"]</label>
+    <div class="ocat-end">
+        <input asp-for="IndexUrl" class="form-control" placeholder="https://docs.orchardcore.net/en/latest/search/search_index.json" />
+        <span asp-validation-for="IndexUrl" class="text-danger"></span>
+        <span class="hint">@T["An explicit prebuilt search index URL. Leave it empty to derive it from the base URL."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="MaxResults" class="ocat-label">@T["Maximum results"]</label>
+    <div class="ocat-end">
+        <input asp-for="MaxResults" type="number" min="1" class="form-control" />
+        <span asp-validation-for="MaxResults" class="text-danger"></span>
+        <span class="hint">@T["The maximum number of passages returned for a single search. Leave it empty to use the default."]</span>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/SitemapDocumentationToolInstance.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/SitemapDocumentationToolInstance.Edit.cshtml
@@ -1,0 +1,39 @@
+@using CrestApps.OrchardCore.AI.ViewModels
+
+@model SitemapDocumentationToolInstanceViewModel
+
+<div class="ocat-wrapper">
+    <label asp-for="BaseUrl" class="ocat-label">@T["Base URL"]</label>
+    <div class="ocat-end">
+        <input asp-for="BaseUrl" class="form-control" placeholder="https://core.crestapps.com" />
+        <span asp-validation-for="BaseUrl" class="text-danger"></span>
+        <span class="hint">@T["The root URL of the documentation site. The crawler discovers pages through the site's sitemap.xml."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="SitemapUrl" class="ocat-label">@T["Sitemap URL"]</label>
+    <div class="ocat-end">
+        <input asp-for="SitemapUrl" class="form-control" placeholder="https://core.crestapps.com/sitemap.xml" />
+        <span asp-validation-for="SitemapUrl" class="text-danger"></span>
+        <span class="hint">@T["An explicit sitemap URL. Leave it empty to derive it from the base URL as {BaseUrl}/sitemap.xml."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="MaxResults" class="ocat-label">@T["Maximum results"]</label>
+    <div class="ocat-end">
+        <input asp-for="MaxResults" type="number" min="1" class="form-control" />
+        <span asp-validation-for="MaxResults" class="text-danger"></span>
+        <span class="hint">@T["The maximum number of passages returned for a single search. Leave it empty to use the default."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="MaxPages" class="ocat-label">@T["Maximum pages"]</label>
+    <div class="ocat-end">
+        <input asp-for="MaxPages" type="number" min="1" class="form-control" />
+        <span asp-validation-for="MaxPages" class="text-danger"></span>
+        <span class="hint">@T["The maximum number of pages the crawler indexes for this site. Leave it empty to use the default."]</span>
+    </div>
+</div>

--- a/tests/CrestApps.OrchardCore.Tests/Mcp/McpServerOptionsConfigurationTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Mcp/McpServerOptionsConfigurationTests.cs
@@ -1,5 +1,7 @@
 using CrestApps.Core.AI.Mcp.Models;
+using CrestApps.OrchardCore.AI.Mcp.Models;
 using CrestApps.OrchardCore.AI.Mcp.Services;
+using CrestApps.OrchardCore.Tests.Telephony.Doubles;
 using Microsoft.Extensions.Configuration;
 using OrchardCore.Environment.Shell.Configuration;
 
@@ -10,30 +12,55 @@ public sealed class McpServerOptionsConfigurationTests
     [Fact]
     public void Configure_DefaultsAuthenticationTypeToOpenId_WhenNotConfigured()
     {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection([])
-            .Build();
-        var options = new McpServerOptions();
-
-        new McpServerOptionsConfiguration(
-            new MockShellConfiguration(configuration)).Configure(options);
+        var options = Configure(new McpServerSettings(), []);
 
         Assert.Equal(McpServerAuthenticationType.OpenId, options.AuthenticationType);
     }
 
     [Fact]
+    public void Configure_DoesNotExposeAnyToolsByDefault()
+    {
+        var options = Configure(new McpServerSettings(), []);
+
+        Assert.False(options.ExposeAllTools);
+        Assert.Empty(options.Tools);
+    }
+
+    [Fact]
+    public void Configure_AppliesTheStoredToolAllowList()
+    {
+        var settings = new McpServerSettings
+        {
+            ExposeAllTools = false,
+            Tools = ["crestapps-docs", "weather"],
+        };
+
+        var options = Configure(settings, []);
+
+        Assert.False(options.ExposeAllTools);
+        Assert.Equal(["crestapps-docs", "weather"], options.Tools);
+    }
+
+    [Fact]
+    public void Configure_AppliesExposeAllToolsFromSettings()
+    {
+        var settings = new McpServerSettings
+        {
+            ExposeAllTools = true,
+        };
+
+        var options = Configure(settings, []);
+
+        Assert.True(options.ExposeAllTools);
+    }
+
+    [Fact]
     public void Configure_PreservesExplicitAnonymousConfiguration_FromNewPath()
     {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
-            {
-                ["CrestApps:AI:McpServer:AuthenticationType"] = "None",
-            })
-            .Build();
-        var options = new McpServerOptions();
-
-        new McpServerOptionsConfiguration(
-            new MockShellConfiguration(configuration)).Configure(options);
+        var options = Configure(new McpServerSettings(), new Dictionary<string, string>
+        {
+            ["CrestApps:AI:McpServer:AuthenticationType"] = "None",
+        });
 
         Assert.Equal(McpServerAuthenticationType.None, options.AuthenticationType);
     }
@@ -41,18 +68,43 @@ public sealed class McpServerOptionsConfigurationTests
     [Fact]
     public void Configure_PreservesExplicitAnonymousConfiguration_FromDeprecatedPath()
     {
+        var options = Configure(new McpServerSettings(), new Dictionary<string, string>
+        {
+            ["CrestApps:McpServer:AuthenticationType"] = "None",
+        });
+
+        Assert.Equal(McpServerAuthenticationType.None, options.AuthenticationType);
+    }
+
+    [Fact]
+    public void Configure_ShellConfigurationOverridesStoredSettings()
+    {
+        var settings = new McpServerSettings
+        {
+            AuthenticationType = McpServerAuthenticationType.OpenId,
+        };
+
+        var options = Configure(settings, new Dictionary<string, string>
+        {
+            ["CrestApps:AI:McpServer:AuthenticationType"] = "ApiKey",
+        });
+
+        Assert.Equal(McpServerAuthenticationType.ApiKey, options.AuthenticationType);
+    }
+
+    private static McpServerOptions Configure(McpServerSettings settings, Dictionary<string, string> configurationValues)
+    {
         var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
-            {
-                ["CrestApps:McpServer:AuthenticationType"] = "None",
-            })
+            .AddInMemoryCollection(configurationValues)
             .Build();
+
         var options = new McpServerOptions();
 
         new McpServerOptionsConfiguration(
+            SiteServiceFactory.Create(settings),
             new MockShellConfiguration(configuration)).Configure(options);
 
-        Assert.Equal(McpServerAuthenticationType.None, options.AuthenticationType);
+        return options;
     }
 
     private sealed class MockShellConfiguration : IShellConfiguration

--- a/tests/CrestApps.OrchardCore.Tests/Mcp/McpServerSettingsTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Mcp/McpServerSettingsTests.cs
@@ -1,0 +1,26 @@
+using CrestApps.Core.AI.Mcp.Models;
+using CrestApps.OrchardCore.AI.Mcp.Models;
+
+namespace CrestApps.OrchardCore.Tests.Mcp;
+
+public sealed class McpServerSettingsTests
+{
+    [Fact]
+    public void Defaults_DoNotExposeAnyTools()
+    {
+        var settings = new McpServerSettings();
+
+        Assert.False(settings.ExposeAllTools);
+        Assert.NotNull(settings.Tools);
+        Assert.Empty(settings.Tools);
+    }
+
+    [Fact]
+    public void Defaults_UseOpenIdWithRequiredAccessPermission()
+    {
+        var settings = new McpServerSettings();
+
+        Assert.Equal(McpServerAuthenticationType.OpenId, settings.AuthenticationType);
+        Assert.True(settings.RequireAccessPermission);
+    }
+}


### PR DESCRIPTION
Bump CrestApps.Core.* to 1.1.0-preview.212, which reworks the MCP server primitive so tools are exposed on an opt-in basis instead of exposing every registered tool by default.

- Add McpServerSettings site settings aligned with McpServerOptions and load them into the options through McpServerOptionsConfiguration (shell configuration still overrides for deployment scenarios).
- Add an MCP Server card on the Settings -> Artificial Intelligence page that configures authentication and selects the tools and tool instances exposed to MCP clients, reusing the AI Profile tool/instance selectors, gated by a new ManageMcpServerSettings permission.
- Register the CrestApps.Core documentation search sources (sitemap, search index, Algolia) on the AI Tool Instances feature with source-specific editors so operators can declare documentation sites as tool instances.
- Document the opt-in model and a usage case wiring the CrestApps and Orchard Core documentation sites, and update the tool instances and changelog docs.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
