### PR TITLE
Backport PR 586 to release/2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -180,6 +180,8 @@
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.4" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+    <!-- Pinned to the patched release for GHSA-q939-rpr3-3284 (SCP directory traversal); versions <= 2025.1.0 are vulnerable. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Sample Packages -->

--- a/src/CrestApps.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/2.0.0.md
@@ -114,6 +114,8 @@ The release adds protocol support for connecting Orchard Core AI experiences wit
 - **MCP Client** lets Orchard Core consume external MCP servers.
 - FTP and SFTP MCP resource modules add file-resource options.
 
+The SFTP MCP dependency chain now pins `SSH.NET` to the patched `2026.0.0` release for GHSA-q939-rpr3-3284.
+
 See [A2A](../ai/a2a/index.md), [Model Context Protocol](../ai/mcp/index.md), [MCP Server](../ai/mcp/server.md), [MCP Client Integration](../ai/mcp/client.md), [FTP MCP resources](../ai/mcp/ftp.md), and [SFTP MCP resources](../ai/mcp/sftp.md).
 
 ### Content Access Control and Phone Field
@@ -158,6 +160,8 @@ It includes:
 - Reporting support when the Reports module is enabled.
 
 Subject behavior is configured from the subject content type, so administrators can manage direction, channel, activity behavior, AI options, and disposition requirements from the content definition experience.
+
+The contact index repair migration now runs each idempotent table, column, and index schema change in its own isolated transaction. This prevents an expected "already exists" DDL failure from poisoning the shared migration transaction, which could otherwise leave `OmnichannelContactsMigrations` stuck on PostgreSQL and other transactional DDL providers.
 
 See [Omnichannel Communications](../omnichannel/index.md), [Omnichannel Management](../omnichannel/management.md), [SMS](../omnichannel/sms.md), and [Event Grid](../omnichannel/event-grid.md).
 

--- a/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Migrations/OmnichannelContactsMigrations.cs
+++ b/src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/Migrations/OmnichannelContactsMigrations.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using CrestApps.OrchardCore.Omnichannel.Core;
 using CrestApps.OrchardCore.Omnichannel.Core.Indexes;
 using CrestApps.OrchardCore.Omnichannel.Managements.Services;
@@ -24,6 +25,21 @@ public sealed class OmnichannelContactsMigrations : DataMigration
 {
     private const string LegacyPhoneIndexTableName = "OmnichannelContactPhoneIndex";
     private const int ReindexBatchSize = 100;
+
+    private static readonly (string Name, string[] Columns)[] _contactIndexIndexes =
+    [
+        ("IDX_OmnichannelContactIndex_DocumentId", ["DocumentId", "ContentItemId"]),
+        ("IDX_OmnichannelContactIndex_NormalizedPrimaryCellPhoneNumber", ["DocumentId", "NormalizedPrimaryCellPhoneNumber"]),
+        ("IDX_OmnichannelContactIndex_NormalizedPrimaryHomePhoneNumber", ["DocumentId", "NormalizedPrimaryHomePhoneNumber"]),
+        ("IDX_OmnichannelContactIndex_TimeZoneId", ["DocumentId", "TimeZoneId"]),
+        ("IDX_OCIndex_ContentItemLatest", ["ContentItemId", "Latest"]),
+        ("IDX_OCIndex_ContentItemPublished", ["ContentItemId", "Published"]),
+        ("IDX_OCIndex_E164Cell", ["NormalizedPrimaryCellPhoneNumber", "Published", "Latest"]),
+        ("IDX_OCIndex_PrimaryCell", ["PrimaryCellPhoneNumber", "Published", "Latest"]),
+        ("IDX_OCIndex_E164Home", ["NormalizedPrimaryHomePhoneNumber", "Published", "Latest"]),
+        ("IDX_OCIndex_PrimaryHome", ["PrimaryHomePhoneNumber", "Published", "Latest"]),
+        ("IDX_OCIndex_TimeZoneVersion", ["TimeZoneId", "Published", "Latest"]),
+    ];
 
     private readonly IContentDefinitionManager _contentDefinitionManager;
     private readonly IStore _store;
@@ -66,8 +82,8 @@ public sealed class OmnichannelContactsMigrations : DataMigration
             .WithDescription("Provides a way to configure a content type to act as an omnichannel subject record.")
         );
 
