### PR TITLE
Update AI chat UI resources

### DIFF
--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -52,6 +52,10 @@ Do not remove the CrestApps SignalR module yet if you want the automatic migrati
 
 ## Change Logs
 
+### Resources
+
+The shared AI chat UI resources now use `@crestapps/ai-chat-ui` 1.2.0. Local package references, CDN URLs, resource versions, and SRI hashes were updated together.
+
 ### Reports
 
 #### Color-coded report cells and styled Excel export

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Services/ResourceManagementOptionsConfiguration.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Services/ResourceManagementOptionsConfiguration.cs
@@ -15,13 +15,13 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
             .DefineScript("ChatInteractionApp")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat.Interactions/scripts/chat-interaction.min.js", "~/CrestApps.OrchardCore.AI.Chat.Interactions/scripts/chat-interaction.js")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/chat-interaction.min.js",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/chat-interaction.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/chat-interaction.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/chat-interaction.js")
             .SetCdnIntegrity(
                 "sha384-uC6L8aVbSTxixhG/bE9jmmHj6RLZpKWJxvKSrEpUNO0xjbLFRSbR7sCwsLXzReFW",
                 "sha384-DOgSQbLi4SIC5E4pkElu6AZwpxhCutOVkQiVsUo6V8x9fadXltD2w9/NN6ZMteQs")
             .SetDependencies("vuejs:3", "signalr", "marked", "chart.js", "highlightjs", "dompurify")
