### PR TITLE
Add CrestApps.OrchardCore.Taxation framework

### DIFF
--- a/CrestApps.OrchardCore.slnx
+++ b/CrestApps.OrchardCore.slnx
@@ -23,6 +23,7 @@
     <Project Path="src/Abstractions/CrestApps.OrchardCore.Payments.Abstractions/CrestApps.OrchardCore.Payments.Abstractions.csproj" />
     <Project Path="src/Abstractions/CrestApps.OrchardCore.Reports.Abstractions/CrestApps.OrchardCore.Reports.Abstractions.csproj" />
     <Project Path="src/Abstractions/CrestApps.OrchardCore.Subscriptions.Abstractions/CrestApps.OrchardCore.Subscriptions.Abstractions.csproj" />
+    <Project Path="src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/CrestApps.OrchardCore.Taxation.Abstractions.csproj" />
     <Project Path="src/Abstractions/CrestApps.OrchardCore.Telephony.Abstractions/CrestApps.OrchardCore.Telephony.Abstractions.csproj" />
     <Project Path="src/Abstractions/CrestApps.OrchardCore.Users.Abstractions/CrestApps.OrchardCore.Users.Abstractions.csproj" />
   </Folder>
@@ -42,6 +43,7 @@
     <Project Path="src/Core/CrestApps.OrchardCore.SignalR.Core/CrestApps.OrchardCore.SignalR.Core.csproj" />
     <Project Path="src/Core/CrestApps.OrchardCore.Stripe.Core/CrestApps.OrchardCore.Stripe.Core.csproj" />
     <Project Path="src/Core/CrestApps.OrchardCore.Subscriptions.Core/CrestApps.OrchardCore.Subscriptions.Core.csproj" />
+    <Project Path="src/Core/CrestApps.OrchardCore.Taxation.Core/CrestApps.OrchardCore.Taxation.Core.csproj" />
     <Project Path="src/Core/CrestApps.OrchardCore.Users.Core/CrestApps.OrchardCore.Users.Core.csproj" />
     <Project Path="src/Core/CrestApps.OrchardCore.YesSql.Core/CrestApps.OrchardCore.YesSql.Core.csproj" />
   </Folder>
@@ -96,6 +98,7 @@
     <Project Path="src/Modules/CrestApps.OrchardCore.SignalR/CrestApps.OrchardCore.SignalR.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.Stripe/CrestApps.OrchardCore.Stripe.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.Subscriptions/CrestApps.OrchardCore.Subscriptions.csproj" />