-        await CreateContactIndexTableAsync();
-        await CreateContactIndexIndexesAsync();
+        await CreateContactIndexTableAsync(SchemaBuilder);
+        await CreateContactIndexIndexesAsync(SchemaBuilder);
         ScheduleContactDefinitionRepair();
 
         return 11;
@@ -106,30 +122,18 @@ public sealed class OmnichannelContactsMigrations : DataMigration
     /// </summary>
     public async Task<int> UpdateFrom2Async()
     {
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.AddColumn<string>("TimeZoneId", column => column.WithLength(64))
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'TimeZoneId' column may already exist on the OmnichannelContactIndex table.");
-        }
+        await using var connection = _dbConnectionAccessor.CreateConnection();
+        await connection.OpenAsync();
 
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OmnichannelContactIndex_TimeZoneId",
-                    "DocumentId",
-                    "TimeZoneId")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OmnichannelContactIndex_TimeZoneId' index may already exist.");
-        }
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.AddColumn<string>("TimeZoneId", column => column.WithLength(64))),
+            "The 'TimeZoneId' column may already exist on the OmnichannelContactIndex table.");
+
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.CreateIndex("IDX_OmnichannelContactIndex_TimeZoneId", "DocumentId", "TimeZoneId")),
+            "The 'IDX_OmnichannelContactIndex_TimeZoneId' index may already exist.");
 
         return 3;
     }
@@ -232,9 +236,9 @@ public sealed class OmnichannelContactsMigrations : DataMigration
                 .RepairOmnichannelContactContentTypesAsync());
     }
 
-    private async Task CreateContactIndexTableAsync()
+    private static async Task CreateContactIndexTableAsync(ISchemaBuilder schemaBuilder)
     {
-        await SchemaBuilder.CreateMapIndexTableAsync<OmnichannelContactIndex>(table => table
+        await schemaBuilder.CreateMapIndexTableAsync<OmnichannelContactIndex>(table => table
             .Column<string>("ContentItemId", column => column.WithLength(26))
             .Column<bool>("Published", column => column.NotNull().WithDefault(false))
             .Column<bool>("Latest", column => column.NotNull().WithDefault(false))
@@ -247,363 +251,142 @@ public sealed class OmnichannelContactsMigrations : DataMigration
         );
     }
 
-    private async Task CreateContactIndexIndexesAsync()
+    private static async Task CreateContactIndexIndexesAsync(ISchemaBuilder schemaBuilder)
     {
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OmnichannelContactIndex_DocumentId",
-                "DocumentId",
-                "ContentItemId")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OmnichannelContactIndex_NormalizedPrimaryCellPhoneNumber",
-                "DocumentId",
-                "NormalizedPrimaryCellPhoneNumber")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OmnichannelContactIndex_NormalizedPrimaryHomePhoneNumber",
-                "DocumentId",
-                "NormalizedPrimaryHomePhoneNumber")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OmnichannelContactIndex_TimeZoneId",
-                "DocumentId",
-                "TimeZoneId")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OCIndex_ContentItemLatest",
-                "ContentItemId",
-                "Latest")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OCIndex_ContentItemPublished",
-                "ContentItemId",
-                "Published")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OCIndex_E164Cell",
-                "NormalizedPrimaryCellPhoneNumber",
-                "Published",
-                "Latest")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OCIndex_PrimaryCell",
-                "PrimaryCellPhoneNumber",
-                "Published",
-                "Latest")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OCIndex_E164Home",
-                "NormalizedPrimaryHomePhoneNumber",
-                "Published",
-                "Latest")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OCIndex_PrimaryHome",
-                "PrimaryHomePhoneNumber",
-                "Published",
-                "Latest")
-        );
-
-        await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-            .CreateIndex(
-                "IDX_OCIndex_TimeZoneVersion",
-                "TimeZoneId",
-                "Published",
-                "Latest")
-        );
+        foreach (var (name, columns) in _contactIndexIndexes)
+        {
+            await schemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.CreateIndex(name, columns));
+        }
     }
 
     private async Task EnsureDefaultContactIndexTableAsync()
     {
         await RemoveLegacyCollectionContactIndexTableAsync();
 
-        try
+        await using var connection = _dbConnectionAccessor.CreateConnection();
+        await connection.OpenAsync();
+
+        if (_logger.IsEnabled(LogLevel.Information))
         {
-            await CreateContactIndexTableAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The default-collection OmnichannelContactIndex table may already exist.");
+            _logger.LogInformation(
+                "Ensuring the default-collection OmnichannelContactIndex schema using the '{SqlDialect}' SQL dialect with table prefix '{TablePrefix}'.",
+                _store.Configuration.SqlDialect.Name,
+                _store.Configuration.TablePrefix);
         }
 
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.AddColumn<bool>("Published", column => column.NotNull().WithDefault(false))
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'Published' column may already exist on the default-collection OmnichannelContactIndex table.");
-        }
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            CreateContactIndexTableAsync,
+            "create the table");
 
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.AddColumn<bool>("Latest", column => column.NotNull().WithDefault(false))
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'Latest' column may already exist on the default-collection OmnichannelContactIndex table.");
-        }
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.AddColumn<bool>("Published", column => column.NotNull().WithDefault(false))),
+            "add the 'Published' column");
 
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.AddColumn<string>("NormalizedPrimaryCellPhoneNumber", column => column.WithLength(50))
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'NormalizedPrimaryCellPhoneNumber' column may already exist on the default-collection OmnichannelContactIndex table.");
-        }
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.AddColumn<bool>("Latest", column => column.NotNull().WithDefault(false))),
+            "add the 'Latest' column");
 
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.AddColumn<string>("NormalizedPrimaryHomePhoneNumber", column => column.WithLength(50))
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'NormalizedPrimaryHomePhoneNumber' column may already exist on the default-collection OmnichannelContactIndex table.");
-        }
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.AddColumn<string>("NormalizedPrimaryCellPhoneNumber", column => column.WithLength(50))),
+            "add the 'NormalizedPrimaryCellPhoneNumber' column");
 
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.AddColumn<string>("TimeZoneId", column => column.WithLength(64))
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'TimeZoneId' column may already exist on the default-collection OmnichannelContactIndex table.");
-        }
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.AddColumn<string>("NormalizedPrimaryHomePhoneNumber", column => column.WithLength(50))),
+            "add the 'NormalizedPrimaryHomePhoneNumber' column");
 
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex("IDX_OmnichannelContactIndex_DocumentId",
-                    "DocumentId",
-                    "ContentItemId"
-                )
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OmnichannelContactIndex_DocumentId' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.AddColumn<string>("TimeZoneId", column => column.WithLength(64))),
+            "add the 'TimeZoneId' column");
 