-            .SetVersion("1.0.0");
+            .SetVersion("1.2.0");
     }
 
     /// <summary>

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/package-lock.json
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@crestapps/ai-chat-ui": "1.0.0-preview.109"
+        "@crestapps/ai-chat-ui": "1.2.0"
       },
       "devDependencies": {
         "eslint": "^10.5.0"
       }
     },
     "node_modules/@crestapps/ai-chat-ui": {
-      "version": "1.0.0-preview.109",
-      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-1.0.0-preview.109.tgz",
-      "integrity": "sha512-KOufDJvQ18hVUm99IiBdVjBulNkfMyucwJ3SToR3CDNWizwWAs1zUQTo2cZ6l6RyY5+y/d1Muel9sQIyN8+lOA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-1.2.0.tgz",
+      "integrity": "sha512-3T4sgbzfZgsqvxqrA2QRnmF96apT7ZRHpDOfkI57ZOHouUD2co8bBO0SZpWw2N9T176G406Wl07PmF/SStG0Eg==",
       "license": "MIT",
       "peerDependencies": {
         "chart.js": ">=3.0.0"

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/package.json
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@crestapps/ai-chat-ui": "1.0.0-preview.109"
+    "@crestapps/ai-chat-ui": "1.2.0"
   },
   "devDependencies": {
     "eslint": "^10.5.0"

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/Services/ResourceManagementOptionsConfiguration.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/Services/ResourceManagementOptionsConfiguration.cs
@@ -15,47 +15,47 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
             .DefineScript("AIChatApp")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat/scripts/ai-chat.min.js", "~/CrestApps.OrchardCore.AI.Chat/scripts/ai-chat.js")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/ai-chat.min.js",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/ai-chat.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/ai-chat.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/ai-chat.js")
             .SetCdnIntegrity(
                 "sha384-DL/Fy8COa8DpU/k2OG12zhBbEyCwojYRYtFTxjV/2AXs2x68QzcuY4EsDIv3c5D/",
                 "sha384-VQATJt3vEMv0uaPi+zZm/2D9fPfXc/PH14dUn+f653lHlEqBSiEP1vULnvU5GyvI")
             .SetDependencies("vuejs:3", "signalr", "marked", "chart.js", "highlightjs", "dompurify")
-            .SetVersion("1.0.0");
+            .SetVersion("1.2.0");
 
         _manifest
             .DefineScript("AIChatWidgetApp")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat/scripts/ai-chat-widget.min.js", "~/CrestApps.OrchardCore.AI.Chat/scripts/ai-chat-widget.js")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/ai-chat-widget.min.js",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/ai-chat-widget.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/ai-chat-widget.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/ai-chat-widget.js")
             .SetCdnIntegrity(
                 "sha384-VcuWu/hKzc1yOALgnAddI5XGBwtR9Nh8zej9YlpzrAXYbnYEWk1hVKpeKgWh7+mL",
                 "sha384-HVtX+x4FVs4C14eqbz5iwSyc4FI9sEQ9uAiGLsAJFs+DTHeksCPQwT5BQOp/7BVi")
             .SetDependencies("AIChatApp")
-            .SetVersion("1.0.0");
+            .SetVersion("1.2.0");
 
         _manifest
             .DefineStyle("AIChatApp")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat/css/ai-chat.min.css", "~/CrestApps.OrchardCore.AI.Chat/css/ai-chat.css")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/ai-chat.min.css",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/ai-chat.css")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/ai-chat.min.css",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/ai-chat.css")
             .SetCdnIntegrity(
                 "sha384-KKZ8hVlHa3DGMa6QV4PPzbSyMsxF76YT6+dRHsiI+cBJ3wt+m9cSBW07CQlKUq87",
                 "sha384-ItWpot1IYdNGFGwJxcWg+uJ42DWXOXkl/WeVy1Byf0LfcKgFjiV8kuKlSkcf/Z4Z")
-            .SetVersion("1.0.0");
+            .SetVersion("1.2.0");
 
         _manifest
             .DefineStyle("AIChatWidget")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat/css/ai-chat-widget.min.css", "~/CrestApps.OrchardCore.AI.Chat/css/ai-chat-widget.css")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/chat-widget.min.css",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/chat-widget.css")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/chat-widget.min.css",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/chat-widget.css")
             .SetCdnIntegrity(
                 "sha384-ETUZFWfTXtm2hDzz71g3rPZQSSA9R0njFfXiYaBT6QTb2+bLMuZNQKChN52Q+pzU",
                 "sha384-8SMfXg8HrWLJjzqfwxowYAz0HVAsaN2o5Y1X46je0Fa3HrwobAKBTbPOrPI0gfz/")
-            .SetVersion("1.0.0");
+            .SetVersion("1.2.0");
 
         _manifest
             .DefineStyle("SpeechToText")

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/package-lock.json
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@crestapps/ai-chat-ui": "1.0.0-preview.109"
+        "@crestapps/ai-chat-ui": "1.2.0"
       }
     },
     "node_modules/@crestapps/ai-chat-ui": {
-      "version": "1.0.0-preview.109",
-      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-1.0.0-preview.109.tgz",
-      "integrity": "sha512-KOufDJvQ18hVUm99IiBdVjBulNkfMyucwJ3SToR3CDNWizwWAs1zUQTo2cZ6l6RyY5+y/d1Muel9sQIyN8+lOA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-1.2.0.tgz",
+      "integrity": "sha512-3T4sgbzfZgsqvxqrA2QRnmF96apT7ZRHpDOfkI57ZOHouUD2co8bBO0SZpWw2N9T176G406Wl07PmF/SStG0Eg==",
       "license": "MIT",
       "peerDependencies": {
         "chart.js": ">=3.0.0"

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/package.json
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@crestapps/ai-chat-ui": "1.0.0-preview.109"
+    "@crestapps/ai-chat-ui": "1.2.0"
   }
 }

--- a/src/Modules/CrestApps.OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
+++ b/src/Modules/CrestApps.OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
@@ -165,12 +165,12 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/technical-name-generator.min.js",
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/technical-name-generator.js")
             .SetCdn(
-               "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/technical-name-generator.min.js",
-               "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/technical-name-generator.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/technical-name-generator.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/technical-name-generator.js")
             .SetCdnIntegrity(
                 "sha384-vk5MiCC6biz7ygKi3CY+whjnNoLe2Ol+ZWoxUr/aoifSyfm9c2WFazGMhNLi8g7I",
                 "sha384-9cJ5WEY0z1tJkCLND8ZMhN+rT6IySJKbK/R1yJcaSqmWgiCMuOyZJ+UUobxuScNs")
-             .SetVersion("1.0.0");
+            .SetVersion("1.2.0");
 
         _manifest
             .DefineScript("document-drop-zone")
