### PR TITLE
Backport PR 585 to release/2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -180,6 +180,8 @@
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.4" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+    <!-- Pinned to the patched release for GHSA-q939-rpr3-3284 (SCP directory traversal); versions <= 2025.1.0 are vulnerable. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Sample Packages -->

--- a/src/CrestApps.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/2.0.0.md
@@ -140,6 +140,8 @@ The **DNC Registry** modules help sites check phone numbers against do-not-call 
 
 Administrators can configure provider settings, protect provider API keys, and use the **Local Do Not Call Registry** to upload country-specific CSV lists. Local uploads are processed in the background and include progress and validation feedback.
 
+The local registry repair migration now resolves physical index table names with the tenant table prefix before checking schema metadata. It also does not rethrow if a table is already present, so a duplicate-object repair path cannot cancel the shared migration session for other features.
+
 See [DNC Registry](../modules/dnc-registry.md).
 
 ### Omnichannel

--- a/src/CrestApps.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/2.0.0.md
@@ -114,6 +114,8 @@ The release adds protocol support for connecting Orchard Core AI experiences wit
 - **MCP Client** lets Orchard Core consume external MCP servers.
 - FTP and SFTP MCP resource modules add file-resource options.
 
+The SFTP MCP dependency chain now pins `SSH.NET` to the patched `2026.0.0` release for GHSA-q939-rpr3-3284.
+
 See [A2A](../ai/a2a/index.md), [Model Context Protocol](../ai/mcp/index.md), [MCP Server](../ai/mcp/server.md), [MCP Client Integration](../ai/mcp/client.md), [FTP MCP resources](../ai/mcp/ftp.md), and [SFTP MCP resources](../ai/mcp/sftp.md).
 
 ### Content Access Control and Phone Field

--- a/src/Modules/CrestApps.OrchardCore.DncRegistry/Migrations/LocalDncRegistryMigrations.cs
+++ b/src/Modules/CrestApps.OrchardCore.DncRegistry/Migrations/LocalDncRegistryMigrations.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using CrestApps.OrchardCore.DncRegistry.Indexes;
 using CrestApps.OrchardCore.DncRegistry.Models;
+using Microsoft.Extensions.Logging;
 using OrchardCore.Data.Migration;
 using YesSql.Sql;
 
@@ -11,6 +12,17 @@ namespace CrestApps.OrchardCore.DncRegistry.Migrations;
 /// </summary>
 internal sealed class LocalDncRegistryMigrations : DataMigration
 {
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalDncRegistryMigrations"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    public LocalDncRegistryMigrations(ILogger<LocalDncRegistryMigrations> logger)
+    {
+        _logger = logger;
+    }
+
     /// <summary>
     /// Creates the initial index tables.
     /// </summary>
@@ -40,22 +52,44 @@ internal sealed class LocalDncRegistryMigrations : DataMigration
 
     private async Task<int> RepairIndexTablesAsync()
     {
-        if (!await IndexTableExistsAsync(typeof(LocalDncListIndex)))
-        {
-            await CreateLocalDncListIndexAsync();
-        }
-
-        if (!await IndexTableExistsAsync(typeof(LocalDncEntryIndex)))
-        {
-            await CreateLocalDncEntryIndexAsync();
-        }
+        await EnsureIndexTableAsync(typeof(LocalDncListIndex), CreateLocalDncListIndexAsync);
+        await EnsureIndexTableAsync(typeof(LocalDncEntryIndex), CreateLocalDncEntryIndexAsync);
 
         return 3;
+    }
+
+    private async Task EnsureIndexTableAsync(Type indexType, Func<Task> createAsync)
+    {
+        if (await IndexTableExistsAsync(indexType))
+        {
+            return;
+        }
+
+        try
+        {
+            await createAsync();
+        }
+        catch (Exception ex)
+        {
+            // The table already exists even though the schema lookup did not report it. The
+            // create must not rethrow because an uncaught migration exception cancels the shared
+            // migration session, which would silently roll back every other feature's migration.
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(ex, "The local DNC index table for '{IndexType}' was not created because it was already present.", indexType.Name);
+            }
+        }
     }
 
     private async Task<bool> IndexTableExistsAsync(Type indexType)
     {
         var tableName = SchemaBuilder.TableNameConvention.GetIndexTable(indexType, DncRegistryConstants.CollectionName);
+
+        // YesSql stores each tenant's tables with the shell's table prefix, so the physical
+        // table name must be resolved before comparing against the database schema. Comparing
+        // the unprefixed name would always report the table as missing on prefixed (for example
+        // multi-tenant) installations and cause a duplicate-object error when it is recreated.
+        var physicalTableName = $"{SchemaBuilder.TablePrefix}{tableName}";
 
         if (SchemaBuilder.Connection.GetType().Name.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
         {
@@ -64,7 +98,7 @@ internal sealed class LocalDncRegistryMigrations : DataMigration
             command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = @tableName";
             var parameter = command.CreateParameter();
             parameter.ParameterName = "@tableName";
-            parameter.Value = tableName;
+            parameter.Value = physicalTableName;
             command.Parameters.Add(parameter);
             var result = await command.ExecuteScalarAsync();
 
@@ -75,7 +109,7 @@ internal sealed class LocalDncRegistryMigrations : DataMigration
 
         return tables.Rows
             .Cast<DataRow>()
-            .Any(row => string.Equals(row["TABLE_NAME"]?.ToString(), tableName, StringComparison.OrdinalIgnoreCase));
+            .Any(row => string.Equals(row["TABLE_NAME"]?.ToString(), physicalTableName, StringComparison.OrdinalIgnoreCase));
     }
 
     private async Task CreateLocalDncListIndexAsync()


### PR DESCRIPTION
## Summary

Backports #585 to the 2.0 release branch and includes the build fix required by CI.

- Applies the Local DNC registry migration repair for prefixed/multi-tenant table-name checks.
- Prevents the repair path from rethrowing when an index table is already present.
- Pins SSH.NET to 2026.0.0 to resolve NU1903 for GHSA-q939-rpr3-3284.
- Excludes the 3.0.0.md changelog change and records the release notes in 2.0.0.md instead.

## Validation

- dotnet build -c Release -warnaserror /p:TreatWarningsAsErrors=true /p:RunAnalyzers=true /p:NuGetAudit=false src/Modules/CrestApps.OrchardCore.DncRegistry/CrestApps.OrchardCore.DncRegistry.csproj
- npm --prefix src/CrestApps.Docs run build -- --no-minify
- dotnet build -c Release -warnaserror /p:TreatWarningsAsErrors=true /p:RunAnalyzers=true /p:NuGetAudit=false src/Modules/CrestApps.OrchardCore.AI.Mcp.Resources.Sftp/CrestApps.OrchardCore.AI.Mcp.Resources.Sftp.csproj was attempted locally but blocked by NuGet connectivity to https://api.nuget.org/v3/index.json (NU1301, SSL/socket error).