-        try
+        foreach (var (name, columns) in _contactIndexIndexes)
         {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OmnichannelContactIndex_NormalizedPrimaryCellPhoneNumber",
-                    "DocumentId",
-                    "NormalizedPrimaryCellPhoneNumber")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OmnichannelContactIndex_NormalizedPrimaryCellPhoneNumber' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
-
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OmnichannelContactIndex_NormalizedPrimaryHomePhoneNumber",
-                    "DocumentId",
-                    "NormalizedPrimaryHomePhoneNumber")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OmnichannelContactIndex_NormalizedPrimaryHomePhoneNumber' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
-
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OmnichannelContactIndex_TimeZoneId",
-                    "DocumentId",
-                    "TimeZoneId")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OmnichannelContactIndex_TimeZoneId' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
-
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OCIndex_ContentItemLatest",
-                    "ContentItemId",
-                    "Latest")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OCIndex_ContentItemLatest' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
-
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OCIndex_ContentItemPublished",
-                    "ContentItemId",
-                    "Published")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OCIndex_ContentItemPublished' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
-
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OCIndex_E164Cell",
-                    "NormalizedPrimaryCellPhoneNumber",
-                    "Published",
-                    "Latest")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OCIndex_E164Cell' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
-
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OCIndex_PrimaryCell",
-                    "PrimaryCellPhoneNumber",
-                    "Published",
-                    "Latest")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OCIndex_PrimaryCell' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
-
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OCIndex_E164Home",
-                    "NormalizedPrimaryHomePhoneNumber",
-                    "Published",
-                    "Latest")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OCIndex_E164Home' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
-
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OCIndex_PrimaryHome",
-                    "PrimaryHomePhoneNumber",
-                    "Published",
-                    "Latest")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OCIndex_PrimaryHome' index may already exist on the default-collection OmnichannelContactIndex table.");
-        }
-
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table => table
-                .CreateIndex(
-                    "IDX_OCIndex_TimeZoneVersion",
-                    "TimeZoneId",
-                    "Published",
-                    "Latest")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The 'IDX_OCIndex_TimeZoneVersion' index may already exist on the default-collection OmnichannelContactIndex table.");
+            await ApplyIsolatedSchemaChangeAsync(connection,
+                builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                    table.CreateIndex(name, columns)),
+                $"create the '{name}' index");
         }
     }
 
     private async Task RemoveRedundantNationalPhoneColumnsAsync()
     {
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.DropIndex("IDX_OCIndex_NationalCell")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The obsolete 'IDX_OCIndex_NationalCell' index may already be removed.");
-        }
+        await using var connection = _dbConnectionAccessor.CreateConnection();
+        await connection.OpenAsync();
+
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.DropIndex("IDX_OCIndex_NationalCell")),
+            "drop the obsolete 'IDX_OCIndex_NationalCell' index");
+
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.DropIndex("IDX_OCIndex_NationalHome")),
+            "drop the obsolete 'IDX_OCIndex_NationalHome' index");
+
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.DropColumn("NationalPrimaryCellPhoneNumber")),
+            "drop the obsolete 'NationalPrimaryCellPhoneNumber' column");
+
+        await ApplyIsolatedSchemaChangeAsync(connection,
+            builder => builder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
+                table.DropColumn("NationalPrimaryHomePhoneNumber")),
+            "drop the obsolete 'NationalPrimaryHomePhoneNumber' column");
+    }
+
+    private async Task ApplyIsolatedSchemaChangeAsync(
+        DbConnection connection,
+        Func<ISchemaBuilder, Task> schemaChange,
+        string operation)
+    {
+        await using var transaction = await connection.BeginTransactionAsync();
 
         try
         {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.DropIndex("IDX_OCIndex_NationalHome")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The obsolete 'IDX_OCIndex_NationalHome' index may already be removed.");
-        }
+            var schemaBuilder = new SchemaBuilder(_store.Configuration, transaction);
+            await schemaChange(schemaBuilder);
+            await transaction.CommitAsync();
 
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.DropColumn("NationalPrimaryCellPhoneNumber")
-            );
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Applied the isolated schema change to {SchemaChangeOperation} on the default-collection OmnichannelContactIndex table.",
+                    operation);
+            }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "The obsolete 'NationalPrimaryCellPhoneNumber' column may already be removed.");
-        }
+            // Each idempotent change runs in its own transaction so a failure here (most often because the
+            // object already exists) cannot poison the shared migration transaction. This is expected during
+            // upgrades, so it is logged at Debug with the exception to keep normal upgrades quiet while still
+            // preserving a full trace when production logging runs at Debug.
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    ex,
+                    "Skipped the isolated schema change to {SchemaChangeOperation} on the default-collection OmnichannelContactIndex table because it could not be applied; it most likely already exists.",
+                    operation);
+            }
 
-        try
-        {
-            await SchemaBuilder.AlterIndexTableAsync<OmnichannelContactIndex>(table =>
-                table.DropColumn("NationalPrimaryHomePhoneNumber")
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "The obsolete 'NationalPrimaryHomePhoneNumber' column may already be removed.");
+            try
+            {
+                await transaction.RollbackAsync();
+            }
+            catch (Exception rollbackException)
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(
+                        rollbackException,
+                        "Failed to roll back the isolated schema change transaction for the operation to {SchemaChangeOperation}.",
+                        operation);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Backports #586 to the 2.0 release branch.

- Applies the Omnichannel contact index isolated schema-change fix.
- Pins SSH.NET to 2026.0.0 for GHSA-q939-rpr3-3284.
- Excludes the 3.0.0.md changelog change and records the release notes in 2.0.0.md instead.

## Validation

- dotnet build -c Release -warnaserror /p:TreatWarningsAsErrors=true /p:RunAnalyzers=true /p:NuGetAudit=false src/Modules/CrestApps.OrchardCore.Omnichannel.Managements/CrestApps.OrchardCore.Omnichannel.Managements.csproj
- npm --prefix src/CrestApps.Docs run build -- --no-minify