+    <Project Path="src/Modules/CrestApps.OrchardCore.Taxation/CrestApps.OrchardCore.Taxation.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.Telephony/CrestApps.OrchardCore.Telephony.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.TimeZones/CrestApps.OrchardCore.TimeZones.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.Users/CrestApps.OrchardCore.Users.csproj" />

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/CrestApps.OrchardCore.Taxation.Abstractions.csproj
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/CrestApps.OrchardCore.Taxation.Abstractions.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Abstractions",""))</RootNamespace>
+    <Title>CrestApps OrchardCore Taxation Abstractions</Title>
+    <Description>
+      $(OCCMSDescription)
+
+      Provider-agnostic abstractions for the CrestApps taxation framework.
+    </Description>
+    <PackageTags>$(PackageTags) CrestApps OrchardCoreCMS Taxation Abstractions</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CrestApps.Core.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/CustomerTaxProfile.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/CustomerTaxProfile.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Describes the tax status of a customer participating in a transaction.
+/// </summary>
+public sealed class CustomerTaxProfile
+{
+    /// <summary>
+    /// Gets or sets the identifier of the customer.
+    /// </summary>
+    public string CustomerId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax classification of the customer.
+    /// </summary>
+    public CustomerTaxType CustomerType { get; set; } = CustomerTaxType.B2C;
+
+    /// <summary>
+    /// Gets or sets the general tax registration number of the customer.
+    /// </summary>
+    public string TaxRegistrationNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the VAT number of the customer.
+    /// </summary>
+    public string VatNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the customer is tax exempt.
+    /// </summary>
+    public bool IsTaxExempt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifiers of the exemption certificates that belong to the customer.
+    /// </summary>
+    public IList<string> ExemptionCertificateIds { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the residential address of the customer.
+    /// </summary>
+    public TaxAddress ResidenceAddress { get; set; }
+
+    /// <summary>
+    /// Gets or sets the business address of the customer.
+    /// </summary>
+    public TaxAddress BusinessAddress { get; set; }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/CustomerTaxType.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/CustomerTaxType.cs
@@ -1,0 +1,17 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Classifies a customer for taxation purposes.
+/// </summary>
+public enum CustomerTaxType
+{
+    /// <summary>
+    /// A business-to-consumer customer.
+    /// </summary>
+    B2C,
+
+    /// <summary>
+    /// A business-to-business customer.
+    /// </summary>
+    B2B,
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/ExemptionCertificate.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/ExemptionCertificate.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CrestApps.Core;
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents an exemption certificate that removes a customer's obligation to be charged a tax for a
+/// set of jurisdictions, tax types, and classifications.
+/// </summary>
+public sealed class ExemptionCertificate : CatalogItem, INameAwareModel, IModifiedUtcAwareModel, ICloneable<ExemptionCertificate>
+{
+    /// <inheritdoc />
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the certificate number.
+    /// </summary>
+    public string CertificateNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the customer the certificate belongs to.
+    /// </summary>
+    public string CustomerId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exemption type (for example <c>Resale</c> or <c>Government</c>).
+    /// </summary>
+    public string ExemptionType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the status of the certificate.
+    /// </summary>
+    public ExemptionStatus Status { get; set; } = ExemptionStatus.Active;
+
+    /// <summary>
+    /// Gets or sets the UTC date the certificate becomes effective.
+    /// </summary>
+    public DateTime? EffectiveFromUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date the certificate expires.
+    /// </summary>
+    public DateTime? ExpirationUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax types the certificate exempts. An empty collection exempts every tax type.
+    /// </summary>
+    public IList<string> TaxTypes { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the jurisdiction identifiers the certificate applies to. An empty collection
+    /// applies to every jurisdiction.
+    /// </summary>
+    public IList<string> JurisdictionIds { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the classification codes the certificate applies to. An empty collection applies to
+    /// every classification.
+    /// </summary>
+    public IList<string> ClassificationCodes { get; set; } = [];
+
+    /// <inheritdoc />
+    public DateTime? ModifiedUtc { get; set; }
+
+    /// <inheritdoc />
+    public ExemptionCertificate Clone()
+    {
+        return new ExemptionCertificate
+        {
+            ItemId = ItemId,
+            Name = Name,
+            CertificateNumber = CertificateNumber,
+            CustomerId = CustomerId,
+            ExemptionType = ExemptionType,
+            Status = Status,
+            EffectiveFromUtc = EffectiveFromUtc,
+            ExpirationUtc = ExpirationUtc,
+            TaxTypes = TaxTypes.ToList(),
+            JurisdictionIds = JurisdictionIds.ToList(),
+            ClassificationCodes = ClassificationCodes.ToList(),
+            ModifiedUtc = ModifiedUtc,
+        };
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/ExemptionStatus.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/ExemptionStatus.cs
@@ -1,0 +1,27 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents the lifecycle status of an exemption certificate.
+/// </summary>
+public enum ExemptionStatus
+{
+    /// <summary>
+    /// The certificate is pending review and is not yet effective.
+    /// </summary>
+    Pending,
+
+    /// <summary>
+    /// The certificate is active and can be applied.
+    /// </summary>
+    Active,
+
+    /// <summary>
+    /// The certificate has expired.
+    /// </summary>
+    Expired,
+
+    /// <summary>
+    /// The certificate has been revoked.
+    /// </summary>
+    Revoked,
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/ITaxableItem.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/ITaxableItem.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents anything that can be taxed. Implementations are provided by taxable-item providers so
+/// that products, subscriptions, bookings, services, content items, and custom objects can all
+/// participate in taxation through a single abstraction.
+/// </summary>
+public interface ITaxableItem
+{
+    /// <summary>
+    /// Gets the stable identifier of the taxable item within the transaction.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Gets the kind of taxable item.
+    /// </summary>
+    TaxableItemKind Kind { get; }
+
+    /// <summary>
+    /// Gets the quantity being taxed.
+    /// </summary>
+    decimal Quantity { get; }
+
+    /// <summary>
+    /// Gets the price of a single unit, before any discount.
+    /// </summary>
+    decimal UnitPrice { get; }
+
+    /// <summary>
+    /// Gets the discount applied to the line, expressed in the same currency as <see cref="UnitPrice"/>.
+    /// </summary>
+    decimal DiscountAmount { get; }
+
+    /// <summary>
+    /// Gets the currency code the amounts are expressed in.
+    /// </summary>
+    string Currency { get; }
+
+    /// <summary>
+    /// Gets the tax category code (for example <c>Electronics</c>) used to classify the item.
+    /// </summary>
+    string TaxCategoryCode { get; }
+
+    /// <summary>
+    /// Gets the tax classification code (for example <c>Television</c>) that refines the category.
+    /// </summary>
+    string TaxClassificationCode { get; }
+
+    /// <summary>
+    /// Gets an optional external or provider-specific tax code.
+    /// </summary>
+    string ExternalTaxCode { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the amounts already include tax.
+    /// </summary>
+    bool? PriceIncludesTax { get; }
+
+    /// <summary>
+    /// Gets the total weight of the line, used by per-weight calculation methods.
+    /// </summary>
+    decimal? Weight { get; }
+
+    /// <summary>
+    /// Gets the total volume of the line, used by per-volume calculation methods.
+    /// </summary>
+    decimal? Volume { get; }
+
+    /// <summary>
+    /// Gets the origin (ship-from) address of the item, when it differs from the transaction origin.
+    /// </summary>
+    TaxAddress Origin { get; }
+
+    /// <summary>
+    /// Gets optional metadata that providers can attach for rule evaluation.
+    /// </summary>
+    IReadOnlyDictionary<string, string> Metadata { get; }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/JurisdictionLevel.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/JurisdictionLevel.cs
@@ -1,0 +1,48 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Identifies the administrative level of a tax jurisdiction. The hierarchy is intentionally open so
+/// that jurisdictions in different countries can model different levels.
+/// </summary>
+public enum JurisdictionLevel
+{
+    /// <summary>
+    /// A country level jurisdiction.
+    /// </summary>
+    Country,
+
+    /// <summary>
+    /// A state jurisdiction.
+    /// </summary>
+    State,
+
+    /// <summary>
+    /// A province jurisdiction.
+    /// </summary>
+    Province,
+
+    /// <summary>
+    /// A region jurisdiction.
+    /// </summary>
+    Region,
+
+    /// <summary>
+    /// A county jurisdiction.
+    /// </summary>
+    County,
+
+    /// <summary>
+    /// A city jurisdiction.
+    /// </summary>
+    City,
+
+    /// <summary>
+    /// A special or district jurisdiction (for example a transit district).
+    /// </summary>
+    Special,
+
+    /// <summary>
+    /// Any other jurisdiction level not covered by the well-known values.
+    /// </summary>
+    Other,
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/MerchantTaxRegistration.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/MerchantTaxRegistration.cs
@@ -1,0 +1,72 @@
+using System;
+using CrestApps.Core;
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents the merchant's registration (nexus) in a jurisdiction for a tax type. A jurisdiction
+/// levying a tax is not enough; the merchant must be registered to be obligated to collect it.
+/// </summary>
+public sealed class MerchantTaxRegistration : CatalogItem, INameAwareModel, IModifiedUtcAwareModel, ICloneable<MerchantTaxRegistration>
+{
+    /// <inheritdoc />
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the jurisdiction the merchant is registered in.
+    /// </summary>
+    public string JurisdictionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax type the registration covers.
+    /// </summary>
+    public string TaxType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the registration number issued by the jurisdiction.
+    /// </summary>
+    public string RegistrationNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the registration is active.
+    /// </summary>
+    public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the UTC date the registration was granted.
+    /// </summary>
+    public DateTime? RegistrationDateUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date the registration becomes effective.
+    /// </summary>
+    public DateTime? EffectiveFromUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date the registration stops being effective.
+    /// </summary>
+    public DateTime? EffectiveToUtc { get; set; }
+
+    /// <inheritdoc />
+    public DateTime? ModifiedUtc { get; set; }
+
+    /// <inheritdoc />
+    public MerchantTaxRegistration Clone()
+    {
+        return new MerchantTaxRegistration
+        {
+            ItemId = ItemId,
+            Name = Name,
+            JurisdictionId = JurisdictionId,
+            TaxType = TaxType,
+            RegistrationNumber = RegistrationNumber,
+            IsActive = IsActive,
+            RegistrationDateUtc = RegistrationDateUtc,
+            EffectiveFromUtc = EffectiveFromUtc,
+            EffectiveToUtc = EffectiveToUtc,
+            ModifiedUtc = ModifiedUtc,
+        };
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxAddress.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxAddress.cs
@@ -1,0 +1,55 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents a location used to determine the applicable tax jurisdictions. No particular hierarchy
+/// is assumed; empty components are simply ignored during jurisdiction resolution.
+/// </summary>
+public sealed class TaxAddress
+{
+    /// <summary>
+    /// Gets or sets the ISO country code (for example <c>US</c> or <c>CA</c>).
+    /// </summary>
+    public string Country { get; set; }
+
+    /// <summary>
+    /// Gets or sets the state, province, or region code.
+    /// </summary>
+    public string Region { get; set; }
+
+    /// <summary>
+    /// Gets or sets the county name or code.
+    /// </summary>
+    public string County { get; set; }
+
+    /// <summary>
+    /// Gets or sets the city name.
+    /// </summary>
+    public string City { get; set; }
+
+    /// <summary>
+    /// Gets or sets the special or tax district identifier.
+    /// </summary>
+    public string District { get; set; }
+
+    /// <summary>
+    /// Gets or sets the postal or ZIP code.
+    /// </summary>
+    public string PostalCode { get; set; }
+
+    /// <summary>
+    /// Creates a shallow copy of the current address.
+    /// </summary>
+    /// <returns>A new <see cref="TaxAddress"/> with the same values.</returns>
+    public TaxAddress Clone()
+    {
+        return new TaxAddress
+        {
+            Country = Country,
+            Region = Region,
+            County = County,
+            City = City,
+            District = District,
+            PostalCode = PostalCode,
+        };
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxCalculationContext.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxCalculationContext.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Carries everything required to deterministically calculate tax for a transaction.
+/// </summary>
+public sealed class TaxCalculationContext
+{
+    /// <summary>
+    /// Gets or sets the taxable items participating in the transaction.
+    /// </summary>
+    public IList<ITaxableItem> Items { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the customer tax profile, when a customer is known.
+    /// </summary>
+    public CustomerTaxProfile Customer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the origin (ship-from / merchant) address.
+    /// </summary>
+    public TaxAddress Origin { get; set; }
+
+    /// <summary>
+    /// Gets or sets the destination (ship-to) address.
+    /// </summary>
+    public TaxAddress Destination { get; set; }
+
+    /// <summary>
+    /// Gets or sets the location where a service is performed.
+    /// </summary>
+    public TaxAddress ServiceLocation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the location where an event takes place.
+    /// </summary>
+    public TaxAddress EventLocation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the transaction date, in UTC, used to select effective rules and tables.
+    /// </summary>
+    public DateTime TransactionDateUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the currency the transaction is expressed in.
+    /// </summary>
+    public string Currency { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether amounts, by default, already include tax.
+    /// Individual items may override this through <see cref="ITaxableItem.PriceIncludesTax"/>.
+    /// </summary>
+    public TaxPriceType DefaultPriceType { get; set; } = TaxPriceType.Exclusive;
+
+    /// <summary>
+    /// Gets or sets an optional override for the rounding level of the calculation.
+    /// </summary>
+    public TaxRoundingLevel? RoundingLevel { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional metadata for the transaction that rules may evaluate.
+    /// </summary>
+    public IDictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxCalculationResult.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxCalculationResult.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents the detailed outcome of a tax calculation.
+/// </summary>
+public sealed class TaxCalculationResult
+{
+    /// <summary>
+    /// Gets or sets the currency the amounts are expressed in.
+    /// </summary>
+    public string Currency { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total taxable base across all lines.
+    /// </summary>
+    public decimal TaxableAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total tax across all lines.
+    /// </summary>
+    public decimal TaxAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total amount, including tax that is not already included in the price.
+    /// </summary>
+    public decimal TotalAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the individual tax lines that explain the determination.
+    /// </summary>
+    public IList<TaxLine> Lines { get; set; } = [];
+
+    /// <summary>
+    /// Gets the tax lines that apply to the specified taxable item.
+    /// </summary>
+    /// <param name="itemId">The identifier of the taxable item.</param>
+    /// <returns>The tax lines produced for the item.</returns>
+    public IEnumerable<TaxLine> GetLinesForItem(string itemId)
+        => Lines.Where(line => line.ItemId == itemId);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxCategory.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxCategory.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using CrestApps.Core;
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents a tax category or classification. Categories form an open hierarchy through
+/// <see cref="ParentCode"/> and are independent of the underlying object type. External codes map
+/// the category to provider-specific tax systems.
+/// </summary>
+public sealed class TaxCategory : CatalogItem, INameAwareModel, IModifiedUtcAwareModel, ICloneable<TaxCategory>
+{
+    /// <inheritdoc />
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unique code of the category (for example <c>Electronics</c> or <c>Television</c>).
+    /// </summary>
+    public string Code { get; set; }
+
+    /// <summary>
+    /// Gets or sets the code of the parent category, forming a hierarchy.
+    /// </summary>
+    public string ParentCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a description of the category.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the external, provider-specific tax codes keyed by provider name.
+    /// </summary>
+    public IDictionary<string, string> ExternalCodes { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public DateTime? ModifiedUtc { get; set; }
+
+    /// <inheritdoc />
+    public TaxCategory Clone()
+    {
+        return new TaxCategory
+        {
+            ItemId = ItemId,
+            Name = Name,
+            Code = Code,
+            ParentCode = ParentCode,
+            Description = Description,
+            ExternalCodes = new Dictionary<string, string>(ExternalCodes, StringComparer.OrdinalIgnoreCase),
+            ModifiedUtc = ModifiedUtc,
+        };
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxComputationRequest.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxComputationRequest.cs
@@ -1,0 +1,48 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// The input passed to an <see cref="Services.ITaxCalculationMethod"/> to compute a single tax amount.
+/// </summary>
+public sealed class TaxComputationRequest
+{
+    /// <summary>
+    /// Gets or sets the taxable base the tax is calculated on. For compound taxes this base already
+    /// includes previously calculated taxes.
+    /// </summary>
+    public decimal TaxableBase { get; set; }
+
+    /// <summary>
+    /// Gets or sets the quantity of the taxable item.
+    /// </summary>
+    public decimal Quantity { get; set; } = 1m;
+
+    /// <summary>
+    /// Gets or sets the total weight of the taxable item, when available.
+    /// </summary>
+    public decimal? Weight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total volume of the taxable item, when available.
+    /// </summary>
+    public decimal? Volume { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rate configured on the rule, expressed as a fraction (for example <c>0.2</c> for 20%).
+    /// </summary>
+    public decimal? Rate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fixed amount configured on the rule, when applicable.
+    /// </summary>
+    public decimal? FixedAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax table used by table-driven methods, when applicable.
+    /// </summary>
+    public TaxTable Table { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the taxable base already includes this tax.
+    /// </summary>
+    public bool PriceIncludesTax { get; set; }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxComputationResult.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxComputationResult.cs
@@ -1,0 +1,23 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// The output produced by an <see cref="Services.ITaxCalculationMethod"/>.
+/// </summary>
+public sealed class TaxComputationResult
+{
+    /// <summary>
+    /// Gets or sets the taxable base the tax was effectively calculated on. For tax-inclusive pricing
+    /// this may differ from the requested base because the tax is extracted from it.
+    /// </summary>
+    public decimal TaxableAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the calculated tax amount.
+    /// </summary>
+    public decimal TaxAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the effective rate that was applied, when the method is rate based.
+    /// </summary>
+    public decimal EffectiveRate { get; set; }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxJurisdiction.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxJurisdiction.cs
@@ -1,0 +1,90 @@
+using System;
+using CrestApps.Core;
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents a tax jurisdiction. Jurisdictions form an open hierarchy through
+/// <see cref="ParentId"/> so that different countries can model different levels.
+/// </summary>
+public sealed class TaxJurisdiction : CatalogItem, INameAwareModel, IModifiedUtcAwareModel, ICloneable<TaxJurisdiction>
+{
+    /// <inheritdoc />
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the code of the jurisdiction.
+    /// </summary>
+    public string Code { get; set; }
+
+    /// <summary>
+    /// Gets or sets the administrative level of the jurisdiction.
+    /// </summary>
+    public JurisdictionLevel Level { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ISO country code the jurisdiction belongs to.
+    /// </summary>
+    public string Country { get; set; }
+
+    /// <summary>
+    /// Gets or sets the state, province, or region code the jurisdiction belongs to.
+    /// </summary>
+    public string Region { get; set; }
+
+    /// <summary>
+    /// Gets or sets the county the jurisdiction belongs to.
+    /// </summary>
+    public string County { get; set; }
+
+    /// <summary>
+    /// Gets or sets the city the jurisdiction belongs to.
+    /// </summary>
+    public string City { get; set; }
+
+    /// <summary>
+    /// Gets or sets the postal code the jurisdiction covers.
+    /// </summary>
+    public string PostalCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the parent jurisdiction, forming a hierarchy.
+    /// </summary>
+    public string ParentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date the jurisdiction becomes effective.
+    /// </summary>
+    public DateTime? EffectiveFromUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date the jurisdiction stops being effective.
+    /// </summary>
+    public DateTime? EffectiveToUtc { get; set; }
+
+    /// <inheritdoc />
+    public DateTime? ModifiedUtc { get; set; }
+
+    /// <inheritdoc />
+    public TaxJurisdiction Clone()
+    {
+        return new TaxJurisdiction
+        {
+            ItemId = ItemId,
+            Name = Name,
+            Code = Code,
+            Level = Level,
+            Country = Country,
+            Region = Region,
+            County = County,
+            City = City,
+            PostalCode = PostalCode,
+            ParentId = ParentId,
+            EffectiveFromUtc = EffectiveFromUtc,
+            EffectiveToUtc = EffectiveToUtc,
+            ModifiedUtc = ModifiedUtc,
+        };
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxLine.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxLine.cs
@@ -1,0 +1,87 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents a single applied tax and explains how it was determined and calculated.
+/// </summary>
+public sealed class TaxLine
+{
+    /// <summary>
+    /// Gets or sets the identifier of the taxable item this line applies to.
+    /// </summary>
+    public string ItemId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the code of the applied tax.
+    /// </summary>
+    public string TaxCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the human readable name of the applied tax.
+    /// </summary>
+    public string TaxName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of the applied tax.
+    /// </summary>
+    public string TaxType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the jurisdiction that levied the tax.
+    /// </summary>
+    public string JurisdictionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the jurisdiction that levied the tax.
+    /// </summary>
+    public string JurisdictionName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the effective rate that was applied, when the method is rate based.
+    /// </summary>
+    public decimal Rate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the taxable base the tax was calculated on.
+    /// </summary>
+    public decimal TaxableAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the calculated tax amount.
+    /// </summary>
+    public decimal TaxAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the calculation method that produced the amount.
+    /// </summary>
+    public string CalculationMethod { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the tax was included in the item price.
+    /// </summary>
+    public bool IncludedInPrice { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the tax is compound (calculated on top of other taxes).
+    /// </summary>
+    public bool IsCompound { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the rule that produced the line.
+    /// </summary>
+    public string RuleId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version of the rule that produced the line.
+    /// </summary>
+    public int RuleVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the tax table used, when applicable.
+    /// </summary>
+    public string TableId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version of the tax table used, when applicable.
+    /// </summary>
+    public int TableVersion { get; set; }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxPriceType.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxPriceType.cs
@@ -1,0 +1,17 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Indicates whether an amount already includes tax or excludes it.
+/// </summary>
+public enum TaxPriceType
+{
+    /// <summary>
+    /// The amount excludes tax; tax is added on top of the amount.
+    /// </summary>
+    Exclusive,
+
+    /// <summary>
+    /// The amount already includes tax; tax is extracted from the amount.
+    /// </summary>
+    Inclusive,
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxRoundingLevel.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxRoundingLevel.cs
@@ -1,0 +1,27 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Determines the level at which tax amounts are rounded during a calculation.
+/// </summary>
+public enum TaxRoundingLevel
+{
+    /// <summary>
+    /// Round every tax line independently.
+    /// </summary>
+    Line,
+
+    /// <summary>
+    /// Round the accumulated amount for each tax type.
+    /// </summary>
+    Tax,
+
+    /// <summary>
+    /// Round the accumulated amount for each jurisdiction.
+    /// </summary>
+    Jurisdiction,
+
+    /// <summary>
+    /// Round only the final transaction total.
+    /// </summary>
+    Transaction,
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxRule.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxRule.cs
@@ -1,0 +1,154 @@
+using System;
+using CrestApps.Core;
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Determines whether and how a tax applies. A rule combines the jurisdiction, tax type, classification,
+/// customer criteria, and a calculation method. Rules are versioned and carry effective dates so that
+/// historical determinations remain reproducible.
+/// </summary>
+public sealed class TaxRule : CatalogItem, INameAwareModel, IModifiedUtcAwareModel, ICloneable<TaxRule>
+{
+    /// <inheritdoc />
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version of the rule. The version is captured on tax lines so historical
+    /// transactions can be reproduced even after the rule is changed.
+    /// </summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the rule is enabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the priority of the rule. Lower values are evaluated first.
+    /// </summary>
+    public int Priority { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of tax the rule produces.
+    /// </summary>
+    public string TaxType { get; set; } = TaxTypeNames.SalesTax;
+
+    /// <summary>
+    /// Gets or sets the human readable name of the tax the rule produces.
+    /// </summary>
+    public string TaxName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the code of the tax the rule produces.
+    /// </summary>
+    public string TaxCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the jurisdiction the rule belongs to.
+    /// </summary>
+    public string JurisdictionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax category code the rule applies to. A <see langword="null"/> value matches
+    /// every category.
+    /// </summary>
+    public string CategoryCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the customer classification the rule applies to. A <see langword="null"/> value
+    /// matches every customer type.
+    /// </summary>
+    public CustomerTaxType? CustomerType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the calculation method used by the rule.
+    /// </summary>
+    public string CalculationMethod { get; set; } = TaxCalculationMethodNames.Percentage;
+
+    /// <summary>
+    /// Gets or sets the rate applied by the rule, expressed as a fraction (for example <c>0.2</c> for 20%).
+    /// </summary>
+    public decimal? Rate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fixed amount applied by the rule, when the method is amount based.
+    /// </summary>
+    public decimal? FixedAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the tax table the rule uses, when the method is table based.
+    /// </summary>
+    public string TaxTableId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the produced tax is included in the item price.
+    /// </summary>
+    public bool IncludedInPrice { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the produced tax is compound (calculated on top of other taxes).
+    /// </summary>
+    public bool IsCompound { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the rule applies to shipping charges.
+    /// </summary>
+    public bool AppliesToShipping { get; set; }
+
+    /// <summary>
+    /// Gets or sets the inclusive minimum taxable amount the rule applies to.
+    /// </summary>
+    public decimal? MinimumAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exclusive maximum taxable amount the rule applies to.
+    /// </summary>
+    public decimal? MaximumAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date the rule becomes effective.
+    /// </summary>
+    public DateTime? EffectiveFromUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date the rule stops being effective.
+    /// </summary>
+    public DateTime? EffectiveToUtc { get; set; }
+
+    /// <inheritdoc />
+    public DateTime? ModifiedUtc { get; set; }
+
+    /// <inheritdoc />
+    public TaxRule Clone()
+    {
+        return new TaxRule
+        {
+            ItemId = ItemId,
+            Name = Name,
+            Version = Version,
+            Enabled = Enabled,
+            Priority = Priority,
+            TaxType = TaxType,
+            TaxName = TaxName,
+            TaxCode = TaxCode,
+            JurisdictionId = JurisdictionId,
+            CategoryCode = CategoryCode,
+            CustomerType = CustomerType,
+            CalculationMethod = CalculationMethod,
+            Rate = Rate,
+            FixedAmount = FixedAmount,
+            TaxTableId = TaxTableId,
+            IncludedInPrice = IncludedInPrice,
+            IsCompound = IsCompound,
+            AppliesToShipping = AppliesToShipping,
+            MinimumAmount = MinimumAmount,
+            MaximumAmount = MaximumAmount,
+            EffectiveFromUtc = EffectiveFromUtc,
+            EffectiveToUtc = EffectiveToUtc,
+            ModifiedUtc = ModifiedUtc,
+        };
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxRuleQuery.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxRuleQuery.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Describes the criteria used to resolve applicable tax rules for a taxable item.
+/// </summary>
+public sealed class TaxRuleQuery
+{
+    /// <summary>
+    /// Gets or sets the identifiers of the jurisdictions to resolve rules for.
+    /// </summary>
+    public IReadOnlyCollection<string> JurisdictionIds { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the tax category code of the taxable item.
+    /// </summary>
+    public string CategoryCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax classification code of the taxable item, which refines the category.
+    /// </summary>
+    public string ClassificationCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the customer classification, when a customer is known.
+    /// </summary>
+    public CustomerTaxType? CustomerType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the transaction date, in UTC, used to select effective rules.
+    /// </summary>
+    public DateTime TransactionDateUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the taxable item is a shipping charge.
+    /// </summary>
+    public bool IsShipping { get; set; }
+
+    /// <summary>
+    /// Gets or sets the taxable base of the item, used to evaluate amount thresholds.
+    /// </summary>
+    public decimal TaxableAmount { get; set; }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxSnapshot.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxSnapshot.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// An immutable capture of a tax determination that is stored with a transaction. A snapshot lets the
+/// system reproduce and audit the original tax without recalculating it with current rules.
+/// </summary>
+public sealed class TaxSnapshot
+{
+    /// <summary>
+    /// Gets or sets the UTC date the snapshot was created.
+    /// </summary>
+    public DateTime CreatedUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the transaction date, in UTC, used when the tax was determined.
+    /// </summary>
+    public DateTime TransactionDateUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the currency the amounts are expressed in.
+    /// </summary>
+    public string Currency { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total taxable base captured at determination time.
+    /// </summary>
+    public decimal TaxableAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total tax captured at determination time.
+    /// </summary>
+    public decimal TaxAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total amount captured at determination time.
+    /// </summary>
+    public decimal TotalAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax lines captured at determination time.
+    /// </summary>
+    public IList<TaxLine> Lines { get; set; } = [];
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxTable.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxTable.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CrestApps.Core;
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// A first-class, versioned tax table used by table-driven calculation methods to model brackets,
+/// progressive schedules, per-unit schedules, and lookup tables.
+/// </summary>
+public sealed class TaxTable : CatalogItem, INameAwareModel, IModifiedUtcAwareModel, ICloneable<TaxTable>
+{
+    /// <inheritdoc />
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version of the table. The version is captured on tax lines so historical
+    /// transactions can be reproduced.
+    /// </summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the UTC date the table becomes effective.
+    /// </summary>
+    public DateTime? EffectiveFromUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC date the table stops being effective.
+    /// </summary>
+    public DateTime? EffectiveToUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rows that make up the table.
+    /// </summary>
+    public IList<TaxTableRow> Rows { get; set; } = [];
+
+    /// <inheritdoc />
+    public DateTime? ModifiedUtc { get; set; }
+
+    /// <inheritdoc />
+    public TaxTable Clone()
+    {
+        return new TaxTable
+        {
+            ItemId = ItemId,
+            Name = Name,
+            Version = Version,
+            EffectiveFromUtc = EffectiveFromUtc,
+            EffectiveToUtc = EffectiveToUtc,
+            Rows = Rows.Select(row => row.Clone()).ToList(),
+            ModifiedUtc = ModifiedUtc,
+        };
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxTableRow.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxTableRow.cs
@@ -1,0 +1,50 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents a single row of a <see cref="TaxTable"/>. Rows are used to model brackets, per-unit
+/// schedules, and lookup tables. Not all fields apply to every calculation method.
+/// </summary>
+public sealed class TaxTableRow
+{
+    /// <summary>
+    /// Gets or sets the inclusive lower bound the row applies to.
+    /// </summary>
+    public decimal Minimum { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exclusive upper bound the row applies to. A <see langword="null"/> value means
+    /// the row has no upper bound.
+    /// </summary>
+    public decimal? Maximum { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rate applied within the row, expressed as a fraction.
+    /// </summary>
+    public decimal Rate { get; set; }
+
+    /// <summary>
+    /// Gets or sets a fixed amount applied within the row.
+    /// </summary>
+    public decimal FixedAmount { get; set; }
+
+    /// <summary>
+    /// Gets or sets a base amount that is added before the rate is applied, used by tiered schedules.
+    /// </summary>
+    public decimal BaseAmount { get; set; }
+
+    /// <summary>
+    /// Creates a copy of the current row.
+    /// </summary>
+    /// <returns>A new <see cref="TaxTableRow"/> with the same values.</returns>
+    public TaxTableRow Clone()
+    {
+        return new TaxTableRow
+        {
+            Minimum = Minimum,
+            Maximum = Maximum,
+            Rate = Rate,
+            FixedAmount = FixedAmount,
+            BaseAmount = BaseAmount,
+        };
+    }
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxableItem.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxableItem.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// A default, mutable <see cref="ITaxableItem"/> implementation that taxable-item providers can build
+/// and return.
+/// </summary>
+public sealed class TaxableItem : ITaxableItem
+{
+    /// <inheritdoc />
+    public string Id { get; set; }
+
+    /// <inheritdoc />
+    public TaxableItemKind Kind { get; set; } = TaxableItemKind.Physical;
+
+    /// <inheritdoc />
+    public decimal Quantity { get; set; } = 1m;
+
+    /// <inheritdoc />
+    public decimal UnitPrice { get; set; }
+
+    /// <inheritdoc />
+    public decimal DiscountAmount { get; set; }
+
+    /// <inheritdoc />
+    public string Currency { get; set; }
+
+    /// <inheritdoc />
+    public string TaxCategoryCode { get; set; }
+
+    /// <inheritdoc />
+    public string TaxClassificationCode { get; set; }
+
+    /// <inheritdoc />
+    public string ExternalTaxCode { get; set; }
+
+    /// <inheritdoc />
+    public bool? PriceIncludesTax { get; set; }
+
+    /// <inheritdoc />
+    public decimal? Weight { get; set; }
+
+    /// <inheritdoc />
+    public decimal? Volume { get; set; }
+
+    /// <inheritdoc />
+    public TaxAddress Origin { get; set; }
+
+    /// <summary>
+    /// Gets or sets the mutable metadata dictionary for the item.
+    /// </summary>
+    public Dictionary<string, string> Metadata { get; set; } = new(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    IReadOnlyDictionary<string, string> ITaxableItem.Metadata => Metadata;
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxableItemKind.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxableItemKind.cs
@@ -1,0 +1,43 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Classifies the nature of a taxable item so that the engine can apply the correct rules without
+/// being coupled to any particular commerce implementation.
+/// </summary>
+public enum TaxableItemKind
+{
+    /// <summary>
+    /// A physical good.
+    /// </summary>
+    Physical,
+
+    /// <summary>
+    /// A digital good or digital service.
+    /// </summary>
+    Digital,
+
+    /// <summary>
+    /// A service.
+    /// </summary>
+    Service,
+
+    /// <summary>
+    /// A booking or reservation.
+    /// </summary>
+    Booking,
+
+    /// <summary>
+    /// An event or ticket.
+    /// </summary>
+    Event,
+
+    /// <summary>
+    /// A shipping charge.
+    /// </summary>
+    Shipping,
+
+    /// <summary>
+    /// Any other charge that participates in taxation.
+    /// </summary>
+    OtherCharge,
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/IExemptionCertificateStore.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/IExemptionCertificateStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Defines the persistence contract for <see cref="ExemptionCertificate"/> entries.
+/// </summary>
+public interface IExemptionCertificateStore : ICatalog<ExemptionCertificate>
+{
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/IMerchantTaxRegistrationProvider.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/IMerchantTaxRegistrationProvider.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Determines whether the merchant has an obligation (nexus) to collect a tax in a jurisdiction.
+/// A jurisdiction levying a tax is not enough; the merchant must also be registered.
+/// </summary>
+public interface IMerchantTaxRegistrationProvider
+{
+    /// <summary>
+    /// Determines whether the merchant is registered to collect the tax type in the jurisdiction.
+    /// </summary>
+    /// <param name="jurisdictionId">The identifier of the jurisdiction.</param>
+    /// <param name="taxType">The tax type to check.</param>
+    /// <param name="onUtc">The UTC date used to filter active registrations.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns><see langword="true"/> when a nexus exists; otherwise <see langword="false"/>.</returns>
+    ValueTask<bool> HasNexusAsync(string jurisdictionId, string taxType, System.DateTime onUtc, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/IMerchantTaxRegistrationStore.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/IMerchantTaxRegistrationStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Defines the persistence contract for <see cref="MerchantTaxRegistration"/> entries.
+/// </summary>
+public interface IMerchantTaxRegistrationStore : ICatalog<MerchantTaxRegistration>
+{
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxCalculationMethod.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxCalculationMethod.cs
@@ -1,0 +1,23 @@
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Implements a single tax calculation strategy (for example percentage, fixed amount, or per unit).
+/// Calculation methods are resolved by <see cref="Name"/> so third parties can register additional
+/// strategies without modifying the framework.
+/// </summary>
+public interface ITaxCalculationMethod
+{
+    /// <summary>
+    /// Gets the unique name of the calculation method.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Computes a tax amount for the supplied request.
+    /// </summary>
+    /// <param name="request">The computation request describing the taxable base and configuration.</param>
+    /// <returns>The computed tax amount and effective rate.</returns>
+    TaxComputationResult Compute(TaxComputationRequest request);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxCalculationMethodProvider.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxCalculationMethodProvider.cs
@@ -1,0 +1,14 @@
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Resolves a registered <see cref="ITaxCalculationMethod"/> by name.
+/// </summary>
+public interface ITaxCalculationMethodProvider
+{
+    /// <summary>
+    /// Gets the calculation method registered under the supplied name.
+    /// </summary>
+    /// <param name="name">The name of the calculation method.</param>
+    /// <returns>The matching calculation method, or <see langword="null"/> when none is registered.</returns>
+    ITaxCalculationMethod GetMethod(string name);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxCategoryStore.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxCategoryStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Defines the persistence contract for <see cref="TaxCategory"/> entries.
+/// </summary>
+public interface ITaxCategoryStore : INamedCatalog<TaxCategory>
+{
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxDeterminationProvider.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxDeterminationProvider.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Provides an external tax determination (for example an integration with a third-party tax engine).
+/// When an enabled provider can handle a context it short-circuits the built-in determination, keeping
+/// the core engine provider-agnostic.
+/// </summary>
+public interface ITaxDeterminationProvider
+{
+    /// <summary>
+    /// Gets the priority of the provider. Lower values are evaluated first.
+    /// </summary>
+    int Order { get; }
+
+    /// <summary>
+    /// Determines whether the provider can handle the supplied context.
+    /// </summary>
+    /// <param name="context">The tax calculation context.</param>
+    /// <returns><see langword="true"/> when the provider can determine tax for the context.</returns>
+    bool CanHandle(TaxCalculationContext context);
+
+    /// <summary>
+    /// Determines the tax for the supplied context.
+    /// </summary>
+    /// <param name="context">The tax calculation context.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The determined <see cref="TaxCalculationResult"/>.</returns>
+    Task<TaxCalculationResult> DetermineAsync(TaxCalculationContext context, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxExemptionResolver.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxExemptionResolver.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Determines whether a customer is exempt from a tax for a given jurisdiction and classification.
+/// </summary>
+public interface ITaxExemptionResolver
+{
+    /// <summary>
+    /// Determines whether the customer is exempt from the tax described by the supplied rule.
+    /// </summary>
+    /// <param name="customer">The customer tax profile, when a customer is known.</param>
+    /// <param name="rule">The rule that would otherwise apply.</param>
+    /// <param name="onUtc">The UTC date used to filter effective certificates.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns><see langword="true"/> when the customer is exempt; otherwise <see langword="false"/>.</returns>
+    ValueTask<bool> IsExemptAsync(CustomerTaxProfile customer, TaxRule rule, System.DateTime onUtc, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxJurisdictionResolver.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxJurisdictionResolver.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Resolves the tax jurisdictions that apply to an address.
+/// </summary>
+public interface ITaxJurisdictionResolver
+{
+    /// <summary>
+    /// Resolves the jurisdictions that apply to the supplied address on the supplied date.
+    /// </summary>
+    /// <param name="address">The address to resolve jurisdictions for.</param>
+    /// <param name="onUtc">The UTC date used to filter effective jurisdictions.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The applicable jurisdictions.</returns>
+    ValueTask<IReadOnlyList<TaxJurisdiction>> ResolveAsync(TaxAddress address, System.DateTime onUtc, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxJurisdictionStore.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxJurisdictionStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Defines the persistence contract for <see cref="TaxJurisdiction"/> entries.
+/// </summary>
+public interface ITaxJurisdictionStore : INamedCatalog<TaxJurisdiction>
+{
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxRoundingStrategy.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxRoundingStrategy.cs
@@ -1,0 +1,15 @@
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Rounds tax amounts using an explicit policy so that results do not depend on incidental decimal behavior.
+/// </summary>
+public interface ITaxRoundingStrategy
+{
+    /// <summary>
+    /// Rounds the supplied value for the supplied currency.
+    /// </summary>
+    /// <param name="value">The value to round.</param>
+    /// <param name="currency">The currency the value is expressed in.</param>
+    /// <returns>The rounded value.</returns>
+    decimal Round(decimal value, string currency);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxRuleProvider.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxRuleProvider.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Resolves the tax rules that apply to a taxable item. The default implementation is backed by the
+/// rule catalog, but third parties can supply their own resolution.
+/// </summary>
+public interface ITaxRuleProvider
+{
+    /// <summary>
+    /// Gets the applicable rules for the supplied query, ordered deterministically.
+    /// </summary>
+    /// <param name="query">The criteria used to resolve rules.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The applicable rules.</returns>
+    ValueTask<IReadOnlyList<TaxRule>> GetApplicableRulesAsync(TaxRuleQuery query, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxRuleStore.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxRuleStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Defines the persistence contract for <see cref="TaxRule"/> entries.
+/// </summary>
+public interface ITaxRuleStore : INamedCatalog<TaxRule>
+{
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxService.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxService.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// The primary entry point for calculating tax. Implementations orchestrate sourcing, jurisdiction
+/// resolution, rule resolution, exemptions, nexus, and calculation to return a deterministic breakdown.
+/// </summary>
+public interface ITaxService
+{
+    /// <summary>
+    /// Calculates the tax for the supplied context.
+    /// </summary>
+    /// <param name="context">The context that describes what, who, where, when, and how to tax.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A detailed <see cref="TaxCalculationResult"/> explaining the determination.</returns>
+    Task<TaxCalculationResult> CalculateAsync(TaxCalculationContext context, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxSnapshotFactory.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxSnapshotFactory.cs
@@ -1,0 +1,18 @@
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Creates an immutable <see cref="TaxSnapshot"/> from a tax determination so that it can be stored
+/// with a transaction and reproduced later.
+/// </summary>
+public interface ITaxSnapshotFactory
+{
+    /// <summary>
+    /// Creates a snapshot from the supplied calculation result and context.
+    /// </summary>
+    /// <param name="context">The context the tax was determined from.</param>
+    /// <param name="result">The calculation result to capture.</param>
+    /// <returns>The created snapshot.</returns>
+    TaxSnapshot Create(TaxCalculationContext context, TaxCalculationResult result);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxSourcingStrategy.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxSourcingStrategy.cs
@@ -1,0 +1,23 @@
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Determines which address is used to resolve the applicable jurisdictions for a taxable item.
+/// Strategies are resolved by <see cref="Name"/>.
+/// </summary>
+public interface ITaxSourcingStrategy
+{
+    /// <summary>
+    /// Gets the unique name of the sourcing strategy.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Resolves the address that should be used to source tax for the supplied item.
+    /// </summary>
+    /// <param name="context">The tax calculation context.</param>
+    /// <param name="item">The taxable item being sourced.</param>
+    /// <returns>The address used for jurisdiction resolution, or <see langword="null"/> when unavailable.</returns>
+    TaxAddress Resolve(TaxCalculationContext context, ITaxableItem item);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxSourcingStrategyProvider.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxSourcingStrategyProvider.cs
@@ -1,0 +1,14 @@
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Resolves a registered <see cref="ITaxSourcingStrategy"/> by name.
+/// </summary>
+public interface ITaxSourcingStrategyProvider
+{
+    /// <summary>
+    /// Gets the sourcing strategy registered under the supplied name.
+    /// </summary>
+    /// <param name="name">The name of the sourcing strategy.</param>
+    /// <returns>The matching sourcing strategy, or <see langword="null"/> when none is registered.</returns>
+    ITaxSourcingStrategy GetStrategy(string name);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxTableStore.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxTableStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Defines the persistence contract for <see cref="TaxTable"/> entries.
+/// </summary>
+public interface ITaxTableStore : INamedCatalog<TaxTable>
+{
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxableBaseCalculator.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxableBaseCalculator.cs
@@ -1,0 +1,17 @@
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Computes the taxable base for a taxable item, taking discounts and other charges into account.
+/// </summary>
+public interface ITaxableBaseCalculator
+{
+    /// <summary>
+    /// Computes the net taxable base for the supplied item, before any tax is applied.
+    /// </summary>
+    /// <param name="item">The taxable item.</param>
+    /// <param name="context">The tax calculation context.</param>
+    /// <returns>The net taxable base.</returns>
+    decimal GetTaxableBase(ITaxableItem item, TaxCalculationContext context);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxableItemProvider.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxableItemProvider.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Converts an arbitrary object into an <see cref="ITaxableItem"/>. Third-party modules register their
+/// own providers so that products, subscriptions, bookings, content items, and custom objects can all
+/// participate in taxation without modifying the framework.
+/// </summary>
+public interface ITaxableItemProvider
+{
+    /// <summary>
+    /// Gets the priority of the provider. Lower values are evaluated first.
+    /// </summary>
+    int Order { get; }
+
+    /// <summary>
+    /// Determines whether the provider can convert the supplied source object.
+    /// </summary>
+    /// <param name="source">The source object to convert.</param>
+    /// <returns><see langword="true"/> when the provider can convert the source.</returns>
+    bool CanCreate(object source);
+
+    /// <summary>
+    /// Creates a taxable item from the supplied source object.
+    /// </summary>
+    /// <param name="source">The source object to convert.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The created taxable item, or <see langword="null"/> when the source cannot be converted.</returns>
+    ValueTask<ITaxableItem> CreateAsync(object source, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxableItemResolver.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Services/ITaxableItemResolver.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Resolves taxable items from arbitrary source objects by delegating to the registered
+/// <see cref="ITaxableItemProvider"/> instances.
+/// </summary>
+public interface ITaxableItemResolver
+{
+    /// <summary>
+    /// Resolves a taxable item from the supplied source object.
+    /// </summary>
+    /// <param name="source">The source object to convert.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The resolved taxable item, or <see langword="null"/> when no provider can convert the source.</returns>
+    ValueTask<ITaxableItem> ResolveAsync(object source, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/TaxCalculationMethodNames.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/TaxCalculationMethodNames.cs
@@ -1,0 +1,51 @@
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Provides the well-known, extensible tax calculation method identifiers.
+/// </summary>
+/// <remarks>
+/// Calculation methods are resolved by name so that third-party modules can register additional
+/// strategies without modifying the taxation framework.
+/// </remarks>
+public static class TaxCalculationMethodNames
+{
+    /// <summary>
+    /// A percentage applied to the taxable base.
+    /// </summary>
+    public const string Percentage = "Percentage";
+
+    /// <summary>
+    /// A fixed amount charged per taxable line, independent of quantity.
+    /// </summary>
+    public const string FixedAmount = "FixedAmount";
+
+    /// <summary>
+    /// A fixed amount charged for every unit of quantity.
+    /// </summary>
+    public const string PerUnit = "PerUnit";
+
+    /// <summary>
+    /// A fixed amount charged for every unit of weight.
+    /// </summary>
+    public const string PerWeight = "PerWeight";
+
+    /// <summary>
+    /// A fixed amount charged for every unit of volume.
+    /// </summary>
+    public const string PerVolume = "PerVolume";
+
+    /// <summary>
+    /// A progressive, tiered calculation driven by a tax table.
+    /// </summary>
+    public const string Progressive = "Progressive";
+
+    /// <summary>
+    /// A calculation that only applies once a threshold is reached.
+    /// </summary>
+    public const string Threshold = "Threshold";
+
+    /// <summary>
+    /// A lookup calculation that resolves a rate or amount from a tax table row.
+    /// </summary>
+    public const string TaxTable = "TaxTable";
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/TaxSourcingNames.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/TaxSourcingNames.cs
@@ -1,0 +1,41 @@
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Provides the well-known, extensible tax sourcing strategy identifiers.
+/// </summary>
+/// <remarks>
+/// Sourcing determines which address is used to resolve the applicable jurisdictions for a taxable item.
+/// Strategies are resolved by name so additional sourcing rules can be introduced by third parties.
+/// </remarks>
+public static class TaxSourcingNames
+{
+    /// <summary>
+    /// Source tax from the origin (ship-from) address.
+    /// </summary>
+    public const string Origin = "Origin";
+
+    /// <summary>
+    /// Source tax from the destination (ship-to) address.
+    /// </summary>
+    public const string Destination = "Destination";
+
+    /// <summary>
+    /// Source tax from the customer residence address.
+    /// </summary>
+    public const string CustomerResidence = "CustomerResidence";
+
+    /// <summary>
+    /// Source tax from the customer business address.
+    /// </summary>
+    public const string CustomerBusiness = "CustomerBusiness";
+
+    /// <summary>
+    /// Source tax from the location where a service is performed.
+    /// </summary>
+    public const string ServiceLocation = "ServiceLocation";
+
+    /// <summary>
+    /// Source tax from the location where an event takes place.
+    /// </summary>
+    public const string EventLocation = "EventLocation";
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/TaxTypeNames.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/TaxTypeNames.cs
@@ -1,0 +1,81 @@
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Provides well-known, extensible tax type identifiers.
+/// </summary>
+/// <remarks>
+/// Tax types are represented as strings so that additional, region-specific types can be introduced
+/// without changing the framework. The engine never embeds country-specific behavior in a tax type.
+/// </remarks>
+public static class TaxTypeNames
+{
+    /// <summary>
+    /// A generic sales tax.
+    /// </summary>
+    public const string SalesTax = "SalesTax";
+
+    /// <summary>
+    /// A value-added tax.
+    /// </summary>
+    public const string Vat = "VAT";
+
+    /// <summary>
+    /// A goods and services tax.
+    /// </summary>
+    public const string Gst = "GST";
+
+    /// <summary>
+    /// A harmonized sales tax.
+    /// </summary>
+    public const string Hst = "HST";
+
+    /// <summary>
+    /// A provincial sales tax.
+    /// </summary>
+    public const string Pst = "PST";
+
+    /// <summary>
+    /// A Quebec sales tax.
+    /// </summary>
+    public const string Qst = "QST";
+
+    /// <summary>
+    /// An excise tax.
+    /// </summary>
+    public const string ExciseTax = "ExciseTax";
+
+    /// <summary>
+    /// A tax levied on alcohol.
+    /// </summary>
+    public const string AlcoholTax = "AlcoholTax";
+
+    /// <summary>
+    /// A tax levied on tobacco.
+    /// </summary>
+    public const string TobaccoTax = "TobaccoTax";
+
+    /// <summary>
+    /// A tourism tax.
+    /// </summary>
+    public const string TourismTax = "TourismTax";
+
+    /// <summary>
+    /// A lodging tax.
+    /// </summary>
+    public const string LodgingTax = "LodgingTax";
+
+    /// <summary>
+    /// An environmental tax.
+    /// </summary>
+    public const string EnvironmentalTax = "EnvironmentalTax";
+
+    /// <summary>
+    /// A digital services tax.
+    /// </summary>
+    public const string DigitalServicesTax = "DigitalServicesTax";
+
+    /// <summary>
+    /// Any other tax type not covered by the well-known values.
+    /// </summary>
+    public const string Other = "Other";
+}

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/TaxationConstants.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/TaxationConstants.cs
@@ -1,0 +1,34 @@
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Provides shared constant values for the taxation framework.
+/// </summary>
+public static class TaxationConstants
+{
+    /// <summary>
+    /// Contains the feature identifiers exposed by the taxation module.
+    /// </summary>
+    public static class Feature
+    {
+        /// <summary>
+        /// The identifier of the core taxation feature.
+        /// </summary>
+        public const string Taxation = "CrestApps.OrchardCore.Taxation";
+    }
+
+    /// <summary>
+    /// Contains the content part names used by the taxation framework.
+    /// </summary>
+    public static class Parts
+    {
+        /// <summary>
+        /// The technical name of the taxation content part.
+        /// </summary>
+        public const string TaxationPart = nameof(TaxationPart);
+    }
+
+    /// <summary>
+    /// The admin settings group identifier for taxation related settings.
+    /// </summary>
+    public const string SettingsGroupId = "taxation";
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/CrestApps.OrchardCore.Taxation.Core.csproj
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/CrestApps.OrchardCore.Taxation.Core.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>CrestApps OrchardCore Taxation Core</Title>
+    <Description>
+      $(OCCMSDescription)
+
+      Core services and default implementations for the CrestApps taxation framework.
+    </Description>
+    <PackageTags>$(PackageTags) CrestApps OrchardCoreCMS Taxation</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CrestApps.Core" />
+    <PackageReference Include="OrchardCore.Infrastructure.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/CrestApps.OrchardCore.Taxation.Abstractions.csproj" />
+    <ProjectReference Include="../CrestApps.OrchardCore.Core/CrestApps.OrchardCore.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Models/TaxationOptions.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Models/TaxationOptions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Models;
+
+/// <summary>
+/// Configures the default behavior of the taxation engine.
+/// </summary>
+public sealed class TaxationOptions
+{
+    /// <summary>
+    /// Gets or sets the number of decimal places tax amounts are rounded to. Defaults to <c>2</c>.
+    /// </summary>
+    public int DecimalPlaces { get; set; } = 2;
+
+    /// <summary>
+    /// Gets or sets the midpoint rounding mode. Defaults to <see cref="MidpointRounding.AwayFromZero"/>.
+    /// </summary>
+    public MidpointRounding MidpointRounding { get; set; } = MidpointRounding.AwayFromZero;
+
+    /// <summary>
+    /// Gets or sets the level at which tax amounts are rounded. Defaults to <see cref="TaxRoundingLevel.Line"/>.
+    /// </summary>
+    public TaxRoundingLevel RoundingLevel { get; set; } = TaxRoundingLevel.Line;
+
+    /// <summary>
+    /// Gets or sets a per-currency override of the number of decimal places, keyed by currency code.
+    /// </summary>
+    public IDictionary<string, int> CurrencyDecimalPlaces { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CatalogMerchantTaxRegistrationProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CatalogMerchantTaxRegistrationProvider.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="IMerchantTaxRegistrationProvider"/> backed by the
+/// <see cref="IMerchantTaxRegistrationStore"/>. When no registrations are configured the merchant is
+/// treated as having nexus everywhere, which supports manual-rule scenarios out of the box. Once any
+/// registration exists, nexus is enforced.
+/// </summary>
+public sealed class CatalogMerchantTaxRegistrationProvider : IMerchantTaxRegistrationProvider
+{
+    private readonly IMerchantTaxRegistrationStore _store;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CatalogMerchantTaxRegistrationProvider"/> class.
+    /// </summary>
+    /// <param name="store">The merchant tax registration store.</param>
+    public CatalogMerchantTaxRegistrationProvider(IMerchantTaxRegistrationStore store)
+    {
+        _store = store;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<bool> HasNexusAsync(string jurisdictionId, string taxType, DateTime onUtc, CancellationToken cancellationToken = default)
+    {
+        var registrations = await _store.GetAllAsync(cancellationToken);
+
+        if (registrations.Count == 0)
+        {
+            return true;
+        }
+
+        return registrations.Any(registration => Covers(registration, jurisdictionId, taxType, onUtc));
+    }
+
+    private static bool Covers(MerchantTaxRegistration registration, string jurisdictionId, string taxType, DateTime onUtc)
+    {
+        if (!registration.IsActive)
+        {
+            return false;
+        }
+
+        if (!string.Equals(registration.JurisdictionId, jurisdictionId, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(registration.TaxType) &&
+            !string.Equals(registration.TaxType, taxType, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (registration.EffectiveFromUtc.HasValue && onUtc < registration.EffectiveFromUtc.Value)
+        {
+            return false;
+        }
+
+        if (registration.EffectiveToUtc.HasValue && onUtc >= registration.EffectiveToUtc.Value)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CatalogTaxExemptionResolver.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CatalogTaxExemptionResolver.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="ITaxExemptionResolver"/> backed by the <see cref="IExemptionCertificateStore"/>.
+/// A customer is exempt when it is flagged tax exempt, or when it holds an active, effective certificate
+/// that covers the tax type, jurisdiction, and classification of the rule.
+/// </summary>
+public sealed class CatalogTaxExemptionResolver : ITaxExemptionResolver
+{
+    private readonly IExemptionCertificateStore _store;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CatalogTaxExemptionResolver"/> class.
+    /// </summary>
+    /// <param name="store">The exemption certificate store.</param>
+    public CatalogTaxExemptionResolver(IExemptionCertificateStore store)
+    {
+        _store = store;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<bool> IsExemptAsync(CustomerTaxProfile customer, TaxRule rule, DateTime onUtc, CancellationToken cancellationToken = default)
+    {
+        if (customer is null)
+        {
+            return false;
+        }
+
+        if (customer.IsTaxExempt)
+        {
+            return true;
+        }
+
+        if (customer.ExemptionCertificateIds is null || customer.ExemptionCertificateIds.Count == 0)
+        {
+            return false;
+        }
+
+        var certificates = await _store.GetAsync(customer.ExemptionCertificateIds, cancellationToken);
+
+        return certificates.Any(certificate => Covers(certificate, rule, onUtc));
+    }
+
+    private static bool Covers(ExemptionCertificate certificate, TaxRule rule, DateTime onUtc)
+    {
+        if (certificate.Status != ExemptionStatus.Active)
+        {
+            return false;
+        }
+
+        if (certificate.EffectiveFromUtc.HasValue && onUtc < certificate.EffectiveFromUtc.Value)
+        {
+            return false;
+        }
+
+        if (certificate.ExpirationUtc.HasValue && onUtc >= certificate.ExpirationUtc.Value)
+        {
+            return false;
+        }
+
+        if (certificate.TaxTypes.Count > 0 && !certificate.TaxTypes.Contains(rule.TaxType, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (certificate.JurisdictionIds.Count > 0 &&
+            !string.IsNullOrEmpty(rule.JurisdictionId) &&
+            !certificate.JurisdictionIds.Contains(rule.JurisdictionId, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (certificate.ClassificationCodes.Count > 0 &&
+            !string.IsNullOrEmpty(rule.CategoryCode) &&
+            !certificate.ClassificationCodes.Contains(rule.CategoryCode, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CatalogTaxJurisdictionResolver.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CatalogTaxJurisdictionResolver.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="ITaxJurisdictionResolver"/> backed by the <see cref="ITaxJurisdictionStore"/>. A
+/// jurisdiction matches when every non-empty component it defines is satisfied by the address.
+/// </summary>
+public sealed class CatalogTaxJurisdictionResolver : ITaxJurisdictionResolver
+{
+    private readonly ITaxJurisdictionStore _store;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CatalogTaxJurisdictionResolver"/> class.
+    /// </summary>
+    /// <param name="store">The jurisdiction store.</param>
+    public CatalogTaxJurisdictionResolver(ITaxJurisdictionStore store)
+    {
+        _store = store;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<TaxJurisdiction>> ResolveAsync(TaxAddress address, DateTime onUtc, CancellationToken cancellationToken = default)
+    {
+        if (address is null)
+        {
+            return [];
+        }
+
+        var jurisdictions = await _store.GetAllAsync(cancellationToken);
+
+        return jurisdictions
+            .Where(jurisdiction => IsEffective(jurisdiction, onUtc) && Matches(jurisdiction, address))
+            .ToArray();
+    }
+
+    private static bool IsEffective(TaxJurisdiction jurisdiction, DateTime onUtc)
+    {
+        if (jurisdiction.EffectiveFromUtc.HasValue && onUtc < jurisdiction.EffectiveFromUtc.Value)
+        {
+            return false;
+        }
+
+        if (jurisdiction.EffectiveToUtc.HasValue && onUtc >= jurisdiction.EffectiveToUtc.Value)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool Matches(TaxJurisdiction jurisdiction, TaxAddress address)
+    {
+        return ComponentMatches(jurisdiction.Country, address.Country) &&
+            ComponentMatches(jurisdiction.Region, address.Region) &&
+            ComponentMatches(jurisdiction.County, address.County) &&
+            ComponentMatches(jurisdiction.City, address.City) &&
+            ComponentMatches(jurisdiction.PostalCode, address.PostalCode);
+    }
+
+    private static bool ComponentMatches(string jurisdictionValue, string addressValue)
+    {
+        if (string.IsNullOrEmpty(jurisdictionValue))
+        {
+            return true;
+        }
+
+        return string.Equals(jurisdictionValue, addressValue, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CatalogTaxRuleProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CatalogTaxRuleProvider.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="ITaxRuleProvider"/> backed by the <see cref="ITaxRuleStore"/>. Rules are filtered
+/// by jurisdiction, classification, customer type, effective dates, thresholds, and shipping, then
+/// ordered deterministically by priority, compound flag, and identifier.
+/// </summary>
+public sealed class CatalogTaxRuleProvider : ITaxRuleProvider
+{
+    private readonly ITaxRuleStore _store;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CatalogTaxRuleProvider"/> class.
+    /// </summary>
+    /// <param name="store">The tax rule store.</param>
+    public CatalogTaxRuleProvider(ITaxRuleStore store)
+    {
+        _store = store;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<TaxRule>> GetApplicableRulesAsync(TaxRuleQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var rules = await _store.GetAllAsync(cancellationToken);
+
+        var applicable = rules.Where(rule => IsApplicable(rule, query));
+
+        return TaxRuleOrdering.Order(applicable).ToArray();
+    }
+
+    private static bool IsApplicable(TaxRule rule, TaxRuleQuery query)
+    {
+        if (!rule.Enabled)
+        {
+            return false;
+        }
+
+        if (query.JurisdictionIds.Count > 0 &&
+            !string.IsNullOrEmpty(rule.JurisdictionId) &&
+            !query.JurisdictionIds.Contains(rule.JurisdictionId))
+        {
+            return false;
+        }
+
+        if (rule.EffectiveFromUtc.HasValue && query.TransactionDateUtc < rule.EffectiveFromUtc.Value)
+        {
+            return false;
+        }
+
+        if (rule.EffectiveToUtc.HasValue && query.TransactionDateUtc >= rule.EffectiveToUtc.Value)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(rule.CategoryCode) &&
+            !MatchesCategory(rule.CategoryCode, query))
+        {
+            return false;
+        }
+
+        if (rule.CustomerType.HasValue && query.CustomerType.HasValue && rule.CustomerType.Value != query.CustomerType.Value)
+        {
+            return false;
+        }
+
+        if (query.IsShipping && !rule.AppliesToShipping)
+        {
+            return false;
+        }
+
+        if (rule.MinimumAmount.HasValue && query.TaxableAmount < rule.MinimumAmount.Value)
+        {
+            return false;
+        }
+
+        if (rule.MaximumAmount.HasValue && query.TaxableAmount >= rule.MaximumAmount.Value)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool MatchesCategory(string ruleCategory, TaxRuleQuery query)
+    {
+        return string.Equals(ruleCategory, query.CategoryCode, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(ruleCategory, query.ClassificationCode, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CustomerBusinessTaxSourcingStrategy.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CustomerBusinessTaxSourcingStrategy.cs
@@ -1,0 +1,17 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Sources tax from the customer business address.
+/// </summary>
+public sealed class CustomerBusinessTaxSourcingStrategy : ITaxSourcingStrategy
+{
+    /// <inheritdoc />
+    public string Name => TaxSourcingNames.CustomerBusiness;
+
+    /// <inheritdoc />
+    public TaxAddress Resolve(TaxCalculationContext context, ITaxableItem item)
+        => context?.Customer?.BusinessAddress;
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CustomerResidenceTaxSourcingStrategy.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/CustomerResidenceTaxSourcingStrategy.cs
@@ -1,0 +1,17 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Sources tax from the customer residence address.
+/// </summary>
+public sealed class CustomerResidenceTaxSourcingStrategy : ITaxSourcingStrategy
+{
+    /// <inheritdoc />
+    public string Name => TaxSourcingNames.CustomerResidence;
+
+    /// <inheritdoc />
+    public TaxAddress Resolve(TaxCalculationContext context, ITaxableItem item)
+        => context?.Customer?.ResidenceAddress;
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxCalculationMethodProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxCalculationMethodProvider.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="ITaxCalculationMethodProvider"/> that resolves calculation methods from the
+/// registered <see cref="ITaxCalculationMethod"/> instances by name.
+/// </summary>
+public sealed class DefaultTaxCalculationMethodProvider : ITaxCalculationMethodProvider
+{
+    private readonly Dictionary<string, ITaxCalculationMethod> _methods;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultTaxCalculationMethodProvider"/> class.
+    /// </summary>
+    /// <param name="methods">The registered calculation methods.</param>
+    public DefaultTaxCalculationMethodProvider(IEnumerable<ITaxCalculationMethod> methods)
+    {
+        _methods = methods.ToDictionary(method => method.Name, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public ITaxCalculationMethod GetMethod(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        return _methods.TryGetValue(name, out var method) ? method : null;
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxRoundingStrategy.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxRoundingStrategy.cs
@@ -1,0 +1,37 @@
+using System;
+using CrestApps.OrchardCore.Taxation.Core.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="ITaxRoundingStrategy"/> that rounds values using the configured number of decimal
+/// places and midpoint mode.
+/// </summary>
+public sealed class DefaultTaxRoundingStrategy : ITaxRoundingStrategy
+{
+    private readonly TaxationOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultTaxRoundingStrategy"/> class.
+    /// </summary>
+    /// <param name="options">The taxation options.</param>
+    public DefaultTaxRoundingStrategy(IOptions<TaxationOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public decimal Round(decimal value, string currency)
+    {
+        var decimals = _options.DecimalPlaces;
+
+        if (!string.IsNullOrEmpty(currency) && _options.CurrencyDecimalPlaces.TryGetValue(currency, out var currencyDecimals))
+        {
+            decimals = currencyDecimals;
+        }
+
+        return Math.Round(value, decimals, _options.MidpointRounding);
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxSnapshotFactory.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxSnapshotFactory.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="ITaxSnapshotFactory"/> that captures an immutable copy of a tax determination.
+/// </summary>
+public sealed class DefaultTaxSnapshotFactory : ITaxSnapshotFactory
+{
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultTaxSnapshotFactory"/> class.
+    /// </summary>
+    /// <param name="clock">The clock used to timestamp the snapshot.</param>
+    public DefaultTaxSnapshotFactory(IClock clock)
+    {
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public TaxSnapshot Create(TaxCalculationContext context, TaxCalculationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(result);
+
+        return new TaxSnapshot
+        {
+            CreatedUtc = _clock.UtcNow,
+            TransactionDateUtc = context.TransactionDateUtc,
+            Currency = result.Currency,
+            TaxableAmount = result.TaxableAmount,
+            TaxAmount = result.TaxAmount,
+            TotalAmount = result.TotalAmount,
+            Lines = result.Lines.Select(CloneLine).ToList(),
+        };
+    }
+
+    private static TaxLine CloneLine(TaxLine line)
+    {
+        return new TaxLine
+        {
+            ItemId = line.ItemId,
+            TaxCode = line.TaxCode,
+            TaxName = line.TaxName,
+            TaxType = line.TaxType,
+            JurisdictionId = line.JurisdictionId,
+            JurisdictionName = line.JurisdictionName,
+            Rate = line.Rate,
+            TaxableAmount = line.TaxableAmount,
+            TaxAmount = line.TaxAmount,
+            CalculationMethod = line.CalculationMethod,
+            IncludedInPrice = line.IncludedInPrice,
+            IsCompound = line.IsCompound,
+            RuleId = line.RuleId,
+            RuleVersion = line.RuleVersion,
+            TableId = line.TableId,
+            TableVersion = line.TableVersion,
+        };
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxSourcingStrategyProvider.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxSourcingStrategyProvider.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="ITaxSourcingStrategyProvider"/> that resolves sourcing strategies from the
+/// registered <see cref="ITaxSourcingStrategy"/> instances by name.
+/// </summary>
+public sealed class DefaultTaxSourcingStrategyProvider : ITaxSourcingStrategyProvider
+{
+    private readonly Dictionary<string, ITaxSourcingStrategy> _strategies;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultTaxSourcingStrategyProvider"/> class.
+    /// </summary>
+    /// <param name="strategies">The registered sourcing strategies.</param>
+    public DefaultTaxSourcingStrategyProvider(IEnumerable<ITaxSourcingStrategy> strategies)
+    {
+        _strategies = strategies.ToDictionary(strategy => strategy.Name, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public ITaxSourcingStrategy GetStrategy(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        return _strategies.TryGetValue(name, out var strategy) ? strategy : null;
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxableBaseCalculator.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxableBaseCalculator.cs
@@ -1,0 +1,22 @@
+using System;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="ITaxableBaseCalculator"/> that computes the net taxable base as the line amount
+/// (quantity multiplied by unit price) reduced by the line discount.
+/// </summary>
+public sealed class DefaultTaxableBaseCalculator : ITaxableBaseCalculator
+{
+    /// <inheritdoc />
+    public decimal GetTaxableBase(ITaxableItem item, TaxCalculationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        var lineAmount = (item.UnitPrice * item.Quantity) - item.DiscountAmount;
+
+        return lineAmount < 0m ? 0m : lineAmount;
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxableItemResolver.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DefaultTaxableItemResolver.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Default <see cref="ITaxableItemResolver"/> that delegates to the registered
+/// <see cref="ITaxableItemProvider"/> instances in priority order.
+/// </summary>
+public sealed class DefaultTaxableItemResolver : ITaxableItemResolver
+{
+    private readonly IReadOnlyList<ITaxableItemProvider> _providers;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultTaxableItemResolver"/> class.
+    /// </summary>
+    /// <param name="providers">The registered taxable item providers.</param>
+    public DefaultTaxableItemResolver(IEnumerable<ITaxableItemProvider> providers)
+    {
+        _providers = providers.OrderBy(provider => provider.Order).ToArray();
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ITaxableItem> ResolveAsync(object source, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        foreach (var provider in _providers)
+        {
+            if (provider.CanCreate(source))
+            {
+                var item = await provider.CreateAsync(source, cancellationToken);
+
+                if (item is not null)
+                {
+                    return item;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DestinationTaxSourcingStrategy.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/DestinationTaxSourcingStrategy.cs
@@ -1,0 +1,17 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Sources tax from the destination (ship-to) address.
+/// </summary>
+public sealed class DestinationTaxSourcingStrategy : ITaxSourcingStrategy
+{
+    /// <inheritdoc />
+    public string Name => TaxSourcingNames.Destination;
+
+    /// <inheritdoc />
+    public TaxAddress Resolve(TaxCalculationContext context, ITaxableItem item)
+        => context?.Destination;
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/EventLocationTaxSourcingStrategy.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/EventLocationTaxSourcingStrategy.cs
@@ -1,0 +1,17 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Sources tax from the location where an event takes place.
+/// </summary>
+public sealed class EventLocationTaxSourcingStrategy : ITaxSourcingStrategy
+{
+    /// <inheritdoc />
+    public string Name => TaxSourcingNames.EventLocation;
+
+    /// <inheritdoc />
+    public TaxAddress Resolve(TaxCalculationContext context, ITaxableItem item)
+        => context?.EventLocation;
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/ExemptionCertificateStore.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/ExemptionCertificateStore.cs
@@ -1,0 +1,22 @@
+using CrestApps.OrchardCore.Core.Services;
+using CrestApps.OrchardCore.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using OrchardCore.Documents;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Document-backed <see cref="IExemptionCertificateStore"/> implementation.
+/// </summary>
+public sealed class ExemptionCertificateStore : Catalog<ExemptionCertificate>, IExemptionCertificateStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExemptionCertificateStore"/> class.
+    /// </summary>
+    /// <param name="documentManager">The document manager for the backing document.</param>
+    public ExemptionCertificateStore(IDocumentManager<DictionaryDocument<ExemptionCertificate>> documentManager)
+        : base(documentManager)
+    {
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/FixedAmountTaxCalculationMethod.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/FixedAmountTaxCalculationMethod.cs
@@ -1,0 +1,29 @@
+using System;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Calculates tax as a single fixed amount per taxable line, independent of quantity.
+/// </summary>
+public sealed class FixedAmountTaxCalculationMethod : ITaxCalculationMethod
+{
+    /// <inheritdoc />
+    public string Name => TaxCalculationMethodNames.FixedAmount;
+
+    /// <inheritdoc />
+    public TaxComputationResult Compute(TaxComputationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var amount = request.FixedAmount ?? 0m;
+
+        return new TaxComputationResult
+        {
+            TaxableAmount = request.TaxableBase,
+            TaxAmount = amount,
+            EffectiveRate = 0m,
+        };
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/MerchantTaxRegistrationStore.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/MerchantTaxRegistrationStore.cs
@@ -1,0 +1,22 @@
+using CrestApps.OrchardCore.Core.Services;
+using CrestApps.OrchardCore.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using OrchardCore.Documents;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Document-backed <see cref="IMerchantTaxRegistrationStore"/> implementation.
+/// </summary>
+public sealed class MerchantTaxRegistrationStore : Catalog<MerchantTaxRegistration>, IMerchantTaxRegistrationStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MerchantTaxRegistrationStore"/> class.
+    /// </summary>
+    /// <param name="documentManager">The document manager for the backing document.</param>
+    public MerchantTaxRegistrationStore(IDocumentManager<DictionaryDocument<MerchantTaxRegistration>> documentManager)
+        : base(documentManager)
+    {
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/OriginTaxSourcingStrategy.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/OriginTaxSourcingStrategy.cs
@@ -1,0 +1,18 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Sources tax from the origin (ship-from) address. The item origin takes precedence over the
+/// transaction origin.
+/// </summary>
+public sealed class OriginTaxSourcingStrategy : ITaxSourcingStrategy
+{
+    /// <inheritdoc />
+    public string Name => TaxSourcingNames.Origin;
+
+    /// <inheritdoc />
+    public TaxAddress Resolve(TaxCalculationContext context, ITaxableItem item)
+        => item?.Origin ?? context?.Origin;
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/PerUnitTaxCalculationMethod.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/PerUnitTaxCalculationMethod.cs
@@ -1,0 +1,29 @@
+using System;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Calculates tax as a fixed amount charged for every unit of quantity.
+/// </summary>
+public sealed class PerUnitTaxCalculationMethod : ITaxCalculationMethod
+{
+    /// <inheritdoc />
+    public string Name => TaxCalculationMethodNames.PerUnit;
+
+    /// <inheritdoc />
+    public TaxComputationResult Compute(TaxComputationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var amountPerUnit = request.FixedAmount ?? 0m;
+
+        return new TaxComputationResult
+        {
+            TaxableAmount = request.TaxableBase,
+            TaxAmount = amountPerUnit * request.Quantity,
+            EffectiveRate = 0m,
+        };
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/PerVolumeTaxCalculationMethod.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/PerVolumeTaxCalculationMethod.cs
@@ -1,0 +1,30 @@
+using System;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Calculates tax as a fixed amount charged for every unit of volume.
+/// </summary>
+public sealed class PerVolumeTaxCalculationMethod : ITaxCalculationMethod
+{
+    /// <inheritdoc />
+    public string Name => TaxCalculationMethodNames.PerVolume;
+
+    /// <inheritdoc />
+    public TaxComputationResult Compute(TaxComputationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var amountPerVolume = request.FixedAmount ?? 0m;
+        var volume = request.Volume ?? 0m;
+
+        return new TaxComputationResult
+        {
+            TaxableAmount = request.TaxableBase,
+            TaxAmount = amountPerVolume * volume,
+            EffectiveRate = 0m,
+        };
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/PerWeightTaxCalculationMethod.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/PerWeightTaxCalculationMethod.cs
@@ -1,0 +1,30 @@
+using System;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Calculates tax as a fixed amount charged for every unit of weight.
+/// </summary>
+public sealed class PerWeightTaxCalculationMethod : ITaxCalculationMethod
+{
+    /// <inheritdoc />
+    public string Name => TaxCalculationMethodNames.PerWeight;
+
+    /// <inheritdoc />
+    public TaxComputationResult Compute(TaxComputationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var amountPerWeight = request.FixedAmount ?? 0m;
+        var weight = request.Weight ?? 0m;
+
+        return new TaxComputationResult
+        {
+            TaxableAmount = request.TaxableBase,
+            TaxAmount = amountPerWeight * weight,
+            EffectiveRate = 0m,
+        };
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/PercentageTaxCalculationMethod.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/PercentageTaxCalculationMethod.cs
@@ -1,0 +1,42 @@
+using System;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Calculates tax as a percentage of the taxable base. Supports both tax-exclusive and tax-inclusive pricing.
+/// </summary>
+public sealed class PercentageTaxCalculationMethod : ITaxCalculationMethod
+{
+    /// <inheritdoc />
+    public string Name => TaxCalculationMethodNames.Percentage;
+
+    /// <inheritdoc />
+    public TaxComputationResult Compute(TaxComputationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var rate = request.Rate ?? 0m;
+
+        if (request.PriceIncludesTax)
+        {
+            var net = rate == -1m ? request.TaxableBase : request.TaxableBase / (1 + rate);
+            var includedTax = request.TaxableBase - net;
+
+            return new TaxComputationResult
+            {
+                TaxableAmount = net,
+                TaxAmount = includedTax,
+                EffectiveRate = rate,
+            };
+        }
+
+        return new TaxComputationResult
+        {
+            TaxableAmount = request.TaxableBase,
+            TaxAmount = request.TaxableBase * rate,
+            EffectiveRate = rate,
+        };
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/ProgressiveTaxCalculationMethod.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/ProgressiveTaxCalculationMethod.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Calculates tax using a progressive, tiered tax table. Each bracket taxes only the portion of the
+/// taxable base that falls within it.
+/// </summary>
+public sealed class ProgressiveTaxCalculationMethod : ITaxCalculationMethod
+{
+    /// <inheritdoc />
+    public string Name => TaxCalculationMethodNames.Progressive;
+
+    /// <inheritdoc />
+    public TaxComputationResult Compute(TaxComputationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var tax = 0m;
+        var rows = request.Table?.Rows;
+
+        if (rows is not null)
+        {
+            foreach (var row in rows.OrderBy(r => r.Minimum))
+            {
+                if (request.TaxableBase <= row.Minimum)
+                {
+                    continue;
+                }
+
+                var upper = row.Maximum ?? request.TaxableBase;
+                var portion = Math.Min(request.TaxableBase, upper) - row.Minimum;
+
+                if (portion > 0m)
+                {
+                    tax += (portion * row.Rate) + row.FixedAmount;
+                }
+            }
+        }
+
+        var effectiveRate = request.TaxableBase > 0m ? tax / request.TaxableBase : 0m;
+
+        return new TaxComputationResult
+        {
+            TaxableAmount = request.TaxableBase,
+            TaxAmount = tax,
+            EffectiveRate = effectiveRate,
+        };
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/ServiceLocationTaxSourcingStrategy.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/ServiceLocationTaxSourcingStrategy.cs
@@ -1,0 +1,17 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Sources tax from the location where a service is performed.
+/// </summary>
+public sealed class ServiceLocationTaxSourcingStrategy : ITaxSourcingStrategy
+{
+    /// <inheritdoc />
+    public string Name => TaxSourcingNames.ServiceLocation;
+
+    /// <inheritdoc />
+    public TaxAddress Resolve(TaxCalculationContext context, ITaxableItem item)
+        => context?.ServiceLocation;
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxCategoryStore.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxCategoryStore.cs
@@ -1,0 +1,22 @@
+using CrestApps.OrchardCore.Core.Services;
+using CrestApps.OrchardCore.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using OrchardCore.Documents;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Document-backed <see cref="ITaxCategoryStore"/> implementation.
+/// </summary>
+public sealed class TaxCategoryStore : NamedCatalog<TaxCategory>, ITaxCategoryStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxCategoryStore"/> class.
+    /// </summary>
+    /// <param name="documentManager">The document manager for the backing document.</param>
+    public TaxCategoryStore(IDocumentManager<DictionaryDocument<TaxCategory>> documentManager)
+        : base(documentManager)
+    {
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxJurisdictionStore.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxJurisdictionStore.cs
@@ -1,0 +1,22 @@
+using CrestApps.OrchardCore.Core.Services;
+using CrestApps.OrchardCore.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using OrchardCore.Documents;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Document-backed <see cref="ITaxJurisdictionStore"/> implementation.
+/// </summary>
+public sealed class TaxJurisdictionStore : NamedCatalog<TaxJurisdiction>, ITaxJurisdictionStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxJurisdictionStore"/> class.
+    /// </summary>
+    /// <param name="documentManager">The document manager for the backing document.</param>
+    public TaxJurisdictionStore(IDocumentManager<DictionaryDocument<TaxJurisdiction>> documentManager)
+        : base(documentManager)
+    {
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxRuleOrdering.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxRuleOrdering.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Provides deterministic ordering of tax rules so that a given set of rules always resolves to the
+/// same sequence. Non-compound rules are evaluated before compound rules.
+/// </summary>
+public static class TaxRuleOrdering
+{
+    /// <summary>
+    /// Orders the supplied rules by priority, then by compound flag, then by identifier.
+    /// </summary>
+    /// <param name="rules">The rules to order.</param>
+    /// <returns>The ordered rules.</returns>
+    public static IEnumerable<TaxRule> Order(IEnumerable<TaxRule> rules)
+    {
+        return rules
+            .OrderBy(rule => rule.IsCompound)
+            .ThenBy(rule => rule.Priority)
+            .ThenBy(rule => rule.ItemId, System.StringComparer.Ordinal);
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxRuleStore.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxRuleStore.cs
@@ -1,0 +1,22 @@
+using CrestApps.OrchardCore.Core.Services;
+using CrestApps.OrchardCore.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using OrchardCore.Documents;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Document-backed <see cref="ITaxRuleStore"/> implementation.
+/// </summary>
+public sealed class TaxRuleStore : NamedCatalog<TaxRule>, ITaxRuleStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxRuleStore"/> class.
+    /// </summary>
+    /// <param name="documentManager">The document manager for the backing document.</param>
+    public TaxRuleStore(IDocumentManager<DictionaryDocument<TaxRule>> documentManager)
+        : base(documentManager)
+    {
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxService.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxService.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Core.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// The default provider-agnostic taxation engine. It orchestrates external determination providers,
+/// sourcing, jurisdiction resolution, rule resolution, exemptions, nexus, and calculation methods to
+/// produce a deterministic and auditable tax breakdown. The engine contains no country-specific behavior.
+/// </summary>
+public sealed class TaxService : ITaxService
+{
+    private readonly IReadOnlyList<ITaxDeterminationProvider> _determinationProviders;
+    private readonly ITaxableBaseCalculator _taxableBaseCalculator;
+    private readonly ITaxSourcingStrategyProvider _sourcingProvider;
+    private readonly ITaxJurisdictionResolver _jurisdictionResolver;
+    private readonly ITaxRuleProvider _ruleProvider;
+    private readonly ITaxExemptionResolver _exemptionResolver;
+    private readonly IMerchantTaxRegistrationProvider _registrationProvider;
+    private readonly ITaxCalculationMethodProvider _methodProvider;
+    private readonly ITaxTableStore _tableStore;
+    private readonly ITaxRoundingStrategy _roundingStrategy;
+    private readonly TaxationOptions _options;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxService"/> class.
+    /// </summary>
+    /// <param name="determinationProviders">The external determination providers.</param>
+    /// <param name="taxableBaseCalculator">The taxable base calculator.</param>
+    /// <param name="sourcingProvider">The sourcing strategy provider.</param>
+    /// <param name="jurisdictionResolver">The jurisdiction resolver.</param>
+    /// <param name="ruleProvider">The rule provider.</param>
+    /// <param name="exemptionResolver">The exemption resolver.</param>
+    /// <param name="registrationProvider">The merchant registration (nexus) provider.</param>
+    /// <param name="methodProvider">The calculation method provider.</param>
+    /// <param name="tableStore">The tax table store.</param>
+    /// <param name="roundingStrategy">The rounding strategy.</param>
+    /// <param name="options">The taxation options.</param>
+    /// <param name="logger">The logger.</param>
+    public TaxService(
+        IEnumerable<ITaxDeterminationProvider> determinationProviders,
+        ITaxableBaseCalculator taxableBaseCalculator,
+        ITaxSourcingStrategyProvider sourcingProvider,
+        ITaxJurisdictionResolver jurisdictionResolver,
+        ITaxRuleProvider ruleProvider,
+        ITaxExemptionResolver exemptionResolver,
+        IMerchantTaxRegistrationProvider registrationProvider,
+        ITaxCalculationMethodProvider methodProvider,
+        ITaxTableStore tableStore,
+        ITaxRoundingStrategy roundingStrategy,
+        IOptions<TaxationOptions> options,
+        ILogger<TaxService> logger)
+    {
+        _determinationProviders = determinationProviders.OrderBy(provider => provider.Order).ToArray();
+        _taxableBaseCalculator = taxableBaseCalculator;
+        _sourcingProvider = sourcingProvider;
+        _jurisdictionResolver = jurisdictionResolver;
+        _ruleProvider = ruleProvider;
+        _exemptionResolver = exemptionResolver;
+        _registrationProvider = registrationProvider;
+        _methodProvider = methodProvider;
+        _tableStore = tableStore;
+        _roundingStrategy = roundingStrategy;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TaxCalculationResult> CalculateAsync(TaxCalculationContext context, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        foreach (var provider in _determinationProviders)
+        {
+            if (provider.CanHandle(context))
+            {
+                return await provider.DetermineAsync(context, cancellationToken);
+            }
+        }
+
+        var result = new TaxCalculationResult
+        {
+            Currency = context.Currency,
+        };
+
+        var roundingLevel = context.RoundingLevel ?? _options.RoundingLevel;
+
+        decimal sumNominal = 0m;
+        decimal sumNet = 0m;
+
+        foreach (var item in context.Items)
+        {
+            var itemState = await CalculateItemAsync(context, item, result, cancellationToken);
+
+            sumNominal += itemState.NominalBase;
+            sumNet += itemState.NetBase;
+        }
+
+        var totalTax = ApplyRounding(result.Lines, roundingLevel, context.Currency);
+        var exclusiveTax = result.Lines.Where(line => !line.IncludedInPrice).Sum(line => line.TaxAmount);
+
+        result.TaxableAmount = _roundingStrategy.Round(sumNet, context.Currency);
+        result.TaxAmount = totalTax;
+        result.TotalAmount = _roundingStrategy.Round(sumNominal, context.Currency) + exclusiveTax;
+
+        return result;
+    }
+
+    private async ValueTask<ItemTaxState> CalculateItemAsync(
+        TaxCalculationContext context,
+        ITaxableItem item,
+        TaxCalculationResult result,
+        CancellationToken cancellationToken)
+    {
+        var nominalBase = _taxableBaseCalculator.GetTaxableBase(item, context);
+
+        var address = ResolveAddress(context, item);
+        var jurisdictions = await _jurisdictionResolver.ResolveAsync(address, context.TransactionDateUtc, cancellationToken);
+        var jurisdictionLookup = BuildJurisdictionLookup(jurisdictions);
+
+        var query = new TaxRuleQuery
+        {
+            JurisdictionIds = jurisdictions.Select(jurisdiction => jurisdiction.ItemId).ToArray(),
+            CategoryCode = item.TaxCategoryCode,
+            ClassificationCode = item.TaxClassificationCode,
+            CustomerType = context.Customer?.CustomerType,
+            TransactionDateUtc = context.TransactionDateUtc,
+            IsShipping = item.Kind == TaxableItemKind.Shipping,
+            TaxableAmount = nominalBase,
+        };
+
+        var candidateRules = await _ruleProvider.GetApplicableRulesAsync(query, cancellationToken);
+        var applicableRules = await FilterRulesAsync(context, candidateRules, cancellationToken);
+
+        var itemInclusive = item.PriceIncludesTax ?? (context.DefaultPriceType == TaxPriceType.Inclusive);
+        var netBase = ComputeNetBase(nominalBase, applicableRules, itemInclusive);
+
+        decimal priorItemTax = 0m;
+
+        foreach (var rule in applicableRules)
+        {
+            var method = _methodProvider.GetMethod(rule.CalculationMethod);
+
+            if (method is null)
+            {
+                _logger.LogWarning("No tax calculation method is registered for '{Method}'. The rule '{Rule}' was skipped.", rule.CalculationMethod, rule.ItemId);
+
+                continue;
+            }
+
+            var effectiveIncluded = itemInclusive || rule.IncludedInPrice;
+            var baseAmount = rule.IsCompound ? netBase + priorItemTax : netBase;
+            var table = await GetTableAsync(rule.TaxTableId, cancellationToken);
+
+            var computation = method.Compute(new TaxComputationRequest
+            {
+                TaxableBase = baseAmount,
+                Quantity = item.Quantity,
+                Weight = item.Weight,
+                Volume = item.Volume,
+                Rate = rule.Rate,
+                FixedAmount = rule.FixedAmount,
+                Table = table,
+                PriceIncludesTax = false,
+            });
+
+            jurisdictionLookup.TryGetValue(rule.JurisdictionId ?? string.Empty, out var jurisdiction);
+
+            result.Lines.Add(new TaxLine
+            {
+                ItemId = item.Id,
+                TaxCode = rule.TaxCode,
+                TaxName = rule.TaxName,
+                TaxType = rule.TaxType,
+                JurisdictionId = rule.JurisdictionId,
+                JurisdictionName = jurisdiction?.Name,
+                Rate = computation.EffectiveRate,
+                TaxableAmount = baseAmount,
+                TaxAmount = computation.TaxAmount,
+                CalculationMethod = rule.CalculationMethod,
+                IncludedInPrice = effectiveIncluded,
+                IsCompound = rule.IsCompound,
+                RuleId = rule.ItemId,
+                RuleVersion = rule.Version,
+                TableId = rule.TaxTableId,
+                TableVersion = table?.Version ?? 0,
+            });
+
+            priorItemTax += computation.TaxAmount;
+        }
+
+        return new ItemTaxState(nominalBase, netBase);
+    }
+
+    private static decimal ComputeNetBase(decimal nominalBase, IReadOnlyList<TaxRule> rules, bool itemInclusive)
+    {
+        decimal sumInclusiveRates = 0m;
+        var anyInclusive = false;
+
+        foreach (var rule in rules)
+        {
+            var effectiveIncluded = itemInclusive || rule.IncludedInPrice;
+
+            if (effectiveIncluded &&
+                !rule.IsCompound &&
+                string.Equals(rule.CalculationMethod, TaxCalculationMethodNames.Percentage, StringComparison.OrdinalIgnoreCase) &&
+                rule.Rate.HasValue)
+            {
+                sumInclusiveRates += rule.Rate.Value;
+                anyInclusive = true;
+            }
+        }
+
+        return anyInclusive ? nominalBase / (1 + sumInclusiveRates) : nominalBase;
+    }
+
+    private async ValueTask<IReadOnlyList<TaxRule>> FilterRulesAsync(
+        TaxCalculationContext context,
+        IReadOnlyList<TaxRule> rules,
+        CancellationToken cancellationToken)
+    {
+        var applicable = new List<TaxRule>();
+
+        foreach (var rule in rules)
+        {
+            if (await _exemptionResolver.IsExemptAsync(context.Customer, rule, context.TransactionDateUtc, cancellationToken))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(rule.JurisdictionId) &&
+                !await _registrationProvider.HasNexusAsync(rule.JurisdictionId, rule.TaxType, context.TransactionDateUtc, cancellationToken))
+            {
+                continue;
+            }
+
+            applicable.Add(rule);
+        }
+
+        return applicable;
+    }
+
+    private TaxAddress ResolveAddress(TaxCalculationContext context, ITaxableItem item)
+    {
+        var strategyName = item.Kind switch
+        {
+            TaxableItemKind.Digital => TaxSourcingNames.Destination,
+            TaxableItemKind.Service => TaxSourcingNames.ServiceLocation,
+            TaxableItemKind.Booking => TaxSourcingNames.ServiceLocation,
+            TaxableItemKind.Event => TaxSourcingNames.EventLocation,
+            _ => TaxSourcingNames.Destination,
+        };
+
+        var strategy = _sourcingProvider.GetStrategy(strategyName);
+        var address = strategy?.Resolve(context, item);
+
+        return address
+            ?? context.Destination
+            ?? item.Origin
+            ?? context.Origin
+            ?? context.Customer?.ResidenceAddress;
+    }
+
+    private async ValueTask<TaxTable> GetTableAsync(string tableId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(tableId))
+        {
+            return null;
+        }
+
+        return await _tableStore.FindByIdAsync(tableId, cancellationToken);
+    }
+
+    private static Dictionary<string, TaxJurisdiction> BuildJurisdictionLookup(IReadOnlyList<TaxJurisdiction> jurisdictions)
+    {
+        var lookup = new Dictionary<string, TaxJurisdiction>(StringComparer.Ordinal);
+
+        foreach (var jurisdiction in jurisdictions)
+        {
+            lookup[jurisdiction.ItemId] = jurisdiction;
+        }
+
+        return lookup;
+    }
+
+    private decimal ApplyRounding(IList<TaxLine> lines, TaxRoundingLevel level, string currency)
+    {
+        if (lines.Count == 0)
+        {
+            return 0m;
+        }
+
+        if (level == TaxRoundingLevel.Line)
+        {
+            decimal total = 0m;
+
+            foreach (var line in lines)
+            {
+                line.TaxAmount = _roundingStrategy.Round(line.TaxAmount, currency);
+                total += line.TaxAmount;
+            }
+
+            return total;
+        }
+
+        var buckets = level switch
+        {
+            TaxRoundingLevel.Tax => lines.GroupBy(line => line.TaxType ?? string.Empty, StringComparer.OrdinalIgnoreCase),
+            TaxRoundingLevel.Jurisdiction => lines.GroupBy(line => line.JurisdictionId ?? string.Empty, StringComparer.OrdinalIgnoreCase),
+            _ => lines.GroupBy(_ => string.Empty),
+        };
+
+        decimal grandTotal = 0m;
+
+        foreach (var bucket in buckets)
+        {
+            var bucketLines = bucket.ToArray();
+            var roundedBucketTotal = _roundingStrategy.Round(bucketLines.Sum(line => line.TaxAmount), currency);
+
+            decimal roundedLineSum = 0m;
+
+            foreach (var line in bucketLines)
+            {
+                line.TaxAmount = _roundingStrategy.Round(line.TaxAmount, currency);
+                roundedLineSum += line.TaxAmount;
+            }
+
+            var residual = roundedBucketTotal - roundedLineSum;
+
+            if (residual != 0m)
+            {
+                bucketLines[bucketLines.Length - 1].TaxAmount += residual;
+            }
+
+            grandTotal += roundedBucketTotal;
+        }
+
+        return grandTotal;
+    }
+
+    private readonly struct ItemTaxState
+    {
+        public ItemTaxState(decimal nominalBase, decimal netBase)
+        {
+            NominalBase = nominalBase;
+            NetBase = netBase;
+        }
+
+        public decimal NominalBase { get; }
+
+        public decimal NetBase { get; }
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxTableStore.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxTableStore.cs
@@ -1,0 +1,22 @@
+using CrestApps.OrchardCore.Core.Services;
+using CrestApps.OrchardCore.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using OrchardCore.Documents;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Document-backed <see cref="ITaxTableStore"/> implementation.
+/// </summary>
+public sealed class TaxTableStore : NamedCatalog<TaxTable>, ITaxTableStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxTableStore"/> class.
+    /// </summary>
+    /// <param name="documentManager">The document manager for the backing document.</param>
+    public TaxTableStore(IDocumentManager<DictionaryDocument<TaxTable>> documentManager)
+        : base(documentManager)
+    {
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxTableTaxCalculationMethod.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/TaxTableTaxCalculationMethod.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Calculates tax by looking up the matching row of a tax table for the taxable base and applying its
+/// rate and fixed amount.
+/// </summary>
+public sealed class TaxTableTaxCalculationMethod : ITaxCalculationMethod
+{
+    /// <inheritdoc />
+    public string Name => TaxCalculationMethodNames.TaxTable;
+
+    /// <inheritdoc />
+    public TaxComputationResult Compute(TaxComputationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var row = request.Table?.Rows?.FirstOrDefault(r =>
+            request.TaxableBase >= r.Minimum && (!r.Maximum.HasValue || request.TaxableBase < r.Maximum.Value));
+
+        if (row is null)
+        {
+            return new TaxComputationResult
+            {
+                TaxableAmount = request.TaxableBase,
+                TaxAmount = 0m,
+                EffectiveRate = 0m,
+            };
+        }
+
+        var tax = (request.TaxableBase * row.Rate) + row.FixedAmount;
+
+        return new TaxComputationResult
+        {
+            TaxableAmount = request.TaxableBase,
+            TaxAmount = tax,
+            EffectiveRate = row.Rate,
+        };
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/ThresholdTaxCalculationMethod.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/Services/ThresholdTaxCalculationMethod.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Core.Services;
+
+/// <summary>
+/// Calculates tax that only applies to the amount exceeding a configured threshold. The threshold and
+/// rate are taken from the matching tax table row.
+/// </summary>
+public sealed class ThresholdTaxCalculationMethod : ITaxCalculationMethod
+{
+    /// <inheritdoc />
+    public string Name => TaxCalculationMethodNames.Threshold;
+
+    /// <inheritdoc />
+    public TaxComputationResult Compute(TaxComputationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var row = request.Table?.Rows?
+            .Where(r => request.TaxableBase >= r.Minimum && (!r.Maximum.HasValue || request.TaxableBase < r.Maximum.Value))
+            .OrderByDescending(r => r.Minimum)
+            .FirstOrDefault();
+
+        if (row is null)
+        {
+            return new TaxComputationResult
+            {
+                TaxableAmount = request.TaxableBase,
+                TaxAmount = 0m,
+                EffectiveRate = 0m,
+            };
+        }
+
+        var taxableExcess = request.TaxableBase - row.Minimum;
+        var tax = (taxableExcess * row.Rate) + row.FixedAmount;
+
+        if (tax < 0m)
+        {
+            tax = 0m;
+        }
+
+        var effectiveRate = request.TaxableBase > 0m ? tax / request.TaxableBase : 0m;
+
+        return new TaxComputationResult
+        {
+            TaxableAmount = request.TaxableBase,
+            TaxAmount = tax,
+            EffectiveRate = effectiveRate,
+        };
+    }
+}

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/TaxationServiceCollectionExtensions.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/TaxationServiceCollectionExtensions.cs
@@ -1,0 +1,120 @@
+using CrestApps.Core;
+using CrestApps.OrchardCore.Core;
+using CrestApps.OrchardCore.Taxation.Core.Services;
+using CrestApps.OrchardCore.Taxation.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace CrestApps.OrchardCore.Taxation.Core;
+
+/// <summary>
+/// Provides extension methods to register the taxation framework services.
+/// </summary>
+public static class TaxationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the provider-agnostic taxation engine, its default implementations, calculation methods,
+    /// sourcing strategies, catalog stores, resolvers, and providers.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, to allow chaining.</returns>
+    public static IServiceCollection AddTaxationCore(this IServiceCollection services)
+    {
+        services
+            .AddCatalogs()
+            .AddCatalogManagers();
+
+        services.TryAddScoped<ITaxJurisdictionStore, TaxJurisdictionStore>();
+        services.TryAddScoped<ITaxCategoryStore, TaxCategoryStore>();
+        services.TryAddScoped<ITaxRuleStore, TaxRuleStore>();
+        services.TryAddScoped<ITaxTableStore, TaxTableStore>();
+        services.TryAddScoped<IExemptionCertificateStore, ExemptionCertificateStore>();
+        services.TryAddScoped<IMerchantTaxRegistrationStore, MerchantTaxRegistrationStore>();
+
+        services.TryAddScoped<ITaxService, TaxService>();
+        services.TryAddScoped<ITaxableBaseCalculator, DefaultTaxableBaseCalculator>();
+        services.TryAddScoped<ITaxRoundingStrategy, DefaultTaxRoundingStrategy>();
+        services.TryAddScoped<ITaxCalculationMethodProvider, DefaultTaxCalculationMethodProvider>();
+        services.TryAddScoped<ITaxSourcingStrategyProvider, DefaultTaxSourcingStrategyProvider>();
+        services.TryAddScoped<ITaxRuleProvider, CatalogTaxRuleProvider>();
+        services.TryAddScoped<ITaxJurisdictionResolver, CatalogTaxJurisdictionResolver>();
+        services.TryAddScoped<ITaxExemptionResolver, CatalogTaxExemptionResolver>();
+        services.TryAddScoped<IMerchantTaxRegistrationProvider, CatalogMerchantTaxRegistrationProvider>();
+        services.TryAddScoped<ITaxableItemResolver, DefaultTaxableItemResolver>();
+        services.TryAddScoped<ITaxSnapshotFactory, DefaultTaxSnapshotFactory>();
+
+        services.AddTaxCalculationMethod<PercentageTaxCalculationMethod>();
+        services.AddTaxCalculationMethod<FixedAmountTaxCalculationMethod>();
+        services.AddTaxCalculationMethod<PerUnitTaxCalculationMethod>();
+        services.AddTaxCalculationMethod<PerWeightTaxCalculationMethod>();
+        services.AddTaxCalculationMethod<PerVolumeTaxCalculationMethod>();
+        services.AddTaxCalculationMethod<TaxTableTaxCalculationMethod>();
+        services.AddTaxCalculationMethod<ProgressiveTaxCalculationMethod>();
+        services.AddTaxCalculationMethod<ThresholdTaxCalculationMethod>();
+
+        services.AddTaxSourcingStrategy<OriginTaxSourcingStrategy>();
+        services.AddTaxSourcingStrategy<DestinationTaxSourcingStrategy>();
+        services.AddTaxSourcingStrategy<CustomerResidenceTaxSourcingStrategy>();
+        services.AddTaxSourcingStrategy<CustomerBusinessTaxSourcingStrategy>();
+        services.AddTaxSourcingStrategy<ServiceLocationTaxSourcingStrategy>();
+        services.AddTaxSourcingStrategy<EventLocationTaxSourcingStrategy>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a tax calculation method so that it can be resolved by name.
+    /// </summary>
+    /// <typeparam name="TMethod">The calculation method type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, to allow chaining.</returns>
+    public static IServiceCollection AddTaxCalculationMethod<TMethod>(this IServiceCollection services)
+        where TMethod : class, ITaxCalculationMethod
+    {
+        services.AddScoped<ITaxCalculationMethod, TMethod>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a tax sourcing strategy so that it can be resolved by name.
+    /// </summary>
+    /// <typeparam name="TStrategy">The sourcing strategy type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, to allow chaining.</returns>
+    public static IServiceCollection AddTaxSourcingStrategy<TStrategy>(this IServiceCollection services)
+        where TStrategy : class, ITaxSourcingStrategy
+    {
+        services.AddScoped<ITaxSourcingStrategy, TStrategy>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers an external tax determination provider that can short-circuit the built-in engine.
+    /// </summary>
+    /// <typeparam name="TProvider">The determination provider type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, to allow chaining.</returns>
+    public static IServiceCollection AddTaxDeterminationProvider<TProvider>(this IServiceCollection services)
+        where TProvider : class, ITaxDeterminationProvider
+    {
+        services.AddScoped<ITaxDeterminationProvider, TProvider>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a taxable item provider that converts an arbitrary object into a taxable item.
+    /// </summary>
+    /// <typeparam name="TProvider">The taxable item provider type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, to allow chaining.</returns>
+    public static IServiceCollection AddTaxableItemProvider<TProvider>(this IServiceCollection services)
+        where TProvider : class, ITaxableItemProvider
+    {
+        services.AddScoped<ITaxableItemProvider, TProvider>();
+
+        return services;
+    }
+}

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -171,3 +171,22 @@ Highlights:
 See [SignalR](../modules/signalr) for details.
 
 -----
+
+### Taxation
+
+#### New provider-agnostic taxation framework
+
+A new **Taxation** module (`CrestApps.OrchardCore.Taxation`) introduces a provider-agnostic, extensible taxation framework for Orchard Core. It models tax as a **determination** — derived from *what* is sold, *who* buys it, *where* it is sourced, *when* it happens, and *how* it is calculated — rather than a static rate stored on a product.
+
+Highlights:
+
+- A new **Taxation** part lets any content type participate in taxation by classification only (tax category and classification), never a stored rate.
+- A deterministic engine (`ITaxService`) produces an auditable, line-by-line breakdown with references to the exact tax rule and tax table versions used.
+- Built-in calculation methods cover percentage, fixed amount, per-unit, per-weight, per-volume, tax table, progressive, and threshold taxes, with tax-inclusive and tax-exclusive pricing.
+- Extensible tax types, hierarchical jurisdictions, categories, versioned rules, tax tables, sourcing strategies, exemption certificates, and merchant nexus registrations.
+- Historical tax snapshots (`ITaxSnapshotFactory`) keep transactions immutable, so changing a rate, rule, or table never alters past transactions, and refunds reverse the original determination.
+- Clean extension points (`ITaxableItemProvider`, `ITaxCalculationMethod`, `ITaxSourcingStrategy`, `ITaxDeterminationProvider`, and more) let Products, Subscriptions, Commerce, Bookings, Services, custom content types, and external tax providers integrate without modifying the Taxation source.
+
+See [Taxation](../modules/taxation) for details.
+
+-----

--- a/src/CrestApps.Docs/docs/modules/index.md
+++ b/src/CrestApps.Docs/docs/modules/index.md
@@ -26,6 +26,7 @@ CrestApps provides a set of standard modules that enhance core Orchard Core CMS 
 | [Resources](resources) | `CrestApps.OrchardCore.Resources` | Shared scripts and stylesheets |
 | [Roles](roles) | `CrestApps.OrchardCore.Roles` | Enhanced role management with RolePickerPart |
 | [SignalR compatibility](signalr) | `CrestApps.OrchardCore.SignalR` | Deprecated compatibility feature for the Orchard Core SignalR module |
+| [Taxation](taxation) | `CrestApps.OrchardCore.Taxation` | Provider-agnostic, extensible taxation framework with the TaxationPart |
 | [Time Zones](time-zones) | `CrestApps.OrchardCore.TimeZones` | Friendly named time zone maps and grouped time zone selection |
 | [Users](users) | `CrestApps.OrchardCore.Users` | Enhanced user management with display names and avatars |
 

--- a/src/CrestApps.Docs/docs/modules/taxation.md
+++ b/src/CrestApps.Docs/docs/modules/taxation.md
@@ -1,0 +1,302 @@
+---
+sidebar_label: Taxation
+sidebar_position: 15
+title: Taxation Framework
+description: A provider-agnostic, extensible taxation framework for Orchard Core that models tax as a determination rather than a stored rate.
+---
+
+| | |
+| --- | --- |
+| **Feature Name** | Taxation |
+| **Feature ID** | `CrestApps.OrchardCore.Taxation` |
+| **Category** | Commerce |
+
+Provides a provider-agnostic, extensible, international taxation framework that any Orchard Core content type or CrestApps module (Products, Subscriptions, Payments, Commerce, Bookings, Services, and custom content) can plug into.
+
+## Overview
+
+The framework is built on a single principle:
+
+> **Tax is a determination, not a property.**
+
+Instead of storing a `TaxRate` on a product, the engine determines the applicable taxes from a combination of *what* is sold, *who* buys it, *where* it is sourced, *when* the transaction happens, and *how* the tax is calculated. The result is a deterministic, auditable, line-by-line breakdown that can be captured as an immutable snapshot on the transaction.
+
+The framework is split into three assemblies:
+
+| Assembly | Purpose |
+|----------|---------|
+| `CrestApps.OrchardCore.Taxation.Abstractions` | Interfaces, models, DTOs, enums, and constants. Lightweight, no infrastructure dependencies. |
+| `CrestApps.OrchardCore.Taxation.Core` | The determination engine, default calculation methods, sourcing strategies, resolvers, catalog stores, and dependency-injection wiring. |
+| `CrestApps.OrchardCore.Taxation` | The Orchard Core module: the `TaxationPart`, its editors, migration, and the content-item taxable-item provider. |
+
+## Getting started
+
+Enable the **Taxation** feature under **Tools → Features**, then:
+
+1. Attach the **Taxation** part to a content type and classify it (see [The TaxationPart](#the-taxationpart)).
+2. Seed jurisdictions, categories, and rules (see [Domain model](#domain-model)).
+3. At checkout, convert your objects into taxable items and call `ITaxService.CalculateAsync` (see [Calculating tax](#calculating-tax)).
+
+## Core concepts
+
+The engine works with a **taxable item** (`ITaxableItem`) — a classification-carrying abstraction that is *not* coupled to Product, Subscription, or content items. Anything can be a taxable item: a product, a variant, a subscription plan, a service, a booking, an event, digital content, shipping, or another charge.
+
+```text
+Content / Product / Subscription / Custom object
+                    │
+                    ▼
+             ITaxableItem
+                    │
+                    ▼
+          Tax determination  (jurisdictions + rules + customer + nexus + exemptions)
+                    │
+                    ▼
+          Tax calculation  (calculation methods + tax tables + rounding)
+                    │
+                    ▼
+          TaxCalculationResult  (auditable tax lines)
+                    │
+                    ▼
+          TaxSnapshot  (immutable transaction record)
+```
+
+## The TaxationPart
+
+The `TaxationPart` lets **any content type participate in taxation without modifying the Taxation module**. The part stores *classification and tax identity only* — never a final tax rate.
+
+| Property | Description |
+|----------|-------------|
+| `Taxable` | Whether the content item is taxable. |
+| `TaxCategoryCode` | The tax category (for example `Electronics`). |
+| `TaxClassificationCode` | The finer classification (for example `Television`). |
+| `ExternalTaxCode` | An optional external/provider tax code for mapping to third-party systems. |
+
+Attach the part through the content-type editor, or with a migration:
+
+```csharp
+internal sealed class TelevisionMigrations : DataMigration
+{
+    private readonly IContentDefinitionManager _contentDefinitionManager;
+
+    public TelevisionMigrations(IContentDefinitionManager contentDefinitionManager)
+    {
+        _contentDefinitionManager = contentDefinitionManager;
+    }
+
+    public async Task<int> CreateAsync()
+    {
+        await _contentDefinitionManager.AlterTypeDefinitionAsync("Television", type => type
+            .WithPart("TaxationPart", part => part
+                .WithDisplayName("Taxation")
+                .WithSettings(new TaxationPartSettings
+                {
+                    DefaultTaxCategoryCode = "Electronics",
+                    DefaultTaxClassificationCode = "Television",
+                    AllowClassificationOverride = true,
+                })
+            )
+        );
+
+        return 1;
+    }
+}
+```
+
+A content editor can then leave the defaults or override the classification per item. During checkout the content item is discovered as a taxable item automatically — **no custom tax logic is required for the `Television` type**.
+
+### TaxationPart settings
+
+| Setting | Description |
+|---------|-------------|
+| `DefaultTaxCategoryCode` | The category applied when the item does not specify one. |
+| `DefaultTaxClassificationCode` | The classification applied when the item does not specify one. |
+| `AllowClassificationOverride` | Whether editors may override the classification per content item. |
+
+## Domain model
+
+All taxation data is stored through the CrestApps catalog abstraction, so each entity is versioned, named, and clonable.
+
+| Entity | Store | Purpose |
+|--------|-------|---------|
+| `TaxJurisdiction` | `ITaxJurisdictionStore` | A hierarchical taxing authority (country → state/province → county → city → special district), matched to an address by its non-empty components. |
+| `TaxCategory` | `ITaxCategoryStore` | A classification such as `Electronics/Television` or `Alcohol/Wine`, with optional external codes. |
+| `TaxRule` | `ITaxRuleStore` | Determines whether and how a tax applies. Versioned, prioritized, with effective dates. |
+| `TaxTable` | `ITaxTableStore` | Brackets, ranges, and schedules for progressive, threshold, and lookup taxes. |
+| `ExemptionCertificate` | `IExemptionCertificateStore` | A customer exemption scoped by tax type, jurisdiction, and classification. |
+| `MerchantTaxRegistration` | `IMerchantTaxRegistrationStore` | The merchant's obligation (nexus) to collect a tax in a jurisdiction. |
+
+### Tax rules
+
+A `TaxRule` binds a jurisdiction, tax type, classification, and customer criteria to a calculation method:
+
+```csharp
+await ruleStore.CreateAsync(new TaxRule
+{
+    Name = "California sales tax",
+    TaxType = TaxTypeNames.SalesTax,
+    TaxName = "CA Sales Tax",
+    TaxCode = "US-CA-SALES",
+    JurisdictionId = californiaJurisdictionId,
+    CategoryCode = "Electronics",
+    CalculationMethod = TaxCalculationMethodNames.Percentage,
+    Rate = 0.075m,
+});
+```
+
+Rules carry `Version`, `Priority`, `EffectiveFromUtc`, `EffectiveToUtc`, `MinimumAmount`, `MaximumAmount`, `CustomerType`, `IsCompound`, `IncludedInPrice`, and `AppliesToShipping`. Historical rules must remain immutable once used by a transaction; publish a new version rather than mutating a rule that has already been applied.
+
+### Nexus vs. a jurisdiction having a tax
+
+The engine distinguishes **a jurisdiction has a tax** from **the merchant is obligated to collect it**. When no `MerchantTaxRegistration` records exist, the engine operates in permissive manual-rule mode and collects the tax. As soon as registrations exist, a rule's tax is only collected when an active registration covers its jurisdiction and tax type.
+
+## Calculating tax
+
+The primary API is `ITaxService`:
+
+```csharp
+public interface ITaxService
+{
+    Task<TaxCalculationResult> CalculateAsync(
+        TaxCalculationContext context,
+        CancellationToken cancellationToken = default);
+}
+```
+
+Build a `TaxCalculationContext` with everything needed for a deterministic determination:
+
+```csharp
+var context = new TaxCalculationContext
+{
+    Currency = "USD",
+    TransactionDateUtc = clock.UtcNow,
+    Destination = new TaxAddress { Country = "US", Region = "CA", City = "Los Angeles", PostalCode = "90001" },
+    Customer = new CustomerTaxProfile { CustomerType = CustomerTaxType.B2C },
+    Items =
+    [
+        new TaxableItem
+        {
+            Id = "sku-123",
+            Kind = TaxableItemKind.Physical,
+            Quantity = 1m,
+            UnitPrice = 500m,
+            Currency = "USD",
+            TaxCategoryCode = "Electronics",
+            TaxClassificationCode = "Television",
+        },
+    ],
+};
+
+var result = await taxService.CalculateAsync(context);
+```
+
+To convert existing objects (content items, products, subscriptions) into taxable items, use `ITaxableItemResolver`, which delegates to the registered `ITaxableItemProvider` implementations:
+
+```csharp
+var taxableItem = await taxableItemResolver.ResolveAsync(contentItem);
+```
+
+### The result
+
+`TaxCalculationResult` returns the taxable amount, total tax, grand total, and a `TaxLine` for every applied tax. Each line explains *how* the tax was determined:
+
+| Field | Description |
+|-------|-------------|
+| `TaxCode`, `TaxName`, `TaxType` | Identity of the tax. |
+| `JurisdictionId`, `JurisdictionName` | The taxing authority. |
+| `Rate`, `TaxableAmount`, `TaxAmount` | The computed values. |
+| `CalculationMethod` | The method used. |
+| `IncludedInPrice`, `IsCompound` | Pricing and compounding flags. |
+| `RuleId`, `RuleVersion`, `TableId`, `TableVersion` | Audit references to the exact rule and table versions used. |
+
+## Calculation methods
+
+The engine ships with the following calculation methods, all registered by name and resolved through `ITaxCalculationMethodProvider`:
+
+| Name (`TaxCalculationMethodNames`) | Behavior |
+|------|----------|
+| `Percentage` | Percentage of the taxable base. Supports tax-inclusive extraction. |
+| `FixedAmount` | A flat amount per line. |
+| `PerUnit` | Amount multiplied by quantity. |
+| `PerWeight` | Amount multiplied by weight. |
+| `PerVolume` | Amount multiplied by volume. |
+| `TaxTable` | A single matching bracket from a tax table. |
+| `Progressive` | Taxes each bracket portion (tiered). |
+| `Threshold` | Taxes only the amount above a threshold. |
+
+### Tax-inclusive vs. tax-exclusive pricing
+
+Set `TaxableItem.PriceIncludesTax` (or `TaxCalculationContext.DefaultPriceType`) to control whether the price already contains tax. For inclusive percentage taxes the engine nets the base out of the gross price before applying each rule, so the total stays equal to the displayed price. Inclusive extraction is supported for percentage taxes.
+
+## Tax sourcing
+
+Do not assume the shipping address is always the tax location. Sourcing is pluggable through `ITaxSourcingStrategy` (resolved by `ITaxSourcingStrategyProvider`), with these built-in strategies: `Origin`, `Destination`, `CustomerResidence`, `CustomerBusiness`, `ServiceLocation`, and `EventLocation`. The engine picks a strategy from the taxable item's `Kind` (for example digital goods use the destination, services and bookings use the service location, and events use the event location) and falls back through destination, item origin, context origin, and customer residence.
+
+## Snapshots, immutability, and refunds
+
+When taxation becomes part of a transaction, capture it with `ITaxSnapshotFactory`:
+
+```csharp
+var snapshot = snapshotFactory.Create(context, result);
+```
+
+A `TaxSnapshot` is an immutable deep copy of the determination, including every tax line with its rule and table versions. Changing a rate, rule, or tax table tomorrow never changes yesterday's snapshot. Refunds and adjustments reverse the original snapshot rather than recalculating with today's rules.
+
+## Rounding
+
+Rounding is explicit and controlled by `TaxationOptions` (or `TaxCalculationContext.RoundingLevel`):
+
+| Level (`TaxRoundingLevel`) | Behavior |
+|-------|----------|
+| `Line` | Each tax line is rounded independently. |
+| `Tax` | Amounts are aggregated per tax type, then rounded. |
+| `Jurisdiction` | Amounts are aggregated per jurisdiction, then rounded. |
+| `Transaction` | The whole transaction is rounded once. |
+
+`TaxationOptions` also configures `DecimalPlaces`, `MidpointRounding`, and per-currency decimal overrides.
+
+## Extending the framework
+
+External modules integrate **without modifying the Taxation source**. Register your implementations in a `Startup` class:
+
+```csharp
+public sealed class Startup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        // Convert your own objects into taxable items.
+        services.AddTaxableItemProvider<SubscriptionTaxableItemProvider>();
+
+        // Add a custom calculation strategy.
+        services.AddTaxCalculationMethod<MyCustomTaxCalculationMethod>();
+
+        // Add a custom sourcing strategy.
+        services.AddTaxSourcingStrategy<MyCustomSourcingStrategy>();
+
+        // Delegate determination to an external provider (Avalara, Stripe Tax, etc.).
+        services.AddTaxDeterminationProvider<MyExternalTaxProvider>();
+    }
+}
+```
+
+The main extension points are:
+
+| Interface | Responsibility |
+|-----------|----------------|
+| `ITaxableItem` / `ITaxableItemProvider` | Represent and produce taxable items from arbitrary objects. |
+| `ITaxService` | The determination engine entry point. |
+| `ITaxCalculationMethod` | A calculation strategy resolvable by name. |
+| `ITaxSourcingStrategy` | Where the tax is sourced from. |
+| `ITaxRuleProvider` | Supplies applicable rules for a query. |
+| `ITaxJurisdictionResolver` | Maps an address to jurisdictions. |
+| `ITaxExemptionResolver` | Determines customer exemptions. |
+| `IMerchantTaxRegistrationProvider` | Determines merchant nexus. |
+| `ITaxableBaseCalculator` | Computes the taxable base for an item. |
+| `ITaxRoundingStrategy` | Applies the rounding policy. |
+| `ITaxSnapshotFactory` | Captures immutable transaction snapshots. |
+| `ITaxDeterminationProvider` | Short-circuits the engine with an external determination. |
+
+An `ITaxDeterminationProvider` whose `CanHandle` returns `true` takes over the entire calculation, which is how third-party tax services (for example `CrestApps.OrchardCore.Taxation.Avalara` or `CrestApps.OrchardCore.Taxation.Stripe`) can be layered on top of the same abstractions.
+
+## Determinism
+
+Given the same `TaxCalculationContext` plus the same tax rule and tax table versions, the result is always the same. The engine avoids hidden dependencies on mutable global state and uses the injected `IClock` for all time-based logic.

--- a/src/CrestApps.Docs/sidebars.js
+++ b/src/CrestApps.Docs/sidebars.js
@@ -120,6 +120,7 @@ const sidebars = {
                 'modules/resources',
                 'modules/roles',
                 'modules/signalr',
+                'modules/taxation',
                 'modules/time-zones',
                 'modules/users',
             ],

--- a/src/Modules/CrestApps.OrchardCore.Taxation/CrestApps.OrchardCore.Taxation.csproj
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/CrestApps.OrchardCore.Taxation.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <Title>CrestApps OrchardCore Taxation</Title>
+    <Description>
+      $(OCCMSDescription)
+
+      Provider-agnostic, extensible taxation framework module for OrchardCore. Provides the TaxationPart
+      that lets any content type participate in taxation, and exposes the taxation engine and its
+      extension points.
+    </Description>
+    <PackageTags>$(PackageTags) CrestApps OrchardCoreCMS Taxation</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OrchardCore.Module.Targets" />
+    <PackageReference Include="OrchardCore.ContentManagement" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" />
+    <PackageReference Include="OrchardCore.DisplayManagement" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Abstractions\CrestApps.OrchardCore.Abstractions\CrestApps.OrchardCore.Abstractions.csproj" />
+    <ProjectReference Include="..\..\Core\CrestApps.OrchardCore.Taxation.Core\CrestApps.OrchardCore.Taxation.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxationPartDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxationPartDisplayDriver.cs
@@ -1,0 +1,56 @@
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.ViewModels;
+using OrchardCore.ContentManagement.Display.ContentDisplay;
+using OrchardCore.ContentManagement.Display.Models;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.Taxation.Drivers;
+
+/// <summary>
+/// Display driver for the <see cref="TaxationPart"/> editor.
+/// </summary>
+public sealed class TaxationPartDisplayDriver : ContentPartDisplayDriver<TaxationPart>
+{
+    /// <inheritdoc />
+    public override IDisplayResult Edit(TaxationPart part, BuildPartEditorContext context)
+    {
+        var settings = context.TypePartDefinition.GetSettings<TaxationPartSettings>();
+
+        return Initialize<TaxationPartViewModel>(GetEditorShapeType(context), model =>
+        {
+            model.Taxable = context.IsNew ? true : part.Taxable;
+            model.TaxCategoryCode = context.IsNew ? settings.DefaultTaxCategoryCode : part.TaxCategoryCode;
+            model.TaxClassificationCode = context.IsNew ? settings.DefaultTaxClassificationCode : part.TaxClassificationCode;
+            model.ExternalTaxCode = part.ExternalTaxCode;
+            model.AllowClassificationOverride = settings.AllowClassificationOverride;
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task<IDisplayResult> UpdateAsync(TaxationPart part, UpdatePartEditorContext context)
+    {
+        var settings = context.TypePartDefinition.GetSettings<TaxationPartSettings>();
+
+        var model = new TaxationPartViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        part.Taxable = model.Taxable;
+        part.ExternalTaxCode = model.ExternalTaxCode;
+
+        if (settings.AllowClassificationOverride)
+        {
+            part.TaxCategoryCode = model.TaxCategoryCode;
+            part.TaxClassificationCode = model.TaxClassificationCode;
+        }
+        else
+        {
+            part.TaxCategoryCode = settings.DefaultTaxCategoryCode;
+            part.TaxClassificationCode = settings.DefaultTaxClassificationCode;
+        }
+
+        return Edit(part, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxationPartSettingsDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxationPartSettingsDisplayDriver.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.ViewModels;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentTypes.Editors;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.Taxation.Drivers;
+
+/// <summary>
+/// Settings display driver for the <see cref="TaxationPart"/> attached to a content type.
+/// </summary>
+public sealed class TaxationPartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver<TaxationPart>
+{
+    /// <inheritdoc />
+    public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, BuildEditorContext context)
+    {
+        return Initialize<TaxationPartSettingsViewModel>("TaxationPartSettings_Edit", model =>
+        {
+            var settings = contentTypePartDefinition.GetSettings<TaxationPartSettings>();
+
+            model.DefaultTaxCategoryCode = settings.DefaultTaxCategoryCode;
+            model.DefaultTaxClassificationCode = settings.DefaultTaxClassificationCode;
+            model.AllowClassificationOverride = settings.AllowClassificationOverride;
+        }).Location("Content");
+    }
+
+    /// <inheritdoc />
+    public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)
+    {
+        var model = new TaxationPartSettingsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        context.Builder.WithSettings(new TaxationPartSettings
+        {
+            DefaultTaxCategoryCode = model.DefaultTaxCategoryCode,
+            DefaultTaxClassificationCode = model.DefaultTaxClassificationCode,
+            AllowClassificationOverride = model.AllowClassificationOverride,
+        });
+
+        return Edit(contentTypePartDefinition, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Manifest.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Manifest.cs
@@ -1,0 +1,17 @@
+using CrestApps.OrchardCore;
+using CrestApps.OrchardCore.Taxation;
+using OrchardCore.Modules.Manifest;
+
+[assembly: Module(
+    Name = "Taxation",
+    Author = CrestAppsManifestConstants.Author,
+    Website = CrestAppsManifestConstants.Website,
+    Version = CrestAppsManifestConstants.Version
+)]
+
+[assembly: Feature(
+    Id = TaxationConstants.Feature.Taxation,
+    Name = "Taxation",
+    Description = "Provides a provider-agnostic, extensible taxation framework and the TaxationPart.",
+    Category = "Commerce"
+)]

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Migrations/TaxationPartMigrations.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Migrations/TaxationPartMigrations.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.ContentManagement.Metadata.Settings;
+using OrchardCore.Data.Migration;
+
+namespace CrestApps.OrchardCore.Taxation.Migrations;
+
+/// <summary>
+/// Defines the <c>TaxationPart</c> so it can be attached to any content type.
+/// </summary>
+public sealed class TaxationPartMigrations : DataMigration
+{
+    private readonly IContentDefinitionManager _contentDefinitionManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxationPartMigrations"/> class.
+    /// </summary>
+    /// <param name="contentDefinitionManager">The content definition manager.</param>
+    public TaxationPartMigrations(IContentDefinitionManager contentDefinitionManager)
+    {
+        _contentDefinitionManager = contentDefinitionManager;
+    }
+
+    /// <summary>
+    /// Creates the taxation part definition.
+    /// </summary>
+    /// <returns>The migration version number.</returns>
+    public async Task<int> CreateAsync()
+    {
+        await _contentDefinitionManager.AlterPartDefinitionAsync(TaxationConstants.Parts.TaxationPart, part => part
+            .Attachable()
+            .WithDisplayName("Taxation")
+            .WithDescription("Classifies a content item for taxation without storing a tax rate."));
+
+        return 1;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Models/TaxationPart.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Models/TaxationPart.cs
@@ -1,0 +1,31 @@
+using OrchardCore.ContentManagement;
+
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// A content part that classifies a content item for taxation. The part carries tax identity and
+/// classification only; it never stores a final tax rate. The taxation engine determines the applicable
+/// tax from the transaction context using this classification.
+/// </summary>
+public sealed class TaxationPart : ContentPart
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the content item is taxable.
+    /// </summary>
+    public bool Taxable { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the tax category code (for example <c>Electronics</c>).
+    /// </summary>
+    public string TaxCategoryCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax classification code (for example <c>Television</c>) that refines the category.
+    /// </summary>
+    public string TaxClassificationCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional external or provider-specific tax code.
+    /// </summary>
+    public string ExternalTaxCode { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Models/TaxationPartSettings.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Models/TaxationPartSettings.cs
@@ -1,0 +1,23 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Configures the behavior of a <see cref="TaxationPart"/> attached to a content type.
+/// </summary>
+public sealed class TaxationPartSettings
+{
+    /// <summary>
+    /// Gets or sets the default tax category code applied to new content items.
+    /// </summary>
+    public string DefaultTaxCategoryCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default tax classification code applied to new content items.
+    /// </summary>
+    public string DefaultTaxClassificationCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the tax classification fields are shown to editors.
+    /// When disabled, only the default codes configured here are used.
+    /// </summary>
+    public bool AllowClassificationOverride { get; set; } = true;
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/README.md
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/README.md
@@ -1,0 +1,21 @@
+# CrestApps.OrchardCore.Taxation
+
+A provider-agnostic, extensible taxation framework for OrchardCore. It models tax as a **determination**
+(from *what*, *who*, *where*, *when*, and *how*) rather than a static property on a product.
+
+## Features
+
+- `TaxationPart` that lets any content type participate in taxation by classification only (no stored rate).
+- A deterministic taxation engine (`ITaxService`) that produces an auditable, line-by-line breakdown.
+- Extensible tax types, jurisdictions, categories, rules, tax tables, calculation methods, sourcing
+  strategies, exemptions, and merchant nexus.
+- Historical tax snapshots (`ITaxSnapshotFactory`) so transactions are never recalculated with new rules.
+- Clean extension points for third-party modules and external tax providers.
+
+## Getting started
+
+Enable the **Taxation** feature. Attach the **Taxation** part to any content type and classify it with a
+tax category and classification. During checkout, resolve the content item into an `ITaxableItem` and call
+`ITaxService.CalculateAsync`.
+
+See the full documentation on the CrestApps documentation site under **Taxation**.

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Services/ContentItemTaxableItemProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Services/ContentItemTaxableItemProvider.cs
@@ -1,0 +1,66 @@
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using OrchardCore.ContentManagement;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Converts a content item that has a <see cref="TaxationPart"/> into an <see cref="ITaxableItem"/>.
+/// The amount is read generically from a well-known <c>ProductPart.Price</c> location when present so
+/// that the taxation module stays decoupled from any particular commerce module.
+/// </summary>
+public sealed class ContentItemTaxableItemProvider : ITaxableItemProvider
+{
+    /// <inheritdoc />
+    public int Order => 0;
+
+    /// <inheritdoc />
+    public bool CanCreate(object source)
+        => source is ContentItem contentItem && contentItem.Has<TaxationPart>();
+
+    /// <inheritdoc />
+    public ValueTask<ITaxableItem> CreateAsync(object source, CancellationToken cancellationToken = default)
+    {
+        if (source is not ContentItem contentItem)
+        {
+            return ValueTask.FromResult<ITaxableItem>(null);
+        }
+
+        var part = contentItem.Get<TaxationPart>(nameof(TaxationPart));
+
+        if (part is null || !part.Taxable)
+        {
+            return ValueTask.FromResult<ITaxableItem>(null);
+        }
+
+        var item = new TaxableItem
+        {
+            Id = contentItem.ContentItemId,
+            UnitPrice = ReadPrice(contentItem),
+            Quantity = 1m,
+            TaxCategoryCode = part.TaxCategoryCode,
+            TaxClassificationCode = part.TaxClassificationCode,
+            ExternalTaxCode = part.ExternalTaxCode,
+        };
+
+        item.Metadata["ContentType"] = contentItem.ContentType;
+
+        return ValueTask.FromResult<ITaxableItem>(item);
+    }
+
+    private static decimal ReadPrice(ContentItem contentItem)
+    {
+        JsonNode content = contentItem.Content;
+        var priceNode = content?["ProductPart"]?["Price"];
+
+        if (priceNode is JsonValue priceValue && priceValue.TryGetValue<decimal>(out var price))
+        {
+            return price;
+        }
+
+        return 0m;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Startup.cs
@@ -1,0 +1,35 @@
+using CrestApps.OrchardCore.Taxation.Core;
+using CrestApps.OrchardCore.Taxation.Drivers;
+using CrestApps.OrchardCore.Taxation.Migrations;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Display.ContentDisplay;
+using OrchardCore.ContentTypes.Editors;
+using OrchardCore.Data.Migration;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Registers the taxation framework services, the <see cref="TaxationPart"/>, and its content
+/// integration.
+/// </summary>
+public sealed class Startup : StartupBase
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddTaxationCore();
+
+        services.AddContentPart<TaxationPart>()
+            .UseDisplayDriver<TaxationPartDisplayDriver>();
+
+        services.AddScoped<IContentTypePartDefinitionDisplayDriver, TaxationPartSettingsDisplayDriver>();
+
+        services.AddDataMigration<TaxationPartMigrations>();
+
+        services.AddTaxableItemProvider<ContentItemTaxableItemProvider>();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxationPartSettingsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxationPartSettingsViewModel.cs
@@ -1,0 +1,22 @@
+namespace CrestApps.OrchardCore.Taxation.ViewModels;
+
+/// <summary>
+/// The settings editor view model for a <see cref="Models.TaxationPart"/>.
+/// </summary>
+public class TaxationPartSettingsViewModel
+{
+    /// <summary>
+    /// Gets or sets the default tax category code applied to new content items.
+    /// </summary>
+    public string DefaultTaxCategoryCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default tax classification code applied to new content items.
+    /// </summary>
+    public string DefaultTaxClassificationCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether editors can override the classification codes.
+    /// </summary>
+    public bool AllowClassificationOverride { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxationPartViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxationPartViewModel.cs
@@ -1,0 +1,32 @@
+namespace CrestApps.OrchardCore.Taxation.ViewModels;
+
+/// <summary>
+/// The editor view model for a <see cref="Models.TaxationPart"/>.
+/// </summary>
+public class TaxationPartViewModel
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the content item is taxable.
+    /// </summary>
+    public bool Taxable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax category code.
+    /// </summary>
+    public string TaxCategoryCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax classification code.
+    /// </summary>
+    public string TaxClassificationCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the external or provider-specific tax code.
+    /// </summary>
+    public string ExternalTaxCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether editors can override the classification codes.
+    /// </summary>
+    public bool AllowClassificationOverride { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxationPart.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxationPart.Edit.cshtml
@@ -1,0 +1,30 @@
+@using CrestApps.OrchardCore.Taxation.ViewModels
+
+@model TaxationPartViewModel
+
+<div class="mb-3 form-check">
+    <input type="checkbox" asp-for="Taxable" class="form-check-input" />
+    <label asp-for="Taxable" class="form-check-label">@T["Taxable"]</label>
+    <span class="hint">@T["When enabled, this item participates in tax calculation."]</span>
+</div>
+
+@if (Model.AllowClassificationOverride)
+{
+    <div class="mb-3">
+        <label asp-for="TaxCategoryCode" class="form-label">@T["Tax category"]</label>
+        <input type="text" asp-for="TaxCategoryCode" class="form-control" />
+        <span class="hint">@T["The tax category code, for example Electronics."]</span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="TaxClassificationCode" class="form-label">@T["Tax classification"]</label>
+        <input type="text" asp-for="TaxClassificationCode" class="form-control" />
+        <span class="hint">@T["The tax classification code that refines the category, for example Television."]</span>
+    </div>
+}
+
+<div class="mb-3">
+    <label asp-for="ExternalTaxCode" class="form-label">@T["External tax code"]</label>
+    <input type="text" asp-for="ExternalTaxCode" class="form-control" />
+    <span class="hint">@T["An optional external or provider-specific tax code."]</span>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxationPartSettings.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxationPartSettings.Edit.cshtml
@@ -1,0 +1,21 @@
+@using CrestApps.OrchardCore.Taxation.ViewModels
+
+@model TaxationPartSettingsViewModel
+
+<div class="mb-3">
+    <label asp-for="DefaultTaxCategoryCode" class="form-label">@T["Default tax category"]</label>
+    <input type="text" asp-for="DefaultTaxCategoryCode" class="form-control" />
+    <span class="hint">@T["The default tax category code applied to new content items."]</span>
+</div>
+
+<div class="mb-3">
+    <label asp-for="DefaultTaxClassificationCode" class="form-label">@T["Default tax classification"]</label>
+    <input type="text" asp-for="DefaultTaxClassificationCode" class="form-control" />
+    <span class="hint">@T["The default tax classification code applied to new content items."]</span>
+</div>
+
+<div class="mb-3 form-check">
+    <input type="checkbox" asp-for="AllowClassificationOverride" class="form-check-input" />
+    <label asp-for="AllowClassificationOverride" class="form-check-label">@T["Allow editors to override the classification"]</label>
+    <span class="hint">@T["When disabled, editors cannot change the category or classification and the defaults above are always used."]</span>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/_ViewImports.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/_ViewImports.cshtml
@@ -1,0 +1,8 @@
+@inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>
+
+@using OrchardCore.DisplayManagement.Views
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, OrchardCore.DisplayManagement
+@addTagHelper *, OrchardCore.ResourceManagement
+@addTagHelper *, OrchardCore.Contents.TagHelpers

--- a/src/Targets/CrestApps.OrchardCore.Cms.Core.Targets/CrestApps.OrchardCore.Cms.Core.Targets.csproj
+++ b/src/Targets/CrestApps.OrchardCore.Cms.Core.Targets/CrestApps.OrchardCore.Cms.Core.Targets.csproj
@@ -82,6 +82,7 @@
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.SignalR/CrestApps.OrchardCore.SignalR.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.Stripe/CrestApps.OrchardCore.Stripe.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.Subscriptions/CrestApps.OrchardCore.Subscriptions.csproj" PrivateAssets="none" />
+    <ProjectReference Include="../../Modules/CrestApps.OrchardCore.Taxation/CrestApps.OrchardCore.Taxation.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.Telephony/CrestApps.OrchardCore.Telephony.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.TimeZones/CrestApps.OrchardCore.TimeZones.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.Users/CrestApps.OrchardCore.Users.csproj" PrivateAssets="none" />

--- a/tests/CrestApps.OrchardCore.Tests/CrestApps.OrchardCore.Tests.csproj
+++ b/tests/CrestApps.OrchardCore.Tests/CrestApps.OrchardCore.Tests.csproj
@@ -73,6 +73,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Abstractions\CrestApps.OrchardCore.Taxation.Abstractions\CrestApps.OrchardCore.Taxation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Core\CrestApps.OrchardCore.Taxation.Core\CrestApps.OrchardCore.Taxation.Core.csproj" />
+    <ProjectReference Include="..\..\src\Modules\CrestApps.OrchardCore.Taxation\CrestApps.OrchardCore.Taxation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/ContentItemTaxableItemProviderTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/ContentItemTaxableItemProviderTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json.Nodes;
+using CrestApps.OrchardCore.Taxation;
+using CrestApps.OrchardCore.Taxation.Core;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using CrestApps.OrchardCore.Tests.Taxation.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.ContentManagement;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class ContentItemTaxableItemProviderTests
+{
+    private static TaxTestHarness CreateHarness()
+        => new(new TestClock(TaxTestData.TransactionDate), services => services.AddTaxableItemProvider<ContentItemTaxableItemProvider>());
+
+    private static ContentItem CreateTelevision(decimal price)
+    {
+        var contentItem = new ContentItem
+        {
+            ContentType = "Television",
+            ContentItemId = "tv-1",
+        };
+
+        contentItem.Weld(nameof(TaxationPart), new TaxationPart
+        {
+            Taxable = true,
+            TaxCategoryCode = "Electronics",
+            TaxClassificationCode = "Television",
+        });
+
+        contentItem.Content["ProductPart"] = new JsonObject
+        {
+            ["Price"] = JsonValue.Create(price),
+        };
+
+        return contentItem;
+    }
+
+    [Fact]
+    public async Task Resolver_ConvertsTaxableContentItemIntoTaxableItem()
+    {
+        var harness = CreateHarness();
+        var resolver = harness.GetService<ITaxableItemResolver>();
+
+        var item = await resolver.ResolveAsync(CreateTelevision(500m));
+
+        Assert.NotNull(item);
+        Assert.Equal("tv-1", item.Id);
+        Assert.Equal(500m, item.UnitPrice);
+        Assert.Equal("Electronics", item.TaxCategoryCode);
+        Assert.Equal("Television", item.TaxClassificationCode);
+    }
+
+    [Fact]
+    public async Task CustomContentType_ParticipatesInTaxationWithoutCustomLogic()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Electronics tax",
+            JurisdictionId = jurisdictionId,
+            CategoryCode = "Electronics",
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.075m,
+        });
+
+        var resolver = harness.GetService<ITaxableItemResolver>();
+        var item = await resolver.ResolveAsync(CreateTelevision(500m));
+
+        var context = new TaxCalculationContext
+        {
+            Currency = "USD",
+            TransactionDateUtc = TaxTestData.TransactionDate,
+            Destination = TaxTestData.California(),
+            Items = [item],
+        };
+
+        var result = await harness.TaxService.CalculateAsync(context);
+
+        var line = Assert.Single(result.Lines);
+        Assert.Equal(37.5m, line.TaxAmount);
+        Assert.Equal(537.5m, result.TotalAmount);
+    }
+
+    [Fact]
+    public async Task NonTaxableContentItem_IsNotResolved()
+    {
+        var harness = CreateHarness();
+        var resolver = harness.GetService<ITaxableItemResolver>();
+
+        var contentItem = new ContentItem
+        {
+            ContentType = "Article",
+            ContentItemId = "article-1",
+        };
+
+        var item = await resolver.ResolveAsync(contentItem);
+
+        Assert.Null(item);
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryExemptionCertificateStore.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryExemptionCertificateStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IExemptionCertificateStore"/> used by the taxation tests.
+/// </summary>
+public sealed class InMemoryExemptionCertificateStore : InMemoryNamedCatalog<ExemptionCertificate>, IExemptionCertificateStore
+{
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryMerchantTaxRegistrationStore.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryMerchantTaxRegistrationStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IMerchantTaxRegistrationStore"/> used by the taxation tests.
+/// </summary>
+public sealed class InMemoryMerchantTaxRegistrationStore : InMemoryNamedCatalog<MerchantTaxRegistration>, IMerchantTaxRegistrationStore
+{
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryNamedCatalog.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryNamedCatalog.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.Core;
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Models;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// A minimal in-memory <see cref="INamedCatalog{T}"/> used by the taxation tests to back the real
+/// catalog providers and resolvers without a document store or dependency injection.
+/// </summary>
+public class InMemoryNamedCatalog<T> : INamedCatalog<T>
+    where T : CatalogItem, INameAwareModel
+{
+    private readonly Dictionary<string, T> _records = new(StringComparer.Ordinal);
+
+    public ValueTask CreateAsync(T entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (string.IsNullOrEmpty(entry.ItemId))
+        {
+            entry.ItemId = UniqueId.GenerateId();
+        }
+
+        _records[entry.ItemId] = Clone(entry);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask UpdateAsync(T entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        _records[entry.ItemId] = Clone(entry);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<bool> DeleteAsync(T entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        return ValueTask.FromResult(_records.Remove(entry.ItemId));
+    }
+
+    public ValueTask<T> FindByIdAsync(string id, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(_records.TryGetValue(id, out var record) ? Clone(record) : null);
+
+    public ValueTask<T> FindByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var record = _records.Values.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
+
+        return ValueTask.FromResult(record is null ? null : Clone(record));
+    }
+
+    public ValueTask<IReadOnlyCollection<T>> GetAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
+    {
+        var result = ids.Where(_records.ContainsKey).Select(id => Clone(_records[id])).ToArray();
+
+        return ValueTask.FromResult<IReadOnlyCollection<T>>(result);
+    }
+
+    public ValueTask<IReadOnlyCollection<T>> GetAllAsync(CancellationToken cancellationToken = default)
+        => ValueTask.FromResult<IReadOnlyCollection<T>>(_records.Values.Select(Clone).ToArray());
+
+    public ValueTask<PageResult<T>> PageAsync<TQuery>(int page, int pageSize, TQuery context, CancellationToken cancellationToken = default)
+        where TQuery : QueryContext
+    {
+        var records = _records.Values.Select(Clone).ToArray();
+        var skip = (page - 1) * pageSize;
+
+        var result = new PageResult<T>
+        {
+            Count = records.Length,
+            Entries = records.Skip(skip).Take(pageSize).ToArray(),
+        };
+
+        return ValueTask.FromResult(result);
+    }
+
+    private static T Clone(T record)
+        => record is ICloneable<T> cloneable ? cloneable.Clone() : record;
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryTaxCategoryStore.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryTaxCategoryStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// In-memory <see cref="ITaxCategoryStore"/> used by the taxation tests.
+/// </summary>
+public sealed class InMemoryTaxCategoryStore : InMemoryNamedCatalog<TaxCategory>, ITaxCategoryStore
+{
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryTaxJurisdictionStore.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryTaxJurisdictionStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// In-memory <see cref="ITaxJurisdictionStore"/> used by the taxation tests.
+/// </summary>
+public sealed class InMemoryTaxJurisdictionStore : InMemoryNamedCatalog<TaxJurisdiction>, ITaxJurisdictionStore
+{
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryTaxRuleStore.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryTaxRuleStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// In-memory <see cref="ITaxRuleStore"/> used by the taxation tests.
+/// </summary>
+public sealed class InMemoryTaxRuleStore : InMemoryNamedCatalog<TaxRule>, ITaxRuleStore
+{
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryTaxTableStore.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/InMemoryTaxTableStore.cs
@@ -1,0 +1,11 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// In-memory <see cref="ITaxTableStore"/> used by the taxation tests.
+/// </summary>
+public sealed class InMemoryTaxTableStore : InMemoryNamedCatalog<TaxTable>, ITaxTableStore
+{
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/TaxTestData.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/TaxTestData.cs
@@ -1,0 +1,99 @@
+using CrestApps.OrchardCore.Taxation.Models;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// Helper factory methods that seed common taxation test fixtures.
+/// </summary>
+public static class TaxTestData
+{
+    /// <summary>
+    /// The fixed transaction date used by most taxation tests.
+    /// </summary>
+    public static readonly DateTime TransactionDate = new(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Creates a destination address in California, United States.
+    /// </summary>
+    /// <returns>The address.</returns>
+    public static TaxAddress California()
+        => new() { Country = "US", Region = "CA", City = "Los Angeles", PostalCode = "90001" };
+
+    /// <summary>
+    /// Creates and stores a state-level jurisdiction, returning its generated identifier.
+    /// </summary>
+    /// <param name="harness">The test harness.</param>
+    /// <param name="name">The jurisdiction name.</param>
+    /// <param name="country">The country component.</param>
+    /// <param name="region">The region component.</param>
+    /// <returns>The generated jurisdiction identifier.</returns>
+    public static async Task<string> AddJurisdictionAsync(
+        TaxTestHarness harness,
+        string name,
+        string country,
+        string region)
+    {
+        var jurisdiction = new TaxJurisdiction
+        {
+            Name = name,
+            Code = name,
+            Level = JurisdictionLevel.State,
+            Country = country,
+            Region = region,
+        };
+
+        await harness.Jurisdictions.CreateAsync(jurisdiction);
+
+        return jurisdiction.ItemId;
+    }
+
+    /// <summary>
+    /// Creates and stores a tax rule, returning its generated identifier.
+    /// </summary>
+    /// <param name="harness">The test harness.</param>
+    /// <param name="rule">The rule to store.</param>
+    /// <returns>The generated rule identifier.</returns>
+    public static async Task<string> AddRuleAsync(TaxTestHarness harness, TaxRule rule)
+    {
+        await harness.Rules.CreateAsync(rule);
+
+        return rule.ItemId;
+    }
+
+    /// <summary>
+    /// Builds a single-item calculation context with a physical taxable item.
+    /// </summary>
+    /// <param name="unitPrice">The unit price.</param>
+    /// <param name="quantity">The quantity.</param>
+    /// <param name="destination">The destination address.</param>
+    /// <param name="customer">The optional customer profile.</param>
+    /// <param name="categoryCode">The optional tax category code.</param>
+    /// <returns>The calculation context.</returns>
+    public static TaxCalculationContext Context(
+        decimal unitPrice,
+        decimal quantity = 1m,
+        TaxAddress destination = null,
+        CustomerTaxProfile customer = null,
+        string categoryCode = null)
+    {
+        return new TaxCalculationContext
+        {
+            Currency = "USD",
+            TransactionDateUtc = TransactionDate,
+            Destination = destination ?? California(),
+            Customer = customer,
+            Items =
+            [
+                new TaxableItem
+                {
+                    Id = "item-1",
+                    Kind = TaxableItemKind.Physical,
+                    Quantity = quantity,
+                    UnitPrice = unitPrice,
+                    Currency = "USD",
+                    TaxCategoryCode = categoryCode,
+                },
+            ],
+        };
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/TaxTestHarness.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/TaxTestHarness.cs
@@ -1,0 +1,99 @@
+using CrestApps.OrchardCore.Taxation.Core;
+using CrestApps.OrchardCore.Taxation.Services;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// Builds a fully wired taxation engine backed by in-memory catalog stores so tests exercise the real
+/// <see cref="ITaxService"/>, calculation methods, sourcing strategies, resolvers, and providers.
+/// </summary>
+public sealed class TaxTestHarness
+{
+    private readonly IServiceProvider _services;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxTestHarness"/> class.
+    /// </summary>
+    /// <param name="clock">The clock used for time-based determination.</param>
+    /// <param name="configure">An optional callback to register additional services or providers.</param>
+    public TaxTestHarness(TestClock clock, Action<IServiceCollection> configure = null)
+    {
+        var services = new ServiceCollection();
+
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSingleton<IClock>(clock);
+
+        services.AddSingleton<ITaxJurisdictionStore, InMemoryTaxJurisdictionStore>();
+        services.AddSingleton<ITaxCategoryStore, InMemoryTaxCategoryStore>();
+        services.AddSingleton<ITaxRuleStore, InMemoryTaxRuleStore>();
+        services.AddSingleton<ITaxTableStore, InMemoryTaxTableStore>();
+        services.AddSingleton<IExemptionCertificateStore, InMemoryExemptionCertificateStore>();
+        services.AddSingleton<IMerchantTaxRegistrationStore, InMemoryMerchantTaxRegistrationStore>();
+
+        services.AddTaxationCore();
+
+        configure?.Invoke(services);
+
+        _services = services.BuildServiceProvider();
+
+        Clock = clock;
+        Jurisdictions = _services.GetRequiredService<ITaxJurisdictionStore>();
+        Categories = _services.GetRequiredService<ITaxCategoryStore>();
+        Rules = _services.GetRequiredService<ITaxRuleStore>();
+        Tables = _services.GetRequiredService<ITaxTableStore>();
+        Exemptions = _services.GetRequiredService<IExemptionCertificateStore>();
+        Registrations = _services.GetRequiredService<IMerchantTaxRegistrationStore>();
+        TaxService = _services.GetRequiredService<ITaxService>();
+    }
+
+    /// <summary>
+    /// Gets the clock used by the harness.
+    /// </summary>
+    public TestClock Clock { get; }
+
+    /// <summary>
+    /// Gets the taxation engine under test.
+    /// </summary>
+    public ITaxService TaxService { get; }
+
+    /// <summary>
+    /// Gets the in-memory jurisdiction store.
+    /// </summary>
+    public ITaxJurisdictionStore Jurisdictions { get; }
+
+    /// <summary>
+    /// Gets the in-memory category store.
+    /// </summary>
+    public ITaxCategoryStore Categories { get; }
+
+    /// <summary>
+    /// Gets the in-memory rule store.
+    /// </summary>
+    public ITaxRuleStore Rules { get; }
+
+    /// <summary>
+    /// Gets the in-memory tax table store.
+    /// </summary>
+    public ITaxTableStore Tables { get; }
+
+    /// <summary>
+    /// Gets the in-memory exemption certificate store.
+    /// </summary>
+    public IExemptionCertificateStore Exemptions { get; }
+
+    /// <summary>
+    /// Gets the in-memory merchant registration store.
+    /// </summary>
+    public IMerchantTaxRegistrationStore Registrations { get; }
+
+    /// <summary>
+    /// Resolves a service from the harness container.
+    /// </summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <returns>The resolved service.</returns>
+    public TService GetService<TService>()
+        => _services.GetRequiredService<TService>();
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/TestClock.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/Fakes/TestClock.cs
@@ -1,0 +1,33 @@
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Tests.Taxation.Fakes;
+
+/// <summary>
+/// A deterministic, mutable <see cref="IClock"/> for taxation tests.
+/// </summary>
+public sealed class TestClock : IClock
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestClock"/> class.
+    /// </summary>
+    /// <param name="utcNow">The initial UTC value the clock returns.</param>
+    public TestClock(DateTime utcNow)
+    {
+        UtcNow = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc);
+    }
+
+    /// <inheritdoc />
+    public DateTime UtcNow { get; set; }
+
+    /// <inheritdoc />
+    public ITimeZone GetTimeZone(string timeZoneId) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public ITimeZone[] GetTimeZones() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public ITimeZone GetSystemTimeZone() => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public DateTimeOffset ConvertToTimeZone(DateTimeOffset dateTimeOffset, ITimeZone timeZone) => throw new NotSupportedException();
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/TaxCalculationMethodTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/TaxCalculationMethodTests.cs
@@ -1,0 +1,174 @@
+using CrestApps.OrchardCore.Taxation.Core.Services;
+using CrestApps.OrchardCore.Taxation.Models;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class TaxCalculationMethodTests
+{
+    [Fact]
+    public void Percentage_Exclusive_ComputesTaxOnTop()
+    {
+        var method = new PercentageTaxCalculationMethod();
+
+        var result = method.Compute(new TaxComputationRequest
+        {
+            TaxableBase = 100m,
+            Rate = 0.10m,
+            PriceIncludesTax = false,
+        });
+
+        Assert.Equal(100m, result.TaxableAmount);
+        Assert.Equal(10m, result.TaxAmount);
+        Assert.Equal(0.10m, result.EffectiveRate);
+    }
+
+    [Fact]
+    public void Percentage_Inclusive_ExtractsEmbeddedTax()
+    {
+        var method = new PercentageTaxCalculationMethod();
+
+        var result = method.Compute(new TaxComputationRequest
+        {
+            TaxableBase = 110m,
+            Rate = 0.10m,
+            PriceIncludesTax = true,
+        });
+
+        Assert.Equal(100m, result.TaxableAmount);
+        Assert.Equal(10m, result.TaxAmount);
+    }
+
+    [Fact]
+    public void FixedAmount_ReturnsConstantTax()
+    {
+        var method = new FixedAmountTaxCalculationMethod();
+
+        var result = method.Compute(new TaxComputationRequest
+        {
+            TaxableBase = 500m,
+            FixedAmount = 7m,
+        });
+
+        Assert.Equal(7m, result.TaxAmount);
+        Assert.Equal(0m, result.EffectiveRate);
+    }
+
+    [Fact]
+    public void PerUnit_MultipliesByQuantity()
+    {
+        var method = new PerUnitTaxCalculationMethod();
+
+        var result = method.Compute(new TaxComputationRequest
+        {
+            TaxableBase = 200m,
+            Quantity = 4m,
+            FixedAmount = 2.5m,
+        });
+
+        Assert.Equal(10m, result.TaxAmount);
+    }
+
+    [Fact]
+    public void PerWeight_MultipliesByWeight()
+    {
+        var method = new PerWeightTaxCalculationMethod();
+
+        var result = method.Compute(new TaxComputationRequest
+        {
+            TaxableBase = 200m,
+            Weight = 3m,
+            FixedAmount = 1.25m,
+        });
+
+        Assert.Equal(3.75m, result.TaxAmount);
+    }
+
+    [Fact]
+    public void PerVolume_MultipliesByVolume()
+    {
+        var method = new PerVolumeTaxCalculationMethod();
+
+        var result = method.Compute(new TaxComputationRequest
+        {
+            TaxableBase = 200m,
+            Volume = 5m,
+            FixedAmount = 0.5m,
+        });
+
+        Assert.Equal(2.5m, result.TaxAmount);
+    }
+
+    [Fact]
+    public void TaxTable_UsesMatchingBracket()
+    {
+        var method = new TaxTableTaxCalculationMethod();
+
+        var table = new TaxTable
+        {
+            Rows =
+            [
+                new TaxTableRow { Minimum = 0m, Maximum = 100m, Rate = 0.05m },
+                new TaxTableRow { Minimum = 100m, Maximum = null, Rate = 0.08m, FixedAmount = 2m },
+            ],
+        };
+
+        var result = method.Compute(new TaxComputationRequest
+        {
+            TaxableBase = 150m,
+            Table = table,
+        });
+
+        Assert.Equal((150m * 0.08m) + 2m, result.TaxAmount);
+        Assert.Equal(0.08m, result.EffectiveRate);
+    }
+
+    [Fact]
+    public void Progressive_TaxesEachBracketPortion()
+    {
+        var method = new ProgressiveTaxCalculationMethod();
+
+        var table = new TaxTable
+        {
+            Rows =
+            [
+                new TaxTableRow { Minimum = 0m, Maximum = 100m, Rate = 0.10m },
+                new TaxTableRow { Minimum = 100m, Maximum = 200m, Rate = 0.20m },
+                new TaxTableRow { Minimum = 200m, Maximum = null, Rate = 0.30m },
+            ],
+        };
+
+        var result = method.Compute(new TaxComputationRequest
+        {
+            TaxableBase = 250m,
+            Table = table,
+        });
+
+        // 100*0.10 + 100*0.20 + 50*0.30 = 10 + 20 + 15 = 45
+        Assert.Equal(45m, result.TaxAmount);
+    }
+
+    [Fact]
+    public void Threshold_TaxesExcessOverMinimum()
+    {
+        var method = new ThresholdTaxCalculationMethod();
+
+        var table = new TaxTable
+        {
+            Rows =
+            [
+                new TaxTableRow { Minimum = 0m, Maximum = 100m, Rate = 0m },
+                new TaxTableRow { Minimum = 100m, Maximum = null, Rate = 0.10m },
+            ],
+        };
+
+        var result = method.Compute(new TaxComputationRequest
+        {
+            TaxableBase = 180m,
+            Table = table,
+        });
+
+        // (180 - 100) * 0.10 = 8
+        Assert.Equal(8m, result.TaxAmount);
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/TaxExemptionTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/TaxExemptionTests.cs
@@ -1,0 +1,129 @@
+using CrestApps.OrchardCore.Taxation;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Tests.Taxation.Fakes;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class TaxExemptionTests
+{
+    private static TaxTestHarness CreateHarness()
+        => new(new TestClock(TaxTestData.TransactionDate));
+
+    private static async Task<string> SeedTaxedRuleAsync(TaxTestHarness harness, string jurisdictionId)
+    {
+        return await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Sales",
+            TaxType = TaxTypeNames.SalesTax,
+            JurisdictionId = jurisdictionId,
+            CategoryCode = "Electronics",
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+        });
+    }
+
+    [Fact]
+    public async Task Customer_MarkedTaxExempt_ProducesNoTax()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        await SeedTaxedRuleAsync(harness, jurisdictionId);
+
+        var context = TaxTestData.Context(100m, customer: new CustomerTaxProfile { IsTaxExempt = true }, categoryCode: "Electronics");
+        var result = await harness.TaxService.CalculateAsync(context);
+
+        Assert.Empty(result.Lines);
+    }
+
+    [Fact]
+    public async Task ValidCertificate_ExemptsTax()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        await SeedTaxedRuleAsync(harness, jurisdictionId);
+
+        var certificate = new ExemptionCertificate
+        {
+            Name = "Resale",
+            CertificateNumber = "RS-1",
+            Status = ExemptionStatus.Active,
+        };
+
+        await harness.Exemptions.CreateAsync(certificate);
+
+        var customer = new CustomerTaxProfile { ExemptionCertificateIds = [certificate.ItemId] };
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m, customer: customer, categoryCode: "Electronics"));
+
+        Assert.Empty(result.Lines);
+    }
+
+    [Fact]
+    public async Task ExpiredCertificate_DoesNotExempt()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        await SeedTaxedRuleAsync(harness, jurisdictionId);
+
+        var certificate = new ExemptionCertificate
+        {
+            Name = "Expired",
+            CertificateNumber = "EX-1",
+            Status = ExemptionStatus.Active,
+            ExpirationUtc = TaxTestData.TransactionDate.AddDays(-1),
+        };
+
+        await harness.Exemptions.CreateAsync(certificate);
+
+        var customer = new CustomerTaxProfile { ExemptionCertificateIds = [certificate.ItemId] };
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m, customer: customer, categoryCode: "Electronics"));
+
+        Assert.Single(result.Lines);
+    }
+
+    [Fact]
+    public async Task JurisdictionSpecificCertificate_OnlyExemptsMatchingJurisdiction()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        await SeedTaxedRuleAsync(harness, jurisdictionId);
+
+        var certificate = new ExemptionCertificate
+        {
+            Name = "Other jurisdiction",
+            CertificateNumber = "OJ-1",
+            Status = ExemptionStatus.Active,
+            JurisdictionIds = ["some-other-jurisdiction"],
+        };
+
+        await harness.Exemptions.CreateAsync(certificate);
+
+        var customer = new CustomerTaxProfile { ExemptionCertificateIds = [certificate.ItemId] };
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m, customer: customer, categoryCode: "Electronics"));
+
+        Assert.Single(result.Lines);
+    }
+
+    [Fact]
+    public async Task ClassificationSpecificCertificate_OnlyExemptsMatchingClassification()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        await SeedTaxedRuleAsync(harness, jurisdictionId);
+
+        var certificate = new ExemptionCertificate
+        {
+            Name = "Food only",
+            CertificateNumber = "FD-1",
+            Status = ExemptionStatus.Active,
+            ClassificationCodes = ["Food"],
+        };
+
+        await harness.Exemptions.CreateAsync(certificate);
+
+        var customer = new CustomerTaxProfile { ExemptionCertificateIds = [certificate.ItemId] };
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m, customer: customer, categoryCode: "Electronics"));
+
+        Assert.Single(result.Lines);
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/TaxNexusTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/TaxNexusTests.cs
@@ -1,0 +1,96 @@
+using CrestApps.OrchardCore.Taxation;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Tests.Taxation.Fakes;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class TaxNexusTests
+{
+    private static TaxTestHarness CreateHarness()
+        => new(new TestClock(TaxTestData.TransactionDate));
+
+    private static async Task<string> SeedRuleAsync(TaxTestHarness harness, string jurisdictionId)
+    {
+        return await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Sales",
+            TaxType = TaxTypeNames.SalesTax,
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+        });
+    }
+
+    [Fact]
+    public async Task NoRegistrations_TaxIsCollected()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        await SeedRuleAsync(harness, jurisdictionId);
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Single(result.Lines);
+    }
+
+    [Fact]
+    public async Task RegistrationCoversJurisdiction_TaxIsCollected()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        await SeedRuleAsync(harness, jurisdictionId);
+
+        await harness.Registrations.CreateAsync(new MerchantTaxRegistration
+        {
+            Name = "CA registration",
+            JurisdictionId = jurisdictionId,
+            TaxType = TaxTypeNames.SalesTax,
+            IsActive = true,
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Single(result.Lines);
+    }
+
+    [Fact]
+    public async Task RegistrationsExistButNoneCoverJurisdiction_TaxIsNotCollected()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        await SeedRuleAsync(harness, jurisdictionId);
+
+        await harness.Registrations.CreateAsync(new MerchantTaxRegistration
+        {
+            Name = "Texas registration",
+            JurisdictionId = "texas-jurisdiction",
+            TaxType = TaxTypeNames.SalesTax,
+            IsActive = true,
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Empty(result.Lines);
+    }
+
+    [Fact]
+    public async Task InactiveRegistration_DoesNotEstablishNexus()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        await SeedRuleAsync(harness, jurisdictionId);
+
+        await harness.Registrations.CreateAsync(new MerchantTaxRegistration
+        {
+            Name = "Inactive CA",
+            JurisdictionId = jurisdictionId,
+            TaxType = TaxTypeNames.SalesTax,
+            IsActive = false,
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Empty(result.Lines);
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/TaxProviderExtensibilityTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/TaxProviderExtensibilityTests.cs
@@ -1,0 +1,108 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Core;
+using CrestApps.OrchardCore.Taxation;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using CrestApps.OrchardCore.Tests.Taxation.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class TaxProviderExtensibilityTests
+{
+    [Fact]
+    public async Task CustomCalculationMethod_CanBeRegisteredAndUsedByRule()
+    {
+        var harness = new TaxTestHarness(
+            new TestClock(TaxTestData.TransactionDate),
+            services => services.AddTaxCalculationMethod<FlatTenTaxCalculationMethod>());
+
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Flat ten",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = FlatTenTaxCalculationMethod.MethodName,
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(250m));
+
+        var line = Assert.Single(result.Lines);
+        Assert.Equal(10m, line.TaxAmount);
+    }
+
+    [Fact]
+    public async Task ExternalDeterminationProvider_ShortCircuitsTheEngine()
+    {
+        var harness = new TaxTestHarness(
+            new TestClock(TaxTestData.TransactionDate),
+            services => services.AddTaxDeterminationProvider<StubExternalTaxProvider>());
+
+        // A jurisdiction and a percentage rule exist, but the external provider takes over.
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Ignored",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        var line = Assert.Single(result.Lines);
+        Assert.Equal("EXTERNAL", line.TaxCode);
+        Assert.Equal(42m, result.TaxAmount);
+    }
+
+    private sealed class FlatTenTaxCalculationMethod : ITaxCalculationMethod
+    {
+        public const string MethodName = "FlatTen";
+
+        public string Name => MethodName;
+
+        public TaxComputationResult Compute(TaxComputationRequest request)
+        {
+            return new TaxComputationResult
+            {
+                TaxableAmount = request.TaxableBase,
+                TaxAmount = 10m,
+                EffectiveRate = 0m,
+            };
+        }
+    }
+
+    private sealed class StubExternalTaxProvider : ITaxDeterminationProvider
+    {
+        public int Order => 0;
+
+        public bool CanHandle(TaxCalculationContext context) => true;
+
+        public Task<TaxCalculationResult> DetermineAsync(TaxCalculationContext context, CancellationToken cancellationToken = default)
+        {
+            var result = new TaxCalculationResult
+            {
+                Currency = context.Currency,
+                TaxableAmount = 100m,
+                TaxAmount = 42m,
+                TotalAmount = 142m,
+                Lines =
+                [
+                    new TaxLine
+                    {
+                        TaxCode = "EXTERNAL",
+                        TaxName = "External provider tax",
+                        TaxAmount = 42m,
+                        TaxableAmount = 100m,
+                    },
+                ],
+            };
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/TaxRoundingTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/TaxRoundingTests.cs
@@ -1,0 +1,66 @@
+using CrestApps.OrchardCore.Taxation;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Tests.Taxation.Fakes;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class TaxRoundingTests
+{
+    private static TaxTestHarness CreateHarness()
+        => new(new TestClock(TaxTestData.TransactionDate));
+
+    private static async Task SeedTwoRulesAsync(TaxTestHarness harness)
+    {
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "State",
+            TaxType = "STATE",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.0825m,
+        });
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "County",
+            TaxType = "COUNTY",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.0825m,
+        });
+    }
+
+    [Fact]
+    public async Task LineRounding_RoundsEachLineIndependently()
+    {
+        var harness = CreateHarness();
+        await SeedTwoRulesAsync(harness);
+
+        var context = TaxTestData.Context(10.10m);
+        context.RoundingLevel = TaxRoundingLevel.Line;
+
+        var result = await harness.TaxService.CalculateAsync(context);
+
+        // Each line: round(10.10 * 0.0825) = round(0.83325) = 0.83; total = 1.66.
+        Assert.All(result.Lines, line => Assert.Equal(0.83m, line.TaxAmount));
+        Assert.Equal(1.66m, result.TaxAmount);
+    }
+
+    [Fact]
+    public async Task TransactionRounding_RoundsAggregatedTotal()
+    {
+        var harness = CreateHarness();
+        await SeedTwoRulesAsync(harness);
+
+        var context = TaxTestData.Context(10.10m);
+        context.RoundingLevel = TaxRoundingLevel.Transaction;
+
+        var result = await harness.TaxService.CalculateAsync(context);
+
+        // Unrounded total: 2 * 0.83325 = 1.6665; rounded to 1.67.
+        Assert.Equal(1.67m, result.TaxAmount);
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/TaxServiceTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/TaxServiceTests.cs
@@ -1,0 +1,305 @@
+using CrestApps.OrchardCore.Taxation;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Tests.Taxation.Fakes;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class TaxServiceTests
+{
+    private static TaxTestHarness CreateHarness()
+        => new(new TestClock(TaxTestData.TransactionDate));
+
+    [Fact]
+    public async Task Calculate_WithNoRules_ReturnsZeroTax()
+    {
+        var harness = CreateHarness();
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Empty(result.Lines);
+        Assert.Equal(0m, result.TaxAmount);
+        Assert.Equal(100m, result.TotalAmount);
+    }
+
+    [Fact]
+    public async Task Calculate_ExclusivePercentage_AddsTaxToTotal()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "CA Sales Tax",
+            TaxType = TaxTypeNames.SalesTax,
+            TaxName = "CA Sales Tax",
+            TaxCode = "US-CA-SALES",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.075m,
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(200m));
+
+        var line = Assert.Single(result.Lines);
+        Assert.Equal(15m, line.TaxAmount);
+        Assert.Equal(jurisdictionId, line.JurisdictionId);
+        Assert.Equal("California", line.JurisdictionName);
+        Assert.Equal(200m, result.TaxableAmount);
+        Assert.Equal(15m, result.TaxAmount);
+        Assert.Equal(215m, result.TotalAmount);
+    }
+
+    [Fact]
+    public async Task Calculate_InclusivePricing_ExtractsTaxFromPrice()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "VAT",
+            TaxType = TaxTypeNames.Vat,
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.20m,
+        });
+
+        var context = TaxTestData.Context(120m);
+        context.DefaultPriceType = TaxPriceType.Inclusive;
+
+        var result = await harness.TaxService.CalculateAsync(context);
+
+        var line = Assert.Single(result.Lines);
+        Assert.Equal(20m, line.TaxAmount);
+        Assert.True(line.IncludedInPrice);
+        Assert.Equal(100m, result.TaxableAmount);
+        Assert.Equal(120m, result.TotalAmount);
+    }
+
+    [Fact]
+    public async Task Calculate_MultipleSimultaneousTaxes_AccumulatesLines()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "State",
+            TaxType = TaxTypeNames.SalesTax,
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.06m,
+        });
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "City",
+            TaxType = TaxTypeNames.SalesTax,
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.025m,
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Equal(2, result.Lines.Count);
+        Assert.Equal(8.5m, result.TaxAmount);
+    }
+
+    [Fact]
+    public async Task Calculate_CompoundTax_TaxesPriorTax()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "Quebec", "CA", "QC");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "GST",
+            TaxType = TaxTypeNames.Gst,
+            JurisdictionId = jurisdictionId,
+            Priority = 1,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.05m,
+        });
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "QST",
+            TaxType = TaxTypeNames.Qst,
+            JurisdictionId = jurisdictionId,
+            Priority = 2,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.09975m,
+            IsCompound = true,
+        });
+
+        var context = TaxTestData.Context(100m, destination: new TaxAddress { Country = "CA", Region = "QC" });
+        var result = await harness.TaxService.CalculateAsync(context);
+
+        var gst = result.Lines.Single(line => line.TaxType == TaxTypeNames.Gst);
+        var qst = result.Lines.Single(line => line.TaxType == TaxTypeNames.Qst);
+
+        Assert.Equal(5m, gst.TaxAmount);
+        // QST is compound: (100 + 5) * 0.09975 = 10.47375, rounded per line to 10.47.
+        Assert.Equal(10.47m, qst.TaxAmount);
+    }
+
+    [Fact]
+    public async Task Calculate_ExpiredRule_IsNotApplied()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Old",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+            EffectiveToUtc = TaxTestData.TransactionDate.AddDays(-1),
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Empty(result.Lines);
+    }
+
+    [Fact]
+    public async Task Calculate_FutureRule_IsNotApplied()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Future",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+            EffectiveFromUtc = TaxTestData.TransactionDate.AddDays(1),
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Empty(result.Lines);
+    }
+
+    [Fact]
+    public async Task Calculate_CategoryMismatch_SkipsRule()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Alcohol only",
+            JurisdictionId = jurisdictionId,
+            CategoryCode = "Alcohol",
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+        });
+
+        var electronics = TaxTestData.Context(100m, categoryCode: "Electronics");
+        var alcohol = TaxTestData.Context(100m, categoryCode: "Alcohol");
+
+        Assert.Empty((await harness.TaxService.CalculateAsync(electronics)).Lines);
+        Assert.Single((await harness.TaxService.CalculateAsync(alcohol)).Lines);
+    }
+
+    [Fact]
+    public async Task Calculate_B2BRule_DoesNotApplyToB2CCustomer()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "B2B tax",
+            JurisdictionId = jurisdictionId,
+            CustomerType = CustomerTaxType.B2B,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+        });
+
+        var b2c = TaxTestData.Context(100m, customer: new CustomerTaxProfile { CustomerType = CustomerTaxType.B2C });
+        var b2b = TaxTestData.Context(100m, customer: new CustomerTaxProfile { CustomerType = CustomerTaxType.B2B });
+
+        Assert.Empty((await harness.TaxService.CalculateAsync(b2c)).Lines);
+        Assert.Single((await harness.TaxService.CalculateAsync(b2b)).Lines);
+    }
+
+    [Fact]
+    public async Task Calculate_MultiJurisdiction_OnlyMatchingApplies()
+    {
+        var harness = CreateHarness();
+        var californiaId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+        var texasId = await TaxTestData.AddJurisdictionAsync(harness, "Texas", "US", "TX");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "CA",
+            JurisdictionId = californiaId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.075m,
+        });
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "TX",
+            JurisdictionId = texasId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.0625m,
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        var line = Assert.Single(result.Lines);
+        Assert.Equal(californiaId, line.JurisdictionId);
+        Assert.Equal(7.5m, line.TaxAmount);
+    }
+
+    [Fact]
+    public async Task Calculate_FixedAmountRule_AppliesFlatTax()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Env fee",
+            TaxType = TaxTypeNames.ExciseTax,
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.FixedAmount,
+            FixedAmount = 3m,
+        });
+
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Equal(3m, result.TaxAmount);
+        Assert.Equal(103m, result.TotalAmount);
+    }
+
+    [Fact]
+    public async Task Calculate_DiscountReducesTaxableBase()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Sales",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+        });
+
+        var context = TaxTestData.Context(100m);
+        ((TaxableItem)context.Items[0]).DiscountAmount = 20m;
+
+        var result = await harness.TaxService.CalculateAsync(context);
+
+        // (100 - 20) * 0.10 = 8
+        Assert.Equal(8m, result.TaxAmount);
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/TaxSnapshotTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/TaxSnapshotTests.cs
@@ -1,0 +1,106 @@
+using CrestApps.OrchardCore.Taxation;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using CrestApps.OrchardCore.Tests.Taxation.Fakes;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class TaxSnapshotTests
+{
+    private static TaxTestHarness CreateHarness()
+        => new(new TestClock(TaxTestData.TransactionDate));
+
+    [Fact]
+    public async Task Snapshot_RemainsUnchanged_WhenRuleRateChangesLater()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        var rule = new TaxRule
+        {
+            Name = "Sales",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+            Version = 1,
+        };
+
+        await TaxTestData.AddRuleAsync(harness, rule);
+
+        var snapshotFactory = harness.GetService<ITaxSnapshotFactory>();
+        var originalResult = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+        var snapshot = snapshotFactory.Create(TaxTestData.Context(100m), originalResult);
+
+        Assert.Equal(10m, snapshot.TaxAmount);
+        Assert.Equal(1, snapshot.Lines[0].RuleVersion);
+
+        // The merchant later raises the rate and publishes a new rule version.
+        rule.Rate = 0.20m;
+        rule.Version = 2;
+        await harness.Rules.UpdateAsync(rule);
+
+        var recalculated = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+
+        Assert.Equal(20m, recalculated.TaxAmount);
+
+        // The historical snapshot is immutable and still reflects the original determination.
+        Assert.Equal(10m, snapshot.TaxAmount);
+        Assert.Equal(1, snapshot.Lines[0].RuleVersion);
+    }
+
+    [Fact]
+    public async Task Snapshot_IsIsolatedFromSubsequentResultMutation()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        await TaxTestData.AddRuleAsync(harness, new TaxRule
+        {
+            Name = "Sales",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+        });
+
+        var snapshotFactory = harness.GetService<ITaxSnapshotFactory>();
+        var result = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+        var snapshot = snapshotFactory.Create(TaxTestData.Context(100m), result);
+
+        result.Lines[0].TaxAmount = 999m;
+        result.TaxAmount = 999m;
+
+        Assert.Equal(10m, snapshot.Lines[0].TaxAmount);
+        Assert.Equal(10m, snapshot.TaxAmount);
+    }
+
+    [Fact]
+    public async Task Refund_UsesOriginalSnapshotDetermination()
+    {
+        var harness = CreateHarness();
+        var jurisdictionId = await TaxTestData.AddJurisdictionAsync(harness, "California", "US", "CA");
+
+        var rule = new TaxRule
+        {
+            Name = "Sales",
+            JurisdictionId = jurisdictionId,
+            CalculationMethod = TaxCalculationMethodNames.Percentage,
+            Rate = 0.10m,
+        };
+
+        await TaxTestData.AddRuleAsync(harness, rule);
+
+        var snapshotFactory = harness.GetService<ITaxSnapshotFactory>();
+        var sale = await harness.TaxService.CalculateAsync(TaxTestData.Context(100m));
+        var snapshot = snapshotFactory.Create(TaxTestData.Context(100m), sale);
+
+        // The rate changes before the refund is issued.
+        rule.Rate = 0.25m;
+        await harness.Rules.UpdateAsync(rule);
+
+        // A refund reverses the original snapshot, not today's rate.
+        var refundTax = -snapshot.TaxAmount;
+
+        Assert.Equal(-10m, refundTax);
+    }
+}


### PR DESCRIPTION
Introduce a provider-agnostic, extensible taxation framework for Orchard Core that models tax as a determination derived from what is sold, who buys it, where it is sourced, when it occurs, and how it is calculated - rather than a static rate stored on a product.

- Add CrestApps.OrchardCore.Taxation.Abstractions with the public contracts, DTOs, enums, and models (ITaxableItem, ITaxService, ITaxCalculationMethod, ITaxSourcingStrategy, ITaxDeterminationProvider, jurisdictions, categories, versioned rules, tax tables, exemption certificates, merchant nexus, and the auditable TaxCalculationResult and TaxSnapshot).
- Add CrestApps.OrchardCore.Taxation.Core with the deterministic tax engine, built-in calculation methods (percentage, fixed, per-unit, per-weight, per-volume, tax table, progressive, threshold), sourcing strategies, rounding, exemption/nexus resolution, snapshot factory, catalog-backed stores, and the AddTaxationCore registration and extension helpers.
- Add the CrestApps.OrchardCore.Taxation module with the TaxationPart (tax classification only, never a stored rate), its driver, migrations, and the ContentItemTaxableItemProvider so any content type can become taxable.
- Wire the projects into the solution, targets, and test project.
- Add 40 unit tests covering every calculation method, engine end-to-end, exemptions, nexus, snapshot immutability and refunds, rounding levels, content-type extensibility, and provider extensibility.
- Document the module in the docs site and add it as a new feature in the 3.0.0 changelog.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
