### PR TITLE
Fix DNC registry migration poisoning the shared migration session

### DIFF
--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -66,6 +66,14 @@ See [Omnichannel Management](../omnichannel/management) for details.
 
 -----
 
+### DNC Registry
+
+#### Local registry migration no longer blocks other feature migrations
+
+The **Local** DNC registry repair migration checked whether its index tables already existed by comparing the database schema against an **unprefixed** table name. On installations that use a table prefix (for example multi-tenant deployments), the check always reported the tables as missing, so the migration tried to recreate them and threw a duplicate-object error. Because Orchard Core runs every feature's automatic migration on a shared session, that uncaught error cancelled the session and silently rolled back every other feature's migration in the same run — most visibly leaving the Omnichannel contact migration stuck on an old version. The existence check now resolves the physical (prefixed) table name, and the repair step no longer rethrows if the table is already present, so a single feature can no longer stall the rest of the migration batch.
+
+-----
+
 ### AI Documents
 
 #### File upload security scanning through Orchard Core

--- a/src/Modules/CrestApps.OrchardCore.DncRegistry/Migrations/LocalDncRegistryMigrations.cs
+++ b/src/Modules/CrestApps.OrchardCore.DncRegistry/Migrations/LocalDncRegistryMigrations.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using CrestApps.OrchardCore.DncRegistry.Indexes;
 using CrestApps.OrchardCore.DncRegistry.Models;
+using Microsoft.Extensions.Logging;
 using OrchardCore.Data.Migration;
 using YesSql.Sql;
 
@@ -11,6 +12,17 @@ namespace CrestApps.OrchardCore.DncRegistry.Migrations;
 /// </summary>
 internal sealed class LocalDncRegistryMigrations : DataMigration
 {
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalDncRegistryMigrations"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    public LocalDncRegistryMigrations(ILogger<LocalDncRegistryMigrations> logger)
+    {
+        _logger = logger;
+    }
+
     /// <summary>
     /// Creates the initial index tables.
     /// </summary>
@@ -40,22 +52,44 @@ internal sealed class LocalDncRegistryMigrations : DataMigration
 
     private async Task<int> RepairIndexTablesAsync()
     {
-        if (!await IndexTableExistsAsync(typeof(LocalDncListIndex)))
-        {
-            await CreateLocalDncListIndexAsync();
-        }
-
-        if (!await IndexTableExistsAsync(typeof(LocalDncEntryIndex)))
-        {
-            await CreateLocalDncEntryIndexAsync();
-        }
+        await EnsureIndexTableAsync(typeof(LocalDncListIndex), CreateLocalDncListIndexAsync);
+        await EnsureIndexTableAsync(typeof(LocalDncEntryIndex), CreateLocalDncEntryIndexAsync);
 
         return 3;
+    }
+
+    private async Task EnsureIndexTableAsync(Type indexType, Func<Task> createAsync)
+    {
+        if (await IndexTableExistsAsync(indexType))
+        {
+            return;
+        }
+
+        try
+        {
+            await createAsync();
+        }
+        catch (Exception ex)
+        {
+            // The table already exists even though the schema lookup did not report it. The
+            // create must not rethrow because an uncaught migration exception cancels the shared
+            // migration session, which would silently roll back every other feature's migration.
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(ex, "The local DNC index table for '{IndexType}' was not created because it was already present.", indexType.Name);
+            }
+        }
     }
 
     private async Task<bool> IndexTableExistsAsync(Type indexType)
     {
         var tableName = SchemaBuilder.TableNameConvention.GetIndexTable(indexType, DncRegistryConstants.CollectionName);
+
+        // YesSql stores each tenant's tables with the shell's table prefix, so the physical
+        // table name must be resolved before comparing against the database schema. Comparing
+        // the unprefixed name would always report the table as missing on prefixed (for example
+        // multi-tenant) installations and cause a duplicate-object error when it is recreated.
+        var physicalTableName = $"{SchemaBuilder.TablePrefix}{tableName}";
 
         if (SchemaBuilder.Connection.GetType().Name.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
         {
@@ -64,7 +98,7 @@ internal sealed class LocalDncRegistryMigrations : DataMigration
             command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = @tableName";
             var parameter = command.CreateParameter();
             parameter.ParameterName = "@tableName";
-            parameter.Value = tableName;
+            parameter.Value = physicalTableName;
             command.Parameters.Add(parameter);
             var result = await command.ExecuteScalarAsync();
 
@@ -75,7 +109,7 @@ internal sealed class LocalDncRegistryMigrations : DataMigration
 
         return tables.Rows
             .Cast<DataRow>()
-            .Any(row => string.Equals(row["TABLE_NAME"]?.ToString(), tableName, StringComparison.OrdinalIgnoreCase));
+            .Any(row => string.Equals(row["TABLE_NAME"]?.ToString(), physicalTableName, StringComparison.OrdinalIgnoreCase));
     }
 
     private async Task CreateLocalDncListIndexAsync()


### PR DESCRIPTION
LocalDncRegistryMigrations checked table existence using an unprefixed table name, so on prefixed/multi-tenant installations it always tried to recreate existing tables and threw a duplicate-object error. That uncaught exception cancelled OrchardCore's shared migration session, silently rolling back every other feature's migration in the same run (most visibly stalling OmnichannelContactsMigrations at an old version).

The existence check now resolves the physical (prefixed) table name, and the repair step no longer rethrows when the table is already present.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
