### PR TITLE
Add color-coding support for report cells and Excel export

### DIFF
--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportColor.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportColor.cs
@@ -1,0 +1,126 @@
+namespace CrestApps.OrchardCore.Reports.Models;
+
+/// <summary>
+/// Provides helpers that normalize the colors used by report styles so the HTML renderer and the export
+/// formats interpret user-supplied color values consistently.
+/// </summary>
+public static class ReportColor
+{
+    /// <summary>
+    /// Attempts to normalize a color into the eight-character <c>AARRGGBB</c> hexadecimal form used by the
+    /// Open XML Excel export. Only hexadecimal colors (with or without a leading <c>#</c>) are supported.
+    /// </summary>
+    /// <param name="color">The color value to normalize.</param>
+    /// <param name="argb">The normalized <c>AARRGGBB</c> value when the color is a valid hexadecimal color.</param>
+    /// <returns><see langword="true"/> when the color was normalized; otherwise <see langword="false"/>.</returns>
+    public static bool TryGetArgb(string color, out string argb)
+    {
+        argb = null;
+
+        var hex = GetHex(color);
+
+        if (hex is null)
+        {
+            return false;
+        }
+
+        argb = hex.Length switch
+        {
+            3 => "FF" + Expand(hex),
+            6 => "FF" + hex.ToUpperInvariant(),
+            8 => hex.ToUpperInvariant(),
+            _ => null,
+        };
+
+        return argb is not null;
+    }
+
+    /// <summary>
+    /// Normalizes a color into a value that is safe to emit inside an inline CSS declaration. Hexadecimal
+    /// colors are returned with a leading <c>#</c>, and simple named colors are passed through.
+    /// </summary>
+    /// <param name="color">The color value to normalize.</param>
+    /// <returns>The CSS color, or <see langword="null"/> when the value cannot be safely represented.</returns>
+    public static string ToCssColor(string color)
+    {
+        if (string.IsNullOrWhiteSpace(color))
+        {
+            return null;
+        }
+
+        var value = color.Trim();
+        var hex = GetHex(value);
+
+        if (hex is not null)
+        {
+            return hex.Length switch
+            {
+                3 or 6 => "#" + hex.ToUpperInvariant(),
+                8 => "#" + hex.Substring(2).ToUpperInvariant(),
+                _ => null,
+            };
+        }
+
+        return IsNamedColor(value) ? value.ToLowerInvariant() : null;
+    }
+
+    private static string GetHex(string color)
+    {
+        if (string.IsNullOrWhiteSpace(color))
+        {
+            return null;
+        }
+
+        var value = color.Trim();
+
+        if (value.StartsWith('#'))
+        {
+            value = value.Substring(1);
+        }
+
+        if (value.Length is not (3 or 6 or 8) || !IsHex(value))
+        {
+            return null;
+        }
+
+        return value;
+    }
+
+    private static bool IsHex(string value)
+    {
+        foreach (var character in value)
+        {
+            var isHex = character is (>= '0' and <= '9') or (>= 'a' and <= 'f') or (>= 'A' and <= 'F');
+
+            if (!isHex)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsNamedColor(string value)
+    {
+        foreach (var character in value)
+        {
+            var isLetter = character is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z');
+
+            if (!isLetter)
+            {
+                return false;
+            }
+        }
+
+        return value.Length is > 0 and <= 30;
+    }
+
+    private static string Expand(string hex)
+    {
+        return string.Concat(
+            hex[0], hex[0],
+            hex[1], hex[1],
+            hex[2], hex[2]).ToUpperInvariant();
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportColumn.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportColumn.cs
@@ -17,10 +17,12 @@ public sealed class ReportColumn
     /// </summary>
     /// <param name="label">The column header label.</param>
     /// <param name="align">The column alignment.</param>
-    public ReportColumn(string label, ReportColumnAlign align = ReportColumnAlign.Start)
+    /// <param name="headerStyle">The optional style applied to the column header cell.</param>
+    public ReportColumn(string label, ReportColumnAlign align = ReportColumnAlign.Start, ReportStyle headerStyle = null)
     {
         Label = label;
         Align = align;
+        HeaderStyle = headerStyle;
     }
 
     /// <summary>
@@ -32,4 +34,10 @@ public sealed class ReportColumn
     /// Gets or sets the column alignment.
     /// </summary>
     public ReportColumnAlign Align { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional style applied to the column header cell, allowing headers to be
+    /// color-coded. Ignored by export formats that do not support styling.
+    /// </summary>
+    public ReportStyle HeaderStyle { get; set; }
 }

--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportRow.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportRow.cs
@@ -48,6 +48,20 @@ public sealed class ReportRow
     public ReportRowKind Kind { get; set; }
 
     /// <summary>
+    /// Gets or sets the optional style applied to every cell in the row (for example to color-code a
+    /// subtotal or grand-total row). A per-cell style set through <see cref="CellStyles"/> takes
+    /// precedence. Ignored by export formats that do not support styling.
+    /// </summary>
+    public ReportStyle Style { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional per-cell styles, aligned by index with <see cref="Cells"/>. An entry may
+    /// be <see langword="null"/> to fall back to the row-level <see cref="Style"/>. Ignored by export
+    /// formats that do not support styling.
+    /// </summary>
+    public IList<ReportStyle> CellStyles { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets a value indicating whether the row should be visually emphasized.
     /// </summary>
     public bool Emphasize
@@ -62,5 +76,57 @@ public sealed class ReportRow
                 ? ReportRowKind.GrandTotal
                 : ReportRowKind.Detail;
         }
+    }
+
+    /// <summary>
+    /// Resolves the effective style for the cell at the supplied index, preferring a per-cell style over
+    /// the row-level <see cref="Style"/>.
+    /// </summary>
+    /// <param name="index">The zero-based cell index.</param>
+    /// <returns>The effective style, or <see langword="null"/> when the cell has no style.</returns>
+    public ReportStyle GetCellStyle(int index)
+    {
+        if (CellStyles is not null && index >= 0 && index < CellStyles.Count && CellStyles[index] is not null)
+        {
+            return CellStyles[index];
+        }
+
+        return Style;
+    }
+
+    /// <summary>
+    /// Sets the row-level style applied to every cell that has no per-cell override, and returns the same
+    /// row for chaining.
+    /// </summary>
+    /// <param name="style">The style to apply to the row.</param>
+    /// <returns>The current row.</returns>
+    public ReportRow WithStyle(ReportStyle style)
+    {
+        Style = style;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the style for a single cell, aligned by index with <see cref="Cells"/>, and returns the same
+    /// row for chaining.
+    /// </summary>
+    /// <param name="index">The zero-based cell index.</param>
+    /// <param name="style">The style to apply to the cell.</param>
+    /// <returns>The current row.</returns>
+    public ReportRow WithCellStyle(int index, ReportStyle style)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+
+        CellStyles ??= [];
+
+        while (CellStyles.Count <= index)
+        {
+            CellStyles.Add(null);
+        }
+
+        CellStyles[index] = style;
+
+        return this;
     }
 }

--- a/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportStyle.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/Models/ReportStyle.cs
@@ -1,0 +1,89 @@
+using System.Text;
+
+namespace CrestApps.OrchardCore.Reports.Models;
+
+/// <summary>
+/// Represents the optional visual styling applied to a report table header or cell. Styling lets a report
+/// color-code individual cells, headers, subtotal rows, and grand-total rows. It is honored by the HTML
+/// renderer and, where the export format supports it, by exporters such as the Open XML Excel workbook
+/// exporter. Formats that cannot represent styling (for example CSV) ignore it.
+/// </summary>
+public sealed class ReportStyle
+{
+    /// <summary>
+    /// Gets or sets the font (text) color. Use a hexadecimal color (for example <c>#2563EB</c>) so the
+    /// value can also be applied by the Excel exporter; simple named colors are honored by the HTML
+    /// renderer only.
+    /// </summary>
+    public string Color { get; set; }
+
+    /// <summary>
+    /// Gets or sets the background (fill) color. Use a hexadecimal color (for example <c>#EFF6FF</c>) so
+    /// the value can also be applied by the Excel exporter; simple named colors are honored by the HTML
+    /// renderer only.
+    /// </summary>
+    public string BackgroundColor { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the text is rendered in a bold (heavier) font weight.
+    /// </summary>
+    public bool Bold { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the style has no effect (no color, no background, and not bold).
+    /// </summary>
+    public bool IsEmpty
+    {
+        get
+        {
+            return string.IsNullOrWhiteSpace(Color) && string.IsNullOrWhiteSpace(BackgroundColor) && !Bold;
+        }
+    }
+
+    /// <summary>
+    /// Creates a report style from the supplied color, background color, and weight.
+    /// </summary>
+    /// <param name="color">The font color, preferably a hexadecimal color.</param>
+    /// <param name="backgroundColor">The background color, preferably a hexadecimal color.</param>
+    /// <param name="bold">Whether the text is bold.</param>
+    /// <returns>The created report style.</returns>
+    public static ReportStyle Create(string color = null, string backgroundColor = null, bool bold = false)
+    {
+        return new ReportStyle
+        {
+            Color = color,
+            BackgroundColor = backgroundColor,
+            Bold = bold,
+        };
+    }
+
+    /// <summary>
+    /// Builds an inline CSS declaration for the style, using only safely normalized color values. Returns
+    /// an empty string when the style has no visual effect.
+    /// </summary>
+    /// <returns>The inline CSS declaration.</returns>
+    public string ToInlineCss()
+    {
+        var builder = new StringBuilder();
+        var color = ReportColor.ToCssColor(Color);
+
+        if (color is not null)
+        {
+            builder.Append("color:").Append(color).Append(';');
+        }
+
+        var background = ReportColor.ToCssColor(BackgroundColor);
+
+        if (background is not null)
+        {
+            builder.Append("background-color:").Append(background).Append(';');
+        }
+
+        if (Bold)
+        {
+            builder.Append("font-weight:600;");
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -42,6 +42,16 @@ This page highlights the changes in the `3.0.0` line.
 
 ## Change Logs
 
+### Reports
+
+#### Color-coded report cells and styled Excel export
+
+Reports can now color-code their tables. A new `ReportStyle` (font color, background color, and bold) can be applied to column headers through `ReportColumn.HeaderStyle`, to an entire row through `ReportRow.WithStyle(...)`, and to an individual cell through `ReportRow.WithCellStyle(index, ...)`. A per-cell style takes precedence over the row style. Colors are supplied as hexadecimal values (for example `#2563EB`) so the same style renders in the browser and exports to Excel; the HTML renderer additionally honors simple named colors.
+
+When the **Reports (OpenXml)** add-on is enabled, the Excel (`.xlsx`) export now writes these styles into the workbook (font color, cell background fill, and bold weight). Header, subtotal, and grand-total rows are exported bold automatically. CSV, which has no native styling, continues to export values only.
+
+See [Reports](../modules/reports) for details.
+
 ### Omnichannel Management
 
 #### Contacts menu in the Interaction Center

--- a/src/CrestApps.Docs/docs/modules/reports.md
+++ b/src/CrestApps.Docs/docs/modules/reports.md
@@ -104,6 +104,35 @@ services.AddScoped<IReport, MyReport>();
 
 `RunAsync` builds a `ReportDocument` from the resolved period (`context.Filter.GetDateRange()`) and any report-specific filter values. Use `ReportSection.ForMetrics`, `ReportSection.ForTable`, `ReportSection.ForBars`, and `ReportSection.ForChart` to compose the document, and `ReportFormat` to format numbers, durations, and percentages consistently. Charts accept ordered labels plus one or more numeric datasets; `Width` places sections on the shared responsive twelve-column layout.
 
+## Color-coding table cells
+
+Report table sections can color-code their headers and cells with `ReportStyle`, which carries a font **color**, a **background color**, and a **bold** flag. Apply it in three places:
+
+- **Header cells** — pass a `HeaderStyle` to `ReportColumn`.
+- **Whole rows** — call `ReportRow.WithStyle(...)`, useful for subtotal and grand-total rows.
+- **Individual cells** — call `ReportRow.WithCellStyle(index, ...)`, which overrides the row style for that one cell.
+
+Supply colors as hexadecimal values (for example `#2563EB`) so the same style renders in the browser **and** exports to Excel. The HTML renderer also accepts simple named colors, but only hexadecimal colors are carried into the Excel workbook.
+
+```csharp
+var columns = new[]
+{
+    new ReportColumn(S["Queue"].Value, ReportColumnAlign.Start, ReportStyle.Create("#FFFFFF", "#2563EB", bold: true)),
+    new ReportColumn(S["Completed"].Value, ReportColumnAlign.End),
+};
+
+var rows = new List<ReportRow>
+{
+    new ReportRow(["Support", "18"]).WithCellStyle(1, ReportStyle.Create("#B91C1C")),
+    new ReportRow(["All queues", "18"], ReportRowKind.GrandTotal).WithStyle(ReportStyle.Create(backgroundColor: "#EFF6FF")),
+};
+
+return new ReportDocument()
+    .Add(ReportSection.ForTable(S["Queues"].Value, columns, rows));
+```
+
+When the **Reports (OpenXml)** add-on is enabled, the Excel (`.xlsx`) export applies the font color, background fill, and bold weight to the matching cells. Header rows, subtotal rows, and grand-total rows are exported bold automatically. CSV has no native styling, so it always exports values only.
+
 ## Enable via recipe
 
 ```json

--- a/src/Modules/CrestApps.OrchardCore.Reports.OpenXml/Services/ExcelReportExportFormat.cs
+++ b/src/Modules/CrestApps.OrchardCore.Reports.OpenXml/Services/ExcelReportExportFormat.cs
@@ -54,6 +54,7 @@ public sealed class ExcelReportExportFormat : IReportExportFormat
 
             var sheets = workbookPart.Workbook.AppendChild(new Sheets());
             var usedSheetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var styleRegistry = new ExcelStyleRegistry();
             uint sheetId = 1;
 
             if (document.Sections.Count == 0)
@@ -78,10 +79,14 @@ public sealed class ExcelReportExportFormat : IReportExportFormat
                         sheetId,
                         i + 1);
 
-                    WriteSection(sheetData, section);
+                    WriteSection(sheetData, section, styleRegistry);
                     sheetId++;
                 }
             }
+
+            var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+            stylesPart.Stylesheet = styleRegistry.Build();
+            stylesPart.Stylesheet.Save();
 
             workbookPart.Workbook.Save();
         }
@@ -158,7 +163,7 @@ public sealed class ExcelReportExportFormat : IReportExportFormat
         return sanitized;
     }
 
-    private static void WriteSection(SheetData sheetData, ReportSection section)
+    private static void WriteSection(SheetData sheetData, ReportSection section, ExcelStyleRegistry styleRegistry)
     {
         if (!string.IsNullOrWhiteSpace(section.Description))
         {
@@ -172,7 +177,7 @@ public sealed class ExcelReportExportFormat : IReportExportFormat
                 WriteMetricsSection(sheetData, section);
                 break;
             case ReportSectionKind.Table:
-                WriteTableSection(sheetData, section);
+                WriteTableSection(sheetData, section, styleRegistry);
                 break;
             case ReportSectionKind.Bars:
                 WriteBarsSection(sheetData, section);
@@ -195,17 +200,72 @@ public sealed class ExcelReportExportFormat : IReportExportFormat
         }
     }
 
-    private static void WriteTableSection(SheetData sheetData, ReportSection section)
+    private static void WriteTableSection(SheetData sheetData, ReportSection section, ExcelStyleRegistry styleRegistry)
     {
         if (section.Columns.Count > 0)
         {
-            AppendTextRow(sheetData, [.. section.Columns.Select(column => column.Label)]);
+            var headerRow = new Row();
+
+            foreach (var column in section.Columns)
+            {
+                var headerStyle = EnsureBold(column.HeaderStyle);
+
+                headerRow.Append(CreateCell(column.Label, styleRegistry.GetCellFormatIndex(headerStyle)));
+            }
+
+            sheetData.Append(headerRow);
         }
 
         foreach (var row in section.Rows)
         {
-            AppendTextRow(sheetData, [.. row.Cells]);
+            var dataRow = new Row();
+            var emphasize = row.Kind != ReportRowKind.Detail;
+
+            for (var i = 0; i < row.Cells.Count; i++)
+            {
+                var cellStyle = row.GetCellStyle(i);
+
+                if (emphasize)
+                {
+                    cellStyle = EnsureBold(cellStyle);
+                }
+
+                dataRow.Append(CreateCell(row.Cells[i], styleRegistry.GetCellFormatIndex(cellStyle)));
+            }
+
+            sheetData.Append(dataRow);
         }
+    }
+
+    private static ReportStyle EnsureBold(ReportStyle style)
+    {
+        if (style is null)
+        {
+            return ReportStyle.Create(bold: true);
+        }
+
+        if (style.Bold)
+        {
+            return style;
+        }
+
+        return ReportStyle.Create(style.Color, style.BackgroundColor, bold: true);
+    }
+
+    private static Cell CreateCell(string value, uint styleIndex)
+    {
+        var cell = new Cell
+        {
+            DataType = CellValues.InlineString,
+            InlineString = new InlineString(new Text(value ?? string.Empty)),
+        };
+
+        if (styleIndex != 0)
+        {
+            cell.StyleIndex = styleIndex;
+        }
+
+        return cell;
     }
 
     private static void WriteBarsSection(SheetData sheetData, ReportSection section)

--- a/src/Modules/CrestApps.OrchardCore.Reports.OpenXml/Services/ExcelStyleRegistry.cs
+++ b/src/Modules/CrestApps.OrchardCore.Reports.OpenXml/Services/ExcelStyleRegistry.cs
@@ -1,0 +1,152 @@
+using CrestApps.OrchardCore.Reports.Models;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace CrestApps.OrchardCore.Reports.OpenXml.Services;
+
+/// <summary>
+/// Collects the distinct fonts, fills, and cell formats required by a report and produces the Open XML
+/// <see cref="Stylesheet"/> that backs them. Each <see cref="ReportStyle"/> is deduplicated and mapped to
+/// a cell-format index that is assigned to the relevant worksheet cells.
+/// </summary>
+internal sealed class ExcelStyleRegistry
+{
+    private const string DefaultFontName = "Calibri";
+    private const double DefaultFontSize = 11d;
+
+    private readonly List<Font> _fonts = [];
+    private readonly List<Fill> _fills = [];
+    private readonly List<CellFormat> _cellFormats = [];
+    private readonly Dictionary<string, uint> _fontIndexByKey = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, uint> _fillIndexByKey = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, uint> _cellFormatIndexByKey = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExcelStyleRegistry"/> class and seeds the mandatory
+    /// default font, fills, and cell format required by the Open XML spreadsheet format.
+    /// </summary>
+    public ExcelStyleRegistry()
+    {
+        _fonts.Add(CreateFont(color: null, bold: false));
+        _fills.Add(new Fill(new PatternFill { PatternType = PatternValues.None }));
+        _fills.Add(new Fill(new PatternFill { PatternType = PatternValues.Gray125 }));
+        _cellFormats.Add(new CellFormat());
+    }
+
+    /// <summary>
+    /// Resolves the cell-format index for the supplied style, creating the backing font, fill, and cell
+    /// format on demand.
+    /// </summary>
+    /// <param name="style">The style to resolve. May be <see langword="null"/>.</param>
+    /// <returns>The cell-format index, or <c>0</c> (the default format) when the style has no effect.</returns>
+    public uint GetCellFormatIndex(ReportStyle style)
+    {
+        if (style is null || style.IsEmpty)
+        {
+            return 0;
+        }
+
+        var fontId = GetFontIndex(style);
+        var fillId = GetFillIndex(style);
+        var key = $"{fontId}:{fillId}";
+
+        if (_cellFormatIndexByKey.TryGetValue(key, out var index))
+        {
+            return index;
+        }
+
+        _cellFormats.Add(new CellFormat
+        {
+            FontId = fontId,
+            FillId = fillId,
+            ApplyFont = fontId != 0,
+            ApplyFill = fillId != 0,
+        });
+
+        index = (uint)(_cellFormats.Count - 1);
+        _cellFormatIndexByKey[key] = index;
+
+        return index;
+    }
+
+    /// <summary>
+    /// Builds the Open XML stylesheet from every font, fill, and cell format registered so far.
+    /// </summary>
+    /// <returns>The stylesheet.</returns>
+    public Stylesheet Build()
+    {
+        return new Stylesheet(
+            new Fonts(_fonts.Select(font => font.CloneNode(true))) { Count = (uint)_fonts.Count },
+            new Fills(_fills.Select(fill => fill.CloneNode(true))) { Count = (uint)_fills.Count },
+            new Borders(new Border()) { Count = 1 },
+            new CellStyleFormats(new CellFormat()) { Count = 1 },
+            new CellFormats(_cellFormats.Select(cellFormat => cellFormat.CloneNode(true))) { Count = (uint)_cellFormats.Count });
+    }
+
+    private uint GetFontIndex(ReportStyle style)
+    {
+        var hasColor = ReportColor.TryGetArgb(style.Color, out var argb);
+
+        if (!hasColor && !style.Bold)
+        {
+            return 0;
+        }
+
+        var key = $"{(hasColor ? argb : string.Empty)}|{style.Bold}";
+
+        if (_fontIndexByKey.TryGetValue(key, out var index))
+        {
+            return index;
+        }
+
+        _fonts.Add(CreateFont(hasColor ? argb : null, style.Bold));
+        index = (uint)(_fonts.Count - 1);
+        _fontIndexByKey[key] = index;
+
+        return index;
+    }
+
+    private uint GetFillIndex(ReportStyle style)
+    {
+        if (!ReportColor.TryGetArgb(style.BackgroundColor, out var argb))
+        {
+            return 0;
+        }
+
+        if (_fillIndexByKey.TryGetValue(argb, out var index))
+        {
+            return index;
+        }
+
+        _fills.Add(new Fill(new PatternFill(new ForegroundColor { Rgb = new HexBinaryValue(argb) })
+        {
+            PatternType = PatternValues.Solid,
+        }));
+
+        index = (uint)(_fills.Count - 1);
+        _fillIndexByKey[argb] = index;
+
+        return index;
+    }
+
+    private static Font CreateFont(string color, bool bold)
+    {
+        var font = new Font();
+
+        if (bold)
+        {
+            font.Append(new Bold());
+        }
+
+        font.Append(new FontSize { Val = DefaultFontSize });
+
+        if (color is not null)
+        {
+            font.Append(new Color { Rgb = new HexBinaryValue(color) });
+        }
+
+        font.Append(new FontName { Val = DefaultFontName });
+
+        return font;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Reports/Views/Reports/_ReportDocument.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Reports/Views/Reports/_ReportDocument.cshtml
@@ -69,7 +69,9 @@
                                 <tr>
                                     @for (var i = 0; i < reportSection.Columns.Count; i++)
                                     {
-                                        <th class="@alignClasses[i]">@reportSection.Columns[i].Label</th>
+                                        var headerStyle = reportSection.Columns[i].HeaderStyle?.ToInlineCss();
+
+                                        <th class="@alignClasses[i]" style="@headerStyle">@reportSection.Columns[i].Label</th>
                                     }
                                 </tr>
                             </thead>
@@ -87,8 +89,9 @@
                                         @for (var i = 0; i < row.Cells.Count; i++)
                                         {
                                             var cell = row.Cells[i];
+                                            var cellStyle = row.GetCellStyle(i)?.ToInlineCss();
 
-                                            <td class="@(i < alignClasses.Count ? alignClasses[i] : "text-start")">
+                                            <td class="@(i < alignClasses.Count ? alignClasses[i] : "text-start")" style="@cellStyle">
                                                 @if (ReportValue.TryGetUserName(cell, out var userName))
                                                 {
                                                     <user-display-name user-name="@userName" display-type="Report" cache-id="report-user-display-name" />

--- a/tests/CrestApps.OrchardCore.Tests/Modules/Reports/OpenXml/Services/ExcelReportExportFormatTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/Reports/OpenXml/Services/ExcelReportExportFormatTests.cs
@@ -127,6 +127,94 @@ public sealed class ExcelReportExportFormatTests
         Assert.Equal(["All queues", "2"], GetCellValues(rows[3]));
     }
 
+    [Fact]
+    public void Serialize_WhenTableCellsAreStyled_ShouldApplyFontColorFillAndBold()
+    {
+        // Arrange
+        var document = new ReportDocument()
+            .Add(ReportSection.ForTable(
+                "Queues",
+                [
+                    new ReportColumn("Queue", ReportColumnAlign.Start, ReportStyle.Create("#FFFFFF", "#2563EB", bold: true)),
+                    new ReportColumn("Count"),
+                ],
+                [
+                    new ReportRow(["Support", "2"]).WithCellStyle(1, ReportStyle.Create("#FF0000")),
+                ]));
+        var exportFormat = new ExcelReportExportFormat(Mock.Of<IStringLocalizer<ExcelReportExportFormat>>());
+
+        // Act
+        var content = exportFormat.Serialize(document);
+
+        // Assert
+        using var stream = new MemoryStream(content);
+        using var spreadsheetDocument = SpreadsheetDocument.Open(stream, false);
+        var workbookPart = spreadsheetDocument.WorkbookPart;
+
+        Assert.NotNull(workbookPart);
+        Assert.NotNull(workbookPart.WorkbookStylesPart);
+
+        var stylesheet = workbookPart.WorkbookStylesPart.Stylesheet;
+        var sheet = Assert.Single(workbookPart.Workbook.Sheets.Elements<Sheet>());
+        var rows = GetSheetRows(workbookPart, sheet);
+
+        var headerCell = rows[0].Elements<Cell>().First();
+        var headerFont = GetFont(stylesheet, headerCell);
+        var headerFill = GetFill(stylesheet, headerCell);
+
+        Assert.NotNull(headerFont.Bold);
+        Assert.Equal("FFFFFFFF", headerFont.Color.Rgb.Value);
+        Assert.Equal("FF2563EB", headerFill.PatternFill.ForegroundColor.Rgb.Value);
+
+        var styledCell = rows[1].Elements<Cell>().ElementAt(1);
+        var styledFont = GetFont(stylesheet, styledCell);
+
+        Assert.Equal("FFFF0000", styledFont.Color.Rgb.Value);
+    }
+
+    [Fact]
+    public void Serialize_WhenTableRowIsEmphasized_ShouldMakeCellsBold()
+    {
+        // Arrange
+        var document = new ReportDocument()
+            .Add(ReportSection.ForTable(
+                "Queues",
+                [new ReportColumn("Queue"), new ReportColumn("Count")],
+                [new ReportRow(["All queues", "2"], ReportRowKind.GrandTotal)]));
+        var exportFormat = new ExcelReportExportFormat(Mock.Of<IStringLocalizer<ExcelReportExportFormat>>());
+
+        // Act
+        var content = exportFormat.Serialize(document);
+
+        // Assert
+        using var stream = new MemoryStream(content);
+        using var spreadsheetDocument = SpreadsheetDocument.Open(stream, false);
+        var workbookPart = spreadsheetDocument.WorkbookPart;
+
+        Assert.NotNull(workbookPart);
+
+        var stylesheet = workbookPart.WorkbookStylesPart.Stylesheet;
+        var sheet = Assert.Single(workbookPart.Workbook.Sheets.Elements<Sheet>());
+        var rows = GetSheetRows(workbookPart, sheet);
+        var totalCell = rows[1].Elements<Cell>().First();
+
+        Assert.NotNull(GetFont(stylesheet, totalCell).Bold);
+    }
+
+    private static Font GetFont(Stylesheet stylesheet, Cell cell)
+    {
+        var cellFormat = stylesheet.CellFormats.Elements<CellFormat>().ElementAt((int)(cell.StyleIndex?.Value ?? 0));
+
+        return stylesheet.Fonts.Elements<Font>().ElementAt((int)(cellFormat.FontId?.Value ?? 0));
+    }
+
+    private static Fill GetFill(Stylesheet stylesheet, Cell cell)
+    {
+        var cellFormat = stylesheet.CellFormats.Elements<CellFormat>().ElementAt((int)(cell.StyleIndex?.Value ?? 0));
+
+        return stylesheet.Fills.Elements<Fill>().ElementAt((int)(cellFormat.FillId?.Value ?? 0));
+    }
+
     private static Row[] GetSheetRows(WorkbookPart workbookPart, Sheet sheet)
     {
         var worksheetPart = (WorksheetPart)workbookPart.GetPartById(sheet.Id);

--- a/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportColorTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportColorTests.cs
@@ -1,0 +1,64 @@
+using CrestApps.OrchardCore.Reports.Models;
+
+namespace CrestApps.OrchardCore.Tests.Modules.Reports;
+
+public sealed class ReportColorTests
+{
+    [Theory]
+    [InlineData("#2563EB", "FF2563EB")]
+    [InlineData("2563eb", "FF2563EB")]
+    [InlineData("#abc", "FFAABBCC")]
+    [InlineData("80FF0000", "80FF0000")]
+    public void TryGetArgb_WhenColorIsHexadecimal_ShouldNormalizeToArgb(string color, string expected)
+    {
+        // Act
+        var result = ReportColor.TryGetArgb(color, out var argb);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(expected, argb);
+    }
+
+    [Theory]
+    [InlineData("red")]
+    [InlineData("not-a-color")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryGetArgb_WhenColorIsNotHexadecimal_ShouldReturnFalse(string color)
+    {
+        // Act
+        var result = ReportColor.TryGetArgb(color, out var argb);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(argb);
+    }
+
+    [Theory]
+    [InlineData("#2563eb", "#2563EB")]
+    [InlineData("2563EB", "#2563EB")]
+    [InlineData("steelblue", "steelblue")]
+    [InlineData("80FF0000", "#FF0000")]
+    public void ToCssColor_WhenColorIsValid_ShouldReturnSafeCssColor(string color, string expected)
+    {
+        // Act
+        var css = ReportColor.ToCssColor(color);
+
+        // Assert
+        Assert.Equal(expected, css);
+    }
+
+    [Theory]
+    [InlineData("red; content: 'x'")]
+    [InlineData("rgb(1,2,3)")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ToCssColor_WhenColorIsUnsafeOrEmpty_ShouldReturnNull(string color)
+    {
+        // Act
+        var css = ReportColor.ToCssColor(color);
+
+        // Assert
+        Assert.Null(css);
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportRowTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportRowTests.cs
@@ -21,4 +21,41 @@ public sealed class ReportRowTests
         Assert.Equal(ReportRowKind.Subtotal, row.Kind);
         Assert.True(row.Emphasize);
     }
+
+    [Fact]
+    public void GetCellStyle_WhenCellHasNoOverride_ShouldFallBackToRowStyle()
+    {
+        // Arrange
+        var rowStyle = ReportStyle.Create("#111111");
+        var row = new ReportRow(["A", "B"]).WithStyle(rowStyle);
+
+        // Act
+        var style = row.GetCellStyle(1);
+
+        // Assert
+        Assert.Same(rowStyle, style);
+    }
+
+    [Fact]
+    public void GetCellStyle_WhenCellHasOverride_ShouldPreferCellStyle()
+    {
+        // Arrange
+        var rowStyle = ReportStyle.Create("#111111");
+        var cellStyle = ReportStyle.Create("#222222");
+        var row = new ReportRow(["A", "B"])
+            .WithStyle(rowStyle)
+            .WithCellStyle(1, cellStyle);
+
+        // Act & Assert
+        Assert.Same(rowStyle, row.GetCellStyle(0));
+        Assert.Same(cellStyle, row.GetCellStyle(1));
+    }
+
+    [Fact]
+    public void WithCellStyle_WhenIndexIsNegative_ShouldThrow()
+    {
+        var row = new ReportRow(["A"]);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => row.WithCellStyle(-1, ReportStyle.Create("#000000")));
+    }
 }

--- a/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportStyleTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/Reports/ReportStyleTests.cs
@@ -1,0 +1,51 @@
+using CrestApps.OrchardCore.Reports.Models;
+
+namespace CrestApps.OrchardCore.Tests.Modules.Reports;
+
+public sealed class ReportStyleTests
+{
+    [Fact]
+    public void IsEmpty_WhenNoColorAndNotBold_ShouldReturnTrue()
+    {
+        var style = new ReportStyle();
+
+        Assert.True(style.IsEmpty);
+    }
+
+    [Theory]
+    [InlineData("#111111", null, false)]
+    [InlineData(null, "#222222", false)]
+    [InlineData(null, null, true)]
+    public void IsEmpty_WhenAnyPropertySet_ShouldReturnFalse(string color, string background, bool bold)
+    {
+        var style = ReportStyle.Create(color, background, bold);
+
+        Assert.False(style.IsEmpty);
+    }
+
+    [Fact]
+    public void ToInlineCss_WhenAllPropertiesSet_ShouldBuildDeclaration()
+    {
+        // Arrange
+        var style = ReportStyle.Create("#2563EB", "#EFF6FF", bold: true);
+
+        // Act
+        var css = style.ToInlineCss();
+
+        // Assert
+        Assert.Equal("color:#2563EB;background-color:#EFF6FF;font-weight:600;", css);
+    }
+
+    [Fact]
+    public void ToInlineCss_WhenColorIsUnsafe_ShouldOmitIt()
+    {
+        // Arrange
+        var style = ReportStyle.Create("red; content:'x'", "steelblue");
+
+        // Act
+        var css = style.ToInlineCss();
+
+        // Assert
+        Assert.Equal("background-color:steelblue;", css);
+    }
+}


### PR DESCRIPTION
Introduce ReportStyle (font color, background color, bold) that can be applied to report table headers, rows, and individual cells. The HTML renderer emits inline styles, and the OpenXml (.xlsx) exporter writes font color, background fill, and bold weight into the workbook. Header, subtotal, and grand-total rows export bold automatically. CSV continues to export values only.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