@@ -178,12 +178,12 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/document-drop-zone.min.js",
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/document-drop-zone.js")
             .SetCdn(
-               "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/document-drop-zone.min.js",
-               "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/document-drop-zone.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/document-drop-zone.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/document-drop-zone.js")
             .SetCdnIntegrity(
-               "sha384-AvXYh7cCLTVJu3IoIikt5045awzgrmZ4S6e8Z5mHQydf5f9mHIPAbZ2xTP+LT5BC",
-               "sha384-8W/wOs7j6d1l50bR3wLRiY6M3/yf0acllYpEJRFraFBwtAXwvYcoyITxQ6FxyNkb")
-             .SetVersion("1.0.0");
+                "sha384-AvXYh7cCLTVJu3IoIikt5045awzgrmZ4S6e8Z5mHQydf5f9mHIPAbZ2xTP+LT5BC",
+                "sha384-8W/wOs7j6d1l50bR3wLRiY6M3/yf0acllYpEJRFraFBwtAXwvYcoyITxQ6FxyNkb")
+            .SetVersion("1.2.0");
 
         _manifest
             .DefineStyle("document-drop-zone")
@@ -191,12 +191,12 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/document-drop-zone.min.css",
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/document-drop-zone.css")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/document-drop-zone.min.css",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.0.0-preview.109/dist/document-drop-zone.css")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/document-drop-zone.min.css",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@1.2.0/dist/document-drop-zone.css")
             .SetCdnIntegrity(
                 "sha384-cTjcD1YHMzaJ5FIvmpJhm3VZDBheTcbiNfGCQfFvBTDg1pZi7PWE5lO6VHRYX9zq",
                 "sha384-NLPKccGh39Ymb5v2aC3tD6zdtg+MhT/Sa+QpCRmDVY2xXSC10rxBNBh0iRqLUQkK")
-            .SetVersion("1.0.0");
+            .SetVersion("1.2.0");
 
         _manifest
             .DefineStyle("intl-tel-input")

--- a/src/Modules/CrestApps.OrchardCore.Resources/package-lock.json
+++ b/src/Modules/CrestApps.OrchardCore.Resources/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "crestapps.orchardcore.resources",
       "dependencies": {
-        "@crestapps/ai-chat-ui": "1.0.0-preview.109",
+        "@crestapps/ai-chat-ui": "1.2.0",
         "@crestapps/bootstrap-select": "1.2.1",
         "chart.js": "^4.5.1",
         "intl-tel-input": "29.1.0"
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@crestapps/ai-chat-ui": {
-      "version": "1.0.0-preview.109",
-      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-1.0.0-preview.109.tgz",
-      "integrity": "sha512-KOufDJvQ18hVUm99IiBdVjBulNkfMyucwJ3SToR3CDNWizwWAs1zUQTo2cZ6l6RyY5+y/d1Muel9sQIyN8+lOA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-1.2.0.tgz",
+      "integrity": "sha512-3T4sgbzfZgsqvxqrA2QRnmF96apT7ZRHpDOfkI57ZOHouUD2co8bBO0SZpWw2N9T176G406Wl07PmF/SStG0Eg==",
       "license": "MIT",
       "peerDependencies": {
         "chart.js": ">=3.0.0"

--- a/src/Modules/CrestApps.OrchardCore.Resources/package.json
+++ b/src/Modules/CrestApps.OrchardCore.Resources/package.json
@@ -9,7 +9,7 @@
     "marked": "^18.0.5"
   },
   "dependencies": {
-    "@crestapps/ai-chat-ui": "1.0.0-preview.109",
+    "@crestapps/ai-chat-ui": "1.2.0",
     "@crestapps/bootstrap-select": "1.2.1",
     "chart.js": "^4.5.1",
     "intl-tel-input": "29.1.0"


### PR DESCRIPTION
## Summary
- Update @crestapps/ai-chat-ui package references from 1.0.0-preview.109 to 1.2.0.
- Update CDN URLs and resource versions for AI Chat, Chat Interactions, and shared Resources assets.
- Update the 3.0.0 release notes.

## Validation
- npm run rebuild
- npm run build --prefix src/CrestApps.Docs
- dotnet build src/Modules/CrestApps.OrchardCore.AI.Chat/CrestApps.OrchardCore.AI.Chat.csproj -c Release -warnaserror /p:TreatWarningsAsErrors=true /p:RunAnalyzers=true /p:NuGetAudit=false
- dotnet build src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/CrestApps.OrchardCore.AI.Chat.Interactions.csproj -c Release -warnaserror /p:TreatWarningsAsErrors=true /p:RunAnalyzers=true /p:NuGetAudit=false
- CDN/local SHA384 SRI validation for 16 AI chat UI asset pairs