### PR TITLE
Add Taxation management admin UI for categories, jurisdictions, and r…

### DIFF
--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxCategory.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxCategory.cs
@@ -36,8 +36,23 @@ public sealed class TaxCategory : CatalogItem, INameAwareModel, IModifiedUtcAwar
     /// </summary>
     public IDictionary<string, string> ExternalCodes { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Gets or sets the UTC date the category was created.
+    /// </summary>
+    public DateTime CreatedUtc { get; set; }
+
     /// <inheritdoc />
     public DateTime? ModifiedUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the user that authored the category.
+    /// </summary>
+    public string Author { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the user that owns the category.
+    /// </summary>
+    public string OwnerId { get; set; }
 
     /// <inheritdoc />
     public TaxCategory Clone()
@@ -50,7 +65,10 @@ public sealed class TaxCategory : CatalogItem, INameAwareModel, IModifiedUtcAwar
             ParentCode = ParentCode,
             Description = Description,
             ExternalCodes = new Dictionary<string, string>(ExternalCodes, StringComparer.OrdinalIgnoreCase),
+            CreatedUtc = CreatedUtc,
             ModifiedUtc = ModifiedUtc,
+            Author = Author,
+            OwnerId = OwnerId,
         };
     }
 }

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxJurisdiction.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxJurisdiction.cs
@@ -67,6 +67,21 @@ public sealed class TaxJurisdiction : CatalogItem, INameAwareModel, IModifiedUtc
     /// <inheritdoc />
     public DateTime? ModifiedUtc { get; set; }
 
+    /// <summary>
+    /// Gets or sets the UTC date the jurisdiction was created.
+    /// </summary>
+    public DateTime CreatedUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the user that authored the jurisdiction.
+    /// </summary>
+    public string Author { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the user that owns the jurisdiction.
+    /// </summary>
+    public string OwnerId { get; set; }
+
     /// <inheritdoc />
     public TaxJurisdiction Clone()
     {
@@ -84,7 +99,10 @@ public sealed class TaxJurisdiction : CatalogItem, INameAwareModel, IModifiedUtc
             ParentId = ParentId,
             EffectiveFromUtc = EffectiveFromUtc,
             EffectiveToUtc = EffectiveToUtc,
+            CreatedUtc = CreatedUtc,
             ModifiedUtc = ModifiedUtc,
+            Author = Author,
+            OwnerId = OwnerId,
         };
     }
 }

--- a/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxRule.cs
+++ b/src/Abstractions/CrestApps.OrchardCore.Taxation.Abstractions/Models/TaxRule.cs
@@ -121,6 +121,21 @@ public sealed class TaxRule : CatalogItem, INameAwareModel, IModifiedUtcAwareMod
     /// <inheritdoc />
     public DateTime? ModifiedUtc { get; set; }
 
+    /// <summary>
+    /// Gets or sets the UTC date the rule was created.
+    /// </summary>
+    public DateTime CreatedUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the user that authored the rule.
+    /// </summary>
+    public string Author { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the user that owns the rule.
+    /// </summary>
+    public string OwnerId { get; set; }
+
     /// <inheritdoc />
     public TaxRule Clone()
     {
@@ -148,7 +163,10 @@ public sealed class TaxRule : CatalogItem, INameAwareModel, IModifiedUtcAwareMod
             MaximumAmount = MaximumAmount,
             EffectiveFromUtc = EffectiveFromUtc,
             EffectiveToUtc = EffectiveToUtc,
+            CreatedUtc = CreatedUtc,
             ModifiedUtc = ModifiedUtc,
+            Author = Author,
+            OwnerId = OwnerId,
         };
     }
 }

--- a/src/Core/CrestApps.OrchardCore.Taxation.Core/TaxationPermissions.cs
+++ b/src/Core/CrestApps.OrchardCore.Taxation.Core/TaxationPermissions.cs
@@ -1,6 +1,6 @@
 using OrchardCore.Security.Permissions;
 
-namespace CrestApps.OrchardCore.Taxation;
+namespace CrestApps.OrchardCore.Taxation.Core;
 
 /// <summary>
 /// Represents the permissions exposed by the taxation module.

--- a/src/CrestApps.Docs/docs/modules/taxation.md
+++ b/src/CrestApps.Docs/docs/modules/taxation.md
@@ -33,9 +33,44 @@ The framework is split into three assemblies:
 
 Enable the **Taxation** feature under **Tools → Features**, then:
 
-1. Attach the **Taxation** part to a content type and classify it (see [The TaxationPart](#the-taxationpart)).
-2. Seed jurisdictions, categories, and rules (see [Domain model](#domain-model)).
+1. Create your tax **categories**, **jurisdictions**, and **rules** from the admin UI (see [Managing taxation from the admin UI](#managing-taxation-from-the-admin-ui)).
+2. Attach the **Taxation** part to a content type and classify it (see [The TaxationPart](#the-taxationpart)).
 3. At checkout, convert your objects into taxable items and call `ITaxService.CalculateAsync` (see [Calculating tax](#calculating-tax)).
+
+## Managing taxation from the admin UI
+
+Once the feature is enabled, an admin with the **Manage taxation** permission gets a **Commerce → Taxation** menu with three screens: **Categories**, **Jurisdictions**, and **Rules**. Each screen is a searchable list with **Add**, **Edit**, and **Delete** actions, and is rendered through Orchard Core's display management so the list items and editors can be extended or overridden by other modules.
+
+Setting up taxes end to end is a four-step workflow. The order matters, because rules reference jurisdictions and categories, and content classification reuses the categories you create.
+
+### 1. Define what you sell — Categories
+
+Go to **Commerce → Taxation → Categories** and add a category for each kind of thing you tax (for example `Electronics`, or a finer `Television`). A category has:
+
+- **Name** — a human-readable label (the unique key, fixed after creation).
+- **Code** — the value matched by tax rules and stored on taxable items (for example `Electronics`).
+- **Parent code** — an optional parent category code, forming a hierarchy.
+- **Description** — optional notes.
+
+Create the broad categories you match rules against, plus any finer classifications you want to assign to individual items.
+
+### 2. Define where you tax — Jurisdictions
+
+Go to **Commerce → Taxation → Jurisdictions** and add a taxing authority for each place you collect tax. Jurisdictions are hierarchical (country → region → county → city → special district) and are matched to an address by their non-empty components. Key fields include the **Level**, an optional **Parent jurisdiction**, the geographic components (**Country**, **Region**, **County**, **City**, **Postal code**), and optional **Effective from/to** dates.
+
+### 3. Define how tax applies — Rules
+
+Go to **Commerce → Taxation → Rules** and add a rule that binds a jurisdiction and category to a calculation. A rule lets you choose the **Jurisdiction**, the **Category** it applies to (or *Any category*), the **Tax type**, the **Calculation method**, the **Rate** or **Fixed amount**, the **Customer type** (or *Any customer*), a **Priority**, **Effective from/to** dates, minimum/maximum thresholds, and flags such as **Enabled**, **Included in price**, **Compound**, and **Applies to shipping**. A disabled rule is never applied, and rules outside their effective window are ignored.
+
+### 4. Classify your content
+
+Attach the **Taxation** part to your content types (see [The TaxationPart](#the-taxationpart)) and, on each item, pick its **Tax category** and optional **Tax classification** from the dropdowns. Those dropdowns are populated from the categories you created in step 1, so there are no free-text codes to keep in sync.
+
+With categories, jurisdictions, and rules in place and your content classified, the engine determines and applies the correct tax automatically at checkout — no per-type tax code is required.
+
+:::tip
+Create at least one **Category** before configuring a content type. The **Tax category** and **Tax classification** dropdowns in the TaxationPart settings and item editors are sourced from the categories catalog, so an empty catalog leaves only the *None* option.
+:::
 
 ## Core concepts
 
@@ -108,9 +143,11 @@ A content editor can then leave the defaults or override the classification per 
 
 | Setting | Description |
 |---------|-------------|
-| `DefaultTaxCategoryCode` | The category applied when the item does not specify one. |
-| `DefaultTaxClassificationCode` | The classification applied when the item does not specify one. |
+| `DefaultTaxCategoryCode` | The category applied when the item does not specify one. Selected from the categories catalog. |
+| `DefaultTaxClassificationCode` | The classification applied when the item does not specify one. Selected from the categories catalog. |
 | `AllowClassificationOverride` | Whether editors may override the classification per content item. |
+
+In the content-type editor, **Default tax category** and **Default tax classification** are dropdowns populated from the tax categories you created under **Commerce → Taxation → Categories**, so create your categories first. When `AllowClassificationOverride` is disabled, editors do not see the category/classification fields and the defaults configured here are always used.
 
 ## Domain model
 

--- a/src/CrestApps.Docs/docs/modules/taxation.md
+++ b/src/CrestApps.Docs/docs/modules/taxation.md
@@ -339,6 +339,7 @@ The main extension points are:
 | `ITaxCalculationMethod` | A calculation strategy resolvable by name. |
 | `ITaxSourcingStrategy` | Where the tax is sourced from. |
 | `ITaxRuleProvider` | Supplies applicable rules for a query. |
+| `ITaxClassificationProvider` | Supplies an *inherited* classification (category / classification / external code) for a content item that does not carry its own — for example from a taxonomy term. |
 | `ITaxJurisdictionResolver` | Maps an address to jurisdictions. |
 | `ITaxExemptionResolver` | Determines customer exemptions. |
 | `IMerchantTaxRegistrationProvider` | Determines merchant nexus. |
@@ -349,6 +350,109 @@ The main extension points are:
 | `ITaxDeterminationProvider` | Short-circuits the engine with an external determination. |
 
 An `ITaxDeterminationProvider` whose `CanHandle` returns `true` takes over the entire calculation, which is how third-party tax services (for example `CrestApps.OrchardCore.Taxation.Avalara` or `CrestApps.OrchardCore.Taxation.Stripe`) can be layered on top of the same abstractions.
+
+## Per-category taxation with taxonomies
+
+A common question is *"how do I apply a different tax code to a whole category of products — for example an excise tax on all Tobacco items?"*
+
+You do **not** put multiple codes on each item. An item carries a single **tax category code** (plus an optional classification code); the *multiplicity* of applied taxes comes from multiple **rules** matching that one category in a jurisdiction. A rule with no `CategoryCode` matches every category (a general sales tax), and it naturally **stacks** with a `CategoryCode = "Tobacco"` excise rule so a pack of cigarettes is taxed by both.
+
+To manage the category assignment per group of products rather than item-by-item, enable the **`OrchardCore.Taxonomies`** feature and let items **inherit** their classification from the taxonomy term they belong to:
+
+1. Create a taxonomy (for example *Product Categories*) with terms such as *Electronics*, *Tobacco*, *Alcohol*.
+2. Attach the **Taxation** part to the **term** content type, and set the **Tax category** (and optional classification) on each term — e.g. the *Tobacco* term gets category `Tobacco`.
+3. Attach a **Taxonomy** field to your product type and tag each product with its term(s).
+
+Now any product tagged *Tobacco* is taxed as `Tobacco` without setting a code on the product itself. The resolution precedence is:
+
+1. The item's **own** `TaxationPart` category (an explicit code on the item always wins).
+2. The classification supplied by the registered `ITaxClassificationProvider`s, consulted in ascending `Order`; the first provider that returns a non-empty category wins (the built-in provider reads the tagged taxonomy term's `TaxationPart`).
+3. The type default configured in the TaxationPart settings.
+
+Only the category is inherited when the item omits it; a classification code set explicitly on the item is preserved. Write your own `ITaxClassificationProvider` to source inherited codes from any other place (an ERP, a parent content item, etc.).
+
+### Worked example — an excise tax on Tobacco
+
+Suppose a US store sells electronics and tobacco. California charges 7.5% sales tax on everything **and** an extra 30% excise tax on tobacco.
+
+1. **Categories** — create `ELEC` (Electronics) and `TOBACCO` (Tobacco).
+2. **Taxonomy** — create a *Product Categories* taxonomy whose **term** content type has the **Taxation** part attached. On the *Tobacco* term set **Tax category = Tobacco**; on the *Electronics* term set **Tax category = Electronics**.
+3. **Products** — add a **Taxonomy** field to the *Product* type and tag each product with its category term. You do **not** set a tax code on the product itself.
+4. **Jurisdiction** — create *California* (`US` / `CA`, level *State*).
+5. **Rules** in California:
+   - a general rule with **no category** at 7.5% (applies to every product), and
+   - a tobacco rule with **category `TOBACCO`** at 30%.
+
+A television tagged *Electronics* inherits category `ELEC`, matches only the general rule → 7.5%. A pack of cigarettes tagged *Tobacco* inherits category `TOBACCO`, matches **both** rules → 7.5% + 30% stacked. No per-item tax codes were entered.
+
+The whole setup is reproducible as a recipe — the taxonomy term simply carries a `TaxationPart` value:
+
+```json
+{
+  "steps": [
+    {
+      "name": "content",
+      "data": [
+        {
+          "ContentType": "ProductCategory",
+          "DisplayText": "Tobacco",
+          "TaxationPart": { "Taxable": true, "TaxCategoryCode": "TOBACCO" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Common scenarios
+
+| You want to… | Do this |
+|---|---|
+| Apply one tax to everything | Create a jurisdiction and a single rule with **no category code**. Every taxable item matches it. |
+| Tax a single product differently | Set the **Tax category** directly on that item's **Taxation** part. An explicit item code always overrides inheritance. |
+| Give every item of a type a default code | Set the **default tax category** in the content type's **TaxationPart settings**. It applies when the item and its taxonomy term leave the code empty. |
+| Tax a whole category/group differently | Enable **`OrchardCore.Taxonomies`**, attach the **Taxation** part to the term type, set the code on the term, and tag products with the term. See [Per-category taxation with taxonomies](#per-category-taxation-with-taxonomies). |
+| Stack an extra tax (excise, environmental fee) on some items | Keep the general rule (no category) and add a second rule scoped to that category. Both match and stack. |
+| Exempt a customer or region | Implement an `ITaxExemptionResolver`; see [Extending the framework](#extending-the-framework). |
+| Delegate to Avalara / Stripe Tax | Register an `ITaxDeterminationProvider` that short-circuits the engine. |
+| Move a catalog between environments | Export the categories, jurisdictions, and rules as a [recipe or deployment plan](#recipes-and-deployment). |
+
+## Recipes and deployment
+
+The three catalog entities — **Tax categories**, **Tax jurisdictions**, and **Tax rules** — can be imported and exported as code.
+
+**Recipe steps** (names `TaxCategory`, `TaxJurisdiction`, `TaxRule`) each take a plural array payload. Environment-owned fields (`CreatedUtc`, `ModifiedUtc`, `Author`, `OwnerId`) are never imported; an entry is matched by its `ItemId` and updated in place, or created when new:
+
+```json
+{
+  "steps": [
+    {
+      "name": "TaxCategory",
+      "TaxCategories": [
+        { "ItemId": "electronics", "Name": "Electronics", "Code": "ELEC" },
+        { "ItemId": "tobacco", "Name": "Tobacco", "Code": "TOBACCO" }
+      ]
+    },
+    {
+      "name": "TaxJurisdiction",
+      "TaxJurisdictions": [
+        { "ItemId": "us-ca", "Name": "California", "CountryCode": "US", "RegionCode": "CA", "Level": "State" }
+      ]
+    },
+    {
+      "name": "TaxRule",
+      "TaxRules": [
+        { "ItemId": "ca-sales", "Name": "CA sales tax", "JurisdictionId": "us-ca", "CalculationMethod": "Percentage", "Rate": 0.075 },
+        { "ItemId": "ca-tobacco", "Name": "CA tobacco excise", "JurisdictionId": "us-ca", "CategoryCode": "TOBACCO", "CalculationMethod": "Percentage", "Rate": 0.30 }
+      ]
+    }
+  ]
+}
+```
+
+When the **`CrestApps.OrchardCore.Recipes`** feature is enabled, JSON Schema is contributed for each of these steps (and for the `TaxationPart` and its settings), giving editor validation and IntelliSense while authoring recipes.
+
+**Deployment steps** with the same three names are available under **Configuration → Deployment**, so an existing tenant's taxation catalog can be exported into a deployment plan and re-imported elsewhere. The exported JSON is identical in shape to the recipe payloads above.
 
 ## Determinism
 

--- a/src/Modules/CrestApps.OrchardCore.Taxation/ConfigurationDeploymentStartup.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/ConfigurationDeploymentStartup.cs
@@ -1,0 +1,28 @@
+using CrestApps.OrchardCore.Taxation.Deployments.Drivers;
+using CrestApps.OrchardCore.Taxation.Deployments.Sources;
+using CrestApps.OrchardCore.Taxation.Deployments.Steps;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Deployment;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Registers the deployment steps that export taxation configuration.
+/// </summary>
+[RequireFeatures("OrchardCore.Deployment")]
+public sealed class ConfigurationDeploymentStartup : StartupBase
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddDeployment<TaxCategoryDeploymentSource, TaxCategoryDeploymentStep>();
+        services.AddDeployment<TaxJurisdictionDeploymentSource, TaxJurisdictionDeploymentStep>();
+        services.AddDeployment<TaxRuleDeploymentSource, TaxRuleDeploymentStep>();
+
+        services.AddDisplayDriver<DeploymentStep, TaxCategoryDeploymentStepDisplayDriver>();
+        services.AddDisplayDriver<DeploymentStep, TaxJurisdictionDeploymentStepDisplayDriver>();
+        services.AddDisplayDriver<DeploymentStep, TaxRuleDeploymentStepDisplayDriver>();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/ConfigurationRecipesStartup.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/ConfigurationRecipesStartup.cs
@@ -1,0 +1,21 @@
+using CrestApps.OrchardCore.Taxation.Recipes;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Modules;
+using OrchardCore.Recipes;
+
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Registers the recipe steps that import taxation configuration.
+/// </summary>
+[RequireFeatures("OrchardCore.Recipes.Core")]
+public sealed class ConfigurationRecipesStartup : StartupBase
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddRecipeExecutionStep<TaxCategoryStep>();
+        services.AddRecipeExecutionStep<TaxJurisdictionStep>();
+        services.AddRecipeExecutionStep<TaxRuleStep>();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxCategoriesController.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxCategoriesController.cs
@@ -1,0 +1,271 @@
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Core.Models;
+using CrestApps.OrchardCore.Core.Validation;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Navigation;
+using OrchardCore.Routing;
+using QueryContext = CrestApps.Core.Models.QueryContext;
+
+namespace CrestApps.OrchardCore.Taxation.Controllers;
+
+/// <summary>
+/// Provides admin endpoints for managing <see cref="TaxCategory"/> entries.
+/// </summary>
+[Admin]
+public sealed class TaxCategoriesController : Controller
+{
+    private const string _optionsSearch = "Options.Search";
+    private const string _nameFieldName = "Name";
+
+    private readonly INamedCatalogManager<TaxCategory> _manager;
+    private readonly INamedCatalog<TaxCategory> _catalog;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IUpdateModelAccessor _updateModelAccessor;
+    private readonly IDisplayManager<TaxCategory> _displayManager;
+    private readonly INotifier _notifier;
+
+    internal readonly IHtmlLocalizer H;
+    internal readonly IStringLocalizer S;
+
+    public TaxCategoriesController(
+        INamedCatalogManager<TaxCategory> manager,
+        INamedCatalog<TaxCategory> catalog,
+        IAuthorizationService authorizationService,
+        IUpdateModelAccessor updateModelAccessor,
+        IDisplayManager<TaxCategory> displayManager,
+        INotifier notifier,
+        IHtmlLocalizer<TaxCategoriesController> htmlLocalizer,
+        IStringLocalizer<TaxCategoriesController> stringLocalizer)
+    {
+        _manager = manager;
+        _catalog = catalog;
+        _authorizationService = authorizationService;
+        _updateModelAccessor = updateModelAccessor;
+        _displayManager = displayManager;
+        _notifier = notifier;
+        H = htmlLocalizer;
+        S = stringLocalizer;
+    }
+
+    [Admin("taxation/categories", "TaxationCategoriesIndex")]
+    public async Task<IActionResult> Index(
+        CatalogEntryOptions options,
+        PagerParameters pagerParameters,
+        [FromServices] IOptions<PagerOptions> pagerOptions,
+        [FromServices] IShapeFactory shapeFactory)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var pager = new Pager(pagerParameters, pagerOptions.Value.GetPageSize());
+
+        var result = await _manager.PageAsync(pager.Page, pager.PageSize, new QueryContext
+        {
+            Name = options.Search,
+        });
+
+        var routeData = new RouteData();
+
+        if (!string.IsNullOrEmpty(options.Search))
+        {
+            routeData.Values.TryAdd(_optionsSearch, options.Search);
+        }
+
+        var viewModel = new ListCatalogEntryViewModel<CatalogEntryViewModel<TaxCategory>>
+        {
+            Models = [],
+            Options = options,
+            Pager = await shapeFactory.PagerAsync(pager, result.Count, routeData),
+        };
+
+        foreach (var model in result.Entries)
+        {
+            viewModel.Models.Add(new CatalogEntryViewModel<TaxCategory>
+            {
+                Model = model,
+                Shape = await _displayManager.BuildDisplayAsync(model, _updateModelAccessor.ModelUpdater, "SummaryAdmin"),
+            });
+        }
+
+        viewModel.Options.BulkActions = [];
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Index))]
+    [FormValueRequired("submit.Filter")]
+    [Admin("taxation/categories", "TaxationCategoriesIndex")]
+    public IActionResult IndexFilterPost(ListCatalogEntryViewModel model)
+        => RedirectToAction(nameof(Index), new RouteValueDictionary
+        {
+            { _optionsSearch, model.Options?.Search },
+        });
+
+    [Admin("taxation/categories/create", "TaxationCategoriesCreate")]
+    public async Task<IActionResult> Create()
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.NewAsync();
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = S["Tax Category"],
+            Editor = await _displayManager.BuildEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Create))]
+    [Admin("taxation/categories/create", "TaxationCategoriesCreate")]
+    public async Task<IActionResult> CreatePost()
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.NewAsync();
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = S["Tax Category"],
+            Editor = await _displayManager.UpdateEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        var isValid = await CatalogEntryValidation.ValidateAsync(_manager, model, _updateModelAccessor.ModelUpdater, nameof(TaxCategory));
+
+        if (isValid && ModelState.IsValid)
+        {
+            var existing = await _catalog.FindByNameAsync(model.Name);
+
+            if (existing != null)
+            {
+                ModelState.AddModelError(_nameFieldName, S["A tax category with the same name already exists."]);
+            }
+
+            if (ModelState.IsValid)
+            {
+                await _manager.CreateAsync(model);
+                await _notifier.SuccessAsync(H["The tax category has been created successfully."]);
+
+                return RedirectToAction(nameof(Index));
+            }
+        }
+
+        return View(viewModel);
+    }
+
+    [Admin("taxation/categories/edit/{id}", "TaxationCategoriesEdit")]
+    public async Task<IActionResult> Edit(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = model.Name,
+            Editor = await _displayManager.BuildEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Edit))]
+    [Admin("taxation/categories/edit/{id}", "TaxationCategoriesEdit")]
+    public async Task<IActionResult> EditPost(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = model.Name,
+            Editor = await _displayManager.UpdateEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        var isValid = await CatalogEntryValidation.ValidateAsync(_manager, model, _updateModelAccessor.ModelUpdater, nameof(TaxCategory));
+
+        if (isValid && ModelState.IsValid)
+        {
+            var existing = await _catalog.FindByNameAsync(model.Name);
+
+            if (existing != null && !string.Equals(existing.ItemId, model.ItemId, StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError(_nameFieldName, S["A tax category with the same name already exists."]);
+            }
+
+            if (ModelState.IsValid)
+            {
+                await _manager.UpdateAsync(model);
+                await _notifier.SuccessAsync(H["The tax category has been updated successfully."]);
+
+                return RedirectToAction(nameof(Index));
+            }
+        }
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName("Delete")]
+    [Admin("taxation/categories/delete/{id}", "TaxationCategoriesDelete")]
+    public async Task<IActionResult> DeletePost(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        if (await _manager.DeleteAsync(model))
+        {
+            await _notifier.SuccessAsync(H["The tax category has been deleted successfully."]);
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxCategoriesController.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxCategoriesController.cs
@@ -1,6 +1,7 @@
 using CrestApps.Core.Services;
 using CrestApps.OrchardCore.Core.Models;
 using CrestApps.OrchardCore.Core.Validation;
+using CrestApps.OrchardCore.Taxation.Core;
 using CrestApps.OrchardCore.Taxation.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxJurisdictionsController.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxJurisdictionsController.cs
@@ -1,6 +1,7 @@
 using CrestApps.Core.Services;
 using CrestApps.OrchardCore.Core.Models;
 using CrestApps.OrchardCore.Core.Validation;
+using CrestApps.OrchardCore.Taxation.Core;
 using CrestApps.OrchardCore.Taxation.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxJurisdictionsController.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxJurisdictionsController.cs
@@ -1,0 +1,271 @@
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Core.Models;
+using CrestApps.OrchardCore.Core.Validation;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Navigation;
+using OrchardCore.Routing;
+using QueryContext = CrestApps.Core.Models.QueryContext;
+
+namespace CrestApps.OrchardCore.Taxation.Controllers;
+
+/// <summary>
+/// Provides admin endpoints for managing <see cref="TaxJurisdiction"/> entries.
+/// </summary>
+[Admin]
+public sealed class TaxJurisdictionsController : Controller
+{
+    private const string _optionsSearch = "Options.Search";
+    private const string _nameFieldName = "Name";
+
+    private readonly INamedCatalogManager<TaxJurisdiction> _manager;
+    private readonly INamedCatalog<TaxJurisdiction> _catalog;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IUpdateModelAccessor _updateModelAccessor;
+    private readonly IDisplayManager<TaxJurisdiction> _displayManager;
+    private readonly INotifier _notifier;
+
+    internal readonly IHtmlLocalizer H;
+    internal readonly IStringLocalizer S;
+
+    public TaxJurisdictionsController(
+        INamedCatalogManager<TaxJurisdiction> manager,
+        INamedCatalog<TaxJurisdiction> catalog,
+        IAuthorizationService authorizationService,
+        IUpdateModelAccessor updateModelAccessor,
+        IDisplayManager<TaxJurisdiction> displayManager,
+        INotifier notifier,
+        IHtmlLocalizer<TaxJurisdictionsController> htmlLocalizer,
+        IStringLocalizer<TaxJurisdictionsController> stringLocalizer)
+    {
+        _manager = manager;
+        _catalog = catalog;
+        _authorizationService = authorizationService;
+        _updateModelAccessor = updateModelAccessor;
+        _displayManager = displayManager;
+        _notifier = notifier;
+        H = htmlLocalizer;
+        S = stringLocalizer;
+    }
+
+    [Admin("taxation/jurisdictions", "TaxationJurisdictionsIndex")]
+    public async Task<IActionResult> Index(
+        CatalogEntryOptions options,
+        PagerParameters pagerParameters,
+        [FromServices] IOptions<PagerOptions> pagerOptions,
+        [FromServices] IShapeFactory shapeFactory)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var pager = new Pager(pagerParameters, pagerOptions.Value.GetPageSize());
+
+        var result = await _manager.PageAsync(pager.Page, pager.PageSize, new QueryContext
+        {
+            Name = options.Search,
+        });
+
+        var routeData = new RouteData();
+
+        if (!string.IsNullOrEmpty(options.Search))
+        {
+            routeData.Values.TryAdd(_optionsSearch, options.Search);
+        }
+
+        var viewModel = new ListCatalogEntryViewModel<CatalogEntryViewModel<TaxJurisdiction>>
+        {
+            Models = [],
+            Options = options,
+            Pager = await shapeFactory.PagerAsync(pager, result.Count, routeData),
+        };
+
+        foreach (var model in result.Entries)
+        {
+            viewModel.Models.Add(new CatalogEntryViewModel<TaxJurisdiction>
+            {
+                Model = model,
+                Shape = await _displayManager.BuildDisplayAsync(model, _updateModelAccessor.ModelUpdater, "SummaryAdmin"),
+            });
+        }
+
+        viewModel.Options.BulkActions = [];
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Index))]
+    [FormValueRequired("submit.Filter")]
+    [Admin("taxation/jurisdictions", "TaxationJurisdictionsIndex")]
+    public IActionResult IndexFilterPost(ListCatalogEntryViewModel model)
+        => RedirectToAction(nameof(Index), new RouteValueDictionary
+        {
+            { _optionsSearch, model.Options?.Search },
+        });
+
+    [Admin("taxation/jurisdictions/create", "TaxationJurisdictionsCreate")]
+    public async Task<IActionResult> Create()
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.NewAsync();
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = S["Tax Jurisdiction"],
+            Editor = await _displayManager.BuildEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Create))]
+    [Admin("taxation/jurisdictions/create", "TaxationJurisdictionsCreate")]
+    public async Task<IActionResult> CreatePost()
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.NewAsync();
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = S["Tax Jurisdiction"],
+            Editor = await _displayManager.UpdateEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        var isValid = await CatalogEntryValidation.ValidateAsync(_manager, model, _updateModelAccessor.ModelUpdater, nameof(TaxJurisdiction));
+
+        if (isValid && ModelState.IsValid)
+        {
+            var existing = await _catalog.FindByNameAsync(model.Name);
+
+            if (existing != null)
+            {
+                ModelState.AddModelError(_nameFieldName, S["A tax jurisdiction with the same name already exists."]);
+            }
+
+            if (ModelState.IsValid)
+            {
+                await _manager.CreateAsync(model);
+                await _notifier.SuccessAsync(H["The tax jurisdiction has been created successfully."]);
+
+                return RedirectToAction(nameof(Index));
+            }
+        }
+
+        return View(viewModel);
+    }
+
+    [Admin("taxation/jurisdictions/edit/{id}", "TaxationJurisdictionsEdit")]
+    public async Task<IActionResult> Edit(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = model.Name,
+            Editor = await _displayManager.BuildEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Edit))]
+    [Admin("taxation/jurisdictions/edit/{id}", "TaxationJurisdictionsEdit")]
+    public async Task<IActionResult> EditPost(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = model.Name,
+            Editor = await _displayManager.UpdateEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        var isValid = await CatalogEntryValidation.ValidateAsync(_manager, model, _updateModelAccessor.ModelUpdater, nameof(TaxJurisdiction));
+
+        if (isValid && ModelState.IsValid)
+        {
+            var existing = await _catalog.FindByNameAsync(model.Name);
+
+            if (existing != null && !string.Equals(existing.ItemId, model.ItemId, StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError(_nameFieldName, S["A tax jurisdiction with the same name already exists."]);
+            }
+
+            if (ModelState.IsValid)
+            {
+                await _manager.UpdateAsync(model);
+                await _notifier.SuccessAsync(H["The tax jurisdiction has been updated successfully."]);
+
+                return RedirectToAction(nameof(Index));
+            }
+        }
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName("Delete")]
+    [Admin("taxation/jurisdictions/delete/{id}", "TaxationJurisdictionsDelete")]
+    public async Task<IActionResult> DeletePost(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        if (await _manager.DeleteAsync(model))
+        {
+            await _notifier.SuccessAsync(H["The tax jurisdiction has been deleted successfully."]);
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxRulesController.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxRulesController.cs
@@ -1,6 +1,7 @@
 using CrestApps.Core.Services;
 using CrestApps.OrchardCore.Core.Models;
 using CrestApps.OrchardCore.Core.Validation;
+using CrestApps.OrchardCore.Taxation.Core;
 using CrestApps.OrchardCore.Taxation.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxRulesController.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Controllers/TaxRulesController.cs
@@ -1,0 +1,271 @@
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Core.Models;
+using CrestApps.OrchardCore.Core.Validation;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Navigation;
+using OrchardCore.Routing;
+using QueryContext = CrestApps.Core.Models.QueryContext;
+
+namespace CrestApps.OrchardCore.Taxation.Controllers;
+
+/// <summary>
+/// Provides admin endpoints for managing <see cref="TaxRule"/> entries.
+/// </summary>
+[Admin]
+public sealed class TaxRulesController : Controller
+{
+    private const string _optionsSearch = "Options.Search";
+    private const string _nameFieldName = "Name";
+
+    private readonly INamedCatalogManager<TaxRule> _manager;
+    private readonly INamedCatalog<TaxRule> _catalog;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IUpdateModelAccessor _updateModelAccessor;
+    private readonly IDisplayManager<TaxRule> _displayManager;
+    private readonly INotifier _notifier;
+
+    internal readonly IHtmlLocalizer H;
+    internal readonly IStringLocalizer S;
+
+    public TaxRulesController(
+        INamedCatalogManager<TaxRule> manager,
+        INamedCatalog<TaxRule> catalog,
+        IAuthorizationService authorizationService,
+        IUpdateModelAccessor updateModelAccessor,
+        IDisplayManager<TaxRule> displayManager,
+        INotifier notifier,
+        IHtmlLocalizer<TaxRulesController> htmlLocalizer,
+        IStringLocalizer<TaxRulesController> stringLocalizer)
+    {
+        _manager = manager;
+        _catalog = catalog;
+        _authorizationService = authorizationService;
+        _updateModelAccessor = updateModelAccessor;
+        _displayManager = displayManager;
+        _notifier = notifier;
+        H = htmlLocalizer;
+        S = stringLocalizer;
+    }
+
+    [Admin("taxation/rules", "TaxationRulesIndex")]
+    public async Task<IActionResult> Index(
+        CatalogEntryOptions options,
+        PagerParameters pagerParameters,
+        [FromServices] IOptions<PagerOptions> pagerOptions,
+        [FromServices] IShapeFactory shapeFactory)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var pager = new Pager(pagerParameters, pagerOptions.Value.GetPageSize());
+
+        var result = await _manager.PageAsync(pager.Page, pager.PageSize, new QueryContext
+        {
+            Name = options.Search,
+        });
+
+        var routeData = new RouteData();
+
+        if (!string.IsNullOrEmpty(options.Search))
+        {
+            routeData.Values.TryAdd(_optionsSearch, options.Search);
+        }
+
+        var viewModel = new ListCatalogEntryViewModel<CatalogEntryViewModel<TaxRule>>
+        {
+            Models = [],
+            Options = options,
+            Pager = await shapeFactory.PagerAsync(pager, result.Count, routeData),
+        };
+
+        foreach (var model in result.Entries)
+        {
+            viewModel.Models.Add(new CatalogEntryViewModel<TaxRule>
+            {
+                Model = model,
+                Shape = await _displayManager.BuildDisplayAsync(model, _updateModelAccessor.ModelUpdater, "SummaryAdmin"),
+            });
+        }
+
+        viewModel.Options.BulkActions = [];
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Index))]
+    [FormValueRequired("submit.Filter")]
+    [Admin("taxation/rules", "TaxationRulesIndex")]
+    public IActionResult IndexFilterPost(ListCatalogEntryViewModel model)
+        => RedirectToAction(nameof(Index), new RouteValueDictionary
+        {
+            { _optionsSearch, model.Options?.Search },
+        });
+
+    [Admin("taxation/rules/create", "TaxationRulesCreate")]
+    public async Task<IActionResult> Create()
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.NewAsync();
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = S["Tax Rule"],
+            Editor = await _displayManager.BuildEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Create))]
+    [Admin("taxation/rules/create", "TaxationRulesCreate")]
+    public async Task<IActionResult> CreatePost()
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.NewAsync();
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = S["Tax Rule"],
+            Editor = await _displayManager.UpdateEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        var isValid = await CatalogEntryValidation.ValidateAsync(_manager, model, _updateModelAccessor.ModelUpdater, nameof(TaxRule));
+
+        if (isValid && ModelState.IsValid)
+        {
+            var existing = await _catalog.FindByNameAsync(model.Name);
+
+            if (existing != null)
+            {
+                ModelState.AddModelError(_nameFieldName, S["A tax rule with the same name already exists."]);
+            }
+
+            if (ModelState.IsValid)
+            {
+                await _manager.CreateAsync(model);
+                await _notifier.SuccessAsync(H["The tax rule has been created successfully."]);
+
+                return RedirectToAction(nameof(Index));
+            }
+        }
+
+        return View(viewModel);
+    }
+
+    [Admin("taxation/rules/edit/{id}", "TaxationRulesEdit")]
+    public async Task<IActionResult> Edit(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = model.Name,
+            Editor = await _displayManager.BuildEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName(nameof(Edit))]
+    [Admin("taxation/rules/edit/{id}", "TaxationRulesEdit")]
+    public async Task<IActionResult> EditPost(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = new EditCatalogEntryViewModel
+        {
+            DisplayName = model.Name,
+            Editor = await _displayManager.UpdateEditorAsync(model, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        var isValid = await CatalogEntryValidation.ValidateAsync(_manager, model, _updateModelAccessor.ModelUpdater, nameof(TaxRule));
+
+        if (isValid && ModelState.IsValid)
+        {
+            var existing = await _catalog.FindByNameAsync(model.Name);
+
+            if (existing != null && !string.Equals(existing.ItemId, model.ItemId, StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError(_nameFieldName, S["A tax rule with the same name already exists."]);
+            }
+
+            if (ModelState.IsValid)
+            {
+                await _manager.UpdateAsync(model);
+                await _notifier.SuccessAsync(H["The tax rule has been updated successfully."]);
+
+                return RedirectToAction(nameof(Index));
+            }
+        }
+
+        return View(viewModel);
+    }
+
+    [HttpPost]
+    [ActionName("Delete")]
+    [Admin("taxation/rules/delete/{id}", "TaxationRulesDelete")]
+    public async Task<IActionResult> DeletePost(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, TaxationPermissions.ManageTaxation))
+        {
+            return Forbid();
+        }
+
+        var model = await _manager.FindByIdAsync(id);
+
+        if (model == null)
+        {
+            return NotFound();
+        }
+
+        if (await _manager.DeleteAsync(model))
+        {
+            await _notifier.SuccessAsync(H["The tax rule has been deleted successfully."]);
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/CrestApps.OrchardCore.Taxation.csproj
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/CrestApps.OrchardCore.Taxation.csproj
@@ -26,6 +26,8 @@
     <PackageReference Include="OrchardCore.ContentManagement" />
     <PackageReference Include="OrchardCore.ContentTypes.Abstractions" />
     <PackageReference Include="OrchardCore.DisplayManagement" />
+    <PackageReference Include="OrchardCore.Contents.Core" />
+    <PackageReference Include="OrchardCore.Navigation.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/CrestApps.OrchardCore.Taxation.csproj
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/CrestApps.OrchardCore.Taxation.csproj
@@ -18,6 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="CrestApps.OrchardCore.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
@@ -28,11 +32,15 @@
     <PackageReference Include="OrchardCore.DisplayManagement" />
     <PackageReference Include="OrchardCore.Contents.Core" />
     <PackageReference Include="OrchardCore.Navigation.Core" />
+    <PackageReference Include="OrchardCore.Recipes.Abstractions" />
+    <PackageReference Include="OrchardCore.Deployment.Abstractions" />
+    <PackageReference Include="OrchardCore.Taxonomies" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Abstractions\CrestApps.OrchardCore.Abstractions\CrestApps.OrchardCore.Abstractions.csproj" />
     <ProjectReference Include="..\..\Core\CrestApps.OrchardCore.Taxation.Core\CrestApps.OrchardCore.Taxation.Core.csproj" />
+    <ProjectReference Include="..\..\Core\CrestApps.OrchardCore.Recipes.Core\CrestApps.OrchardCore.Recipes.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Drivers/TaxCategoryDeploymentStepDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Drivers/TaxCategoryDeploymentStepDisplayDriver.cs
@@ -1,0 +1,16 @@
+using CrestApps.OrchardCore.Taxation.Deployments.Steps;
+using OrchardCore.Deployment;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments.Drivers;
+
+internal sealed class TaxCategoryDeploymentStepDisplayDriver : DisplayDriver<DeploymentStep, TaxCategoryDeploymentStep>
+{
+    public override IDisplayResult Display(TaxCategoryDeploymentStep step, BuildDisplayContext context)
+    {
+        return Combine(
+            View("TaxCategoryDeploymentStep_Summary", step).Location("Summary", "Content"),
+            View("TaxCategoryDeploymentStep_Thumbnail", step).Location("Thumbnail", "Content"));
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Drivers/TaxJurisdictionDeploymentStepDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Drivers/TaxJurisdictionDeploymentStepDisplayDriver.cs
@@ -1,0 +1,16 @@
+using CrestApps.OrchardCore.Taxation.Deployments.Steps;
+using OrchardCore.Deployment;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments.Drivers;
+
+internal sealed class TaxJurisdictionDeploymentStepDisplayDriver : DisplayDriver<DeploymentStep, TaxJurisdictionDeploymentStep>
+{
+    public override IDisplayResult Display(TaxJurisdictionDeploymentStep step, BuildDisplayContext context)
+    {
+        return Combine(
+            View("TaxJurisdictionDeploymentStep_Summary", step).Location("Summary", "Content"),
+            View("TaxJurisdictionDeploymentStep_Thumbnail", step).Location("Thumbnail", "Content"));
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Drivers/TaxRuleDeploymentStepDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Drivers/TaxRuleDeploymentStepDisplayDriver.cs
@@ -1,0 +1,16 @@
+using CrestApps.OrchardCore.Taxation.Deployments.Steps;
+using OrchardCore.Deployment;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments.Drivers;
+
+internal sealed class TaxRuleDeploymentStepDisplayDriver : DisplayDriver<DeploymentStep, TaxRuleDeploymentStep>
+{
+    public override IDisplayResult Display(TaxRuleDeploymentStep step, BuildDisplayContext context)
+    {
+        return Combine(
+            View("TaxRuleDeploymentStep_Summary", step).Location("Summary", "Content"),
+            View("TaxRuleDeploymentStep_Thumbnail", step).Location("Thumbnail", "Content"));
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Sources/TaxCategoryDeploymentSource.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Sources/TaxCategoryDeploymentSource.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Deployments.Steps;
+using CrestApps.OrchardCore.Taxation.Models;
+using OrchardCore.Deployment;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments.Sources;
+
+internal sealed class TaxCategoryDeploymentSource : DeploymentSourceBase<TaxCategoryDeploymentStep>
+{
+    private readonly INamedCatalogManager<TaxCategory> _manager;
+
+    public TaxCategoryDeploymentSource(INamedCatalogManager<TaxCategory> manager)
+    {
+        _manager = manager;
+    }
+
+    protected override async Task ProcessAsync(TaxCategoryDeploymentStep step, DeploymentPlanResult result)
+    {
+        var entries = await _manager.GetAllAsync();
+
+        var data = new JsonArray();
+
+        foreach (var entry in entries)
+        {
+            data.Add(TaxationDeploymentSerializer.Export(entry));
+        }
+
+        result.Steps.Add(new JsonObject
+        {
+            ["name"] = TaxationDeploymentSteps.TaxCategory,
+            ["TaxCategories"] = data,
+        });
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Sources/TaxJurisdictionDeploymentSource.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Sources/TaxJurisdictionDeploymentSource.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Deployments.Steps;
+using CrestApps.OrchardCore.Taxation.Models;
+using OrchardCore.Deployment;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments.Sources;
+
+internal sealed class TaxJurisdictionDeploymentSource : DeploymentSourceBase<TaxJurisdictionDeploymentStep>
+{
+    private readonly INamedCatalogManager<TaxJurisdiction> _manager;
+
+    public TaxJurisdictionDeploymentSource(INamedCatalogManager<TaxJurisdiction> manager)
+    {
+        _manager = manager;
+    }
+
+    protected override async Task ProcessAsync(TaxJurisdictionDeploymentStep step, DeploymentPlanResult result)
+    {
+        var entries = await _manager.GetAllAsync();
+
+        var data = new JsonArray();
+
+        foreach (var entry in entries)
+        {
+            data.Add(TaxationDeploymentSerializer.Export(entry));
+        }
+
+        result.Steps.Add(new JsonObject
+        {
+            ["name"] = TaxationDeploymentSteps.TaxJurisdiction,
+            ["TaxJurisdictions"] = data,
+        });
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Sources/TaxRuleDeploymentSource.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Sources/TaxRuleDeploymentSource.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Deployments.Steps;
+using CrestApps.OrchardCore.Taxation.Models;
+using OrchardCore.Deployment;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments.Sources;
+
+internal sealed class TaxRuleDeploymentSource : DeploymentSourceBase<TaxRuleDeploymentStep>
+{
+    private readonly INamedCatalogManager<TaxRule> _manager;
+
+    public TaxRuleDeploymentSource(INamedCatalogManager<TaxRule> manager)
+    {
+        _manager = manager;
+    }
+
+    protected override async Task ProcessAsync(TaxRuleDeploymentStep step, DeploymentPlanResult result)
+    {
+        var entries = await _manager.GetAllAsync();
+
+        var data = new JsonArray();
+
+        foreach (var entry in entries)
+        {
+            data.Add(TaxationDeploymentSerializer.Export(entry));
+        }
+
+        result.Steps.Add(new JsonObject
+        {
+            ["name"] = TaxationDeploymentSteps.TaxRule,
+            ["TaxRules"] = data,
+        });
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Steps/TaxCategoryDeploymentStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Steps/TaxCategoryDeploymentStep.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Localization;
+using OrchardCore.Deployment;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments.Steps;
+
+/// <summary>
+/// Represents a deployment step that exports tax categories.
+/// </summary>
+public sealed class TaxCategoryDeploymentStep : DeploymentStep
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxCategoryDeploymentStep"/> class.
+    /// </summary>
+    public TaxCategoryDeploymentStep()
+    {
+        Name = TaxationDeploymentSteps.TaxCategory;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxCategoryDeploymentStep"/> class.
+    /// </summary>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public TaxCategoryDeploymentStep(IStringLocalizer<TaxCategoryDeploymentStep> stringLocalizer)
+        : this()
+    {
+        Category = stringLocalizer["Taxation"];
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Steps/TaxJurisdictionDeploymentStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Steps/TaxJurisdictionDeploymentStep.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Localization;
+using OrchardCore.Deployment;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments.Steps;
+
+/// <summary>
+/// Represents a deployment step that exports tax jurisdictions.
+/// </summary>
+public sealed class TaxJurisdictionDeploymentStep : DeploymentStep
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxJurisdictionDeploymentStep"/> class.
+    /// </summary>
+    public TaxJurisdictionDeploymentStep()
+    {
+        Name = TaxationDeploymentSteps.TaxJurisdiction;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxJurisdictionDeploymentStep"/> class.
+    /// </summary>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public TaxJurisdictionDeploymentStep(IStringLocalizer<TaxJurisdictionDeploymentStep> stringLocalizer)
+        : this()
+    {
+        Category = stringLocalizer["Taxation"];
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Steps/TaxRuleDeploymentStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/Steps/TaxRuleDeploymentStep.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Localization;
+using OrchardCore.Deployment;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments.Steps;
+
+/// <summary>
+/// Represents a deployment step that exports tax rules.
+/// </summary>
+public sealed class TaxRuleDeploymentStep : DeploymentStep
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxRuleDeploymentStep"/> class.
+    /// </summary>
+    public TaxRuleDeploymentStep()
+    {
+        Name = TaxationDeploymentSteps.TaxRule;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaxRuleDeploymentStep"/> class.
+    /// </summary>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public TaxRuleDeploymentStep(IStringLocalizer<TaxRuleDeploymentStep> stringLocalizer)
+        : this()
+    {
+        Category = stringLocalizer["Taxation"];
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/TaxationDeploymentSerializer.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/TaxationDeploymentSerializer.cs
@@ -1,0 +1,110 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using OrchardCore.Json;
+
+namespace CrestApps.OrchardCore.Taxation.Deployments;
+
+/// <summary>
+/// Serializes taxation catalog entries to and from the JSON shape a deployment plan carries.
+/// </summary>
+/// <remarks>
+/// Binding is driven by reflection over the entry type rather than by a hand-written property list, so a property
+/// added to an entry travels between environments without any further change to the deployment source or the recipe
+/// step. Members owned by the environment that stores the entry are never carried; the target environment stamps them.
+/// </remarks>
+internal static class TaxationDeploymentSerializer
+{
+    private static readonly ConcurrentDictionary<Type, BindableProperty[]> _properties = new();
+
+    /// <summary>
+    /// The options used to export an entry. Null members are written rather than omitted, so a value cleared in the
+    /// source environment clears wherever the plan is replayed instead of keeping its stale value.
+    /// </summary>
+    public static readonly JsonSerializerOptions Options = new(JOptions.Default)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    /// <summary>
+    /// Gets the names of the members that belong to the environment that stores the entry rather than to its configuration.
+    /// </summary>
+    public static readonly IReadOnlySet<string> EnvironmentOwnedMembers = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "CreatedUtc",
+        "ModifiedUtc",
+        "OwnerId",
+        "Author",
+    };
+
+    /// <summary>
+    /// Serializes an entry into the JSON shape stored in a deployment plan.
+    /// </summary>
+    /// <param name="entry">The entry to serialize.</param>
+    /// <returns>A JSON object containing every portable member of the entry.</returns>
+    public static JsonObject Export(object entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var node = JsonSerializer.SerializeToNode(entry, entry.GetType(), Options)?.AsObject()
+            ?? [];
+
+        foreach (var member in EnvironmentOwnedMembers)
+        {
+            node.Remove(member);
+        }
+
+        return node;
+    }
+
+    /// <summary>
+    /// Applies every portable member present in the given JSON onto an existing entry.
+    /// </summary>
+    /// <param name="entry">The entry to populate.</param>
+    /// <param name="data">The JSON to read the values from.</param>
+    public static void Populate(object entry, JsonNode data)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (data is not JsonObject json)
+        {
+            return;
+        }
+
+        var type = entry.GetType();
+        object source = null;
+
+        foreach (var property in GetProperties(type))
+        {
+            if (!json.ContainsKey(property.JsonName))
+            {
+                continue;
+            }
+
+            source ??= JsonSerializer.Deserialize(json, type, Options);
+
+            if (source is null)
+            {
+                return;
+            }
+
+            property.Member.SetValue(entry, property.Member.GetValue(source));
+        }
+    }
+
+    private static BindableProperty[] GetProperties(Type type)
+        => _properties.GetOrAdd(type, static key => key
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.CanRead
+                && property.CanWrite
+                && property.GetIndexParameters().Length == 0
+                && property.GetCustomAttribute<JsonIgnoreAttribute>() is null
+                && !EnvironmentOwnedMembers.Contains(property.Name)
+                && property.Name != "ItemId")
+            .Select(property => new BindableProperty(property, property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name))
+            .ToArray());
+
+    private sealed record BindableProperty(PropertyInfo Member, string JsonName);
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/TaxationDeploymentSteps.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Deployments/TaxationDeploymentSteps.cs
@@ -1,0 +1,22 @@
+namespace CrestApps.OrchardCore.Taxation.Deployments;
+
+/// <summary>
+/// Names the recipe steps that carry taxation configuration between environments.
+/// </summary>
+public static class TaxationDeploymentSteps
+{
+    /// <summary>
+    /// The recipe step that carries tax categories.
+    /// </summary>
+    public const string TaxCategory = "TaxCategory";
+
+    /// <summary>
+    /// The recipe step that carries tax jurisdictions.
+    /// </summary>
+    public const string TaxJurisdiction = "TaxJurisdiction";
+
+    /// <summary>
+    /// The recipe step that carries tax rules.
+    /// </summary>
+    public const string TaxRule = "TaxRule";
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxCategoryDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxCategoryDisplayDriver.cs
@@ -1,0 +1,52 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.ViewModels;
+using OrchardCore;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.Taxation.Drivers;
+
+internal sealed class TaxCategoryDisplayDriver : DisplayDriver<TaxCategory>
+{
+    public override Task<IDisplayResult> DisplayAsync(TaxCategory category, BuildDisplayContext context)
+    {
+        return CombineAsync(
+            View("TaxCategory_Fields_SummaryAdmin", category)
+                .Location(OrchardCoreConstants.DisplayType.SummaryAdmin, "Content:1"),
+            View("TaxCategory_Buttons_SummaryAdmin", category)
+                .Location(OrchardCoreConstants.DisplayType.SummaryAdmin, "Actions:5"),
+            View("TaxCategory_DefaultMeta_SummaryAdmin", category)
+                .Location(OrchardCoreConstants.DisplayType.SummaryAdmin, "Meta:5")
+        );
+    }
+
+    public override IDisplayResult Edit(TaxCategory category, BuildEditorContext context)
+    {
+        return Initialize<TaxCategoryViewModel>("TaxCategoryFields_Edit", model =>
+        {
+            model.IsNew = context.IsNew;
+            model.Name = category.Name;
+            model.Code = category.Code;
+            model.ParentCode = category.ParentCode;
+            model.Description = category.Description;
+        }).Location("Content:1");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(TaxCategory category, UpdateEditorContext context)
+    {
+        var model = new TaxCategoryViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (context.IsNew)
+        {
+            category.Name = model.Name?.Trim();
+        }
+
+        category.Code = model.Code?.Trim();
+        category.ParentCode = model.ParentCode?.Trim();
+        category.Description = model.Description?.Trim();
+
+        return Edit(category, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxJurisdictionDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxJurisdictionDisplayDriver.cs
@@ -1,0 +1,87 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using CrestApps.OrchardCore.Taxation.ViewModels;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using OrchardCore;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.Taxation.Drivers;
+
+internal sealed class TaxJurisdictionDisplayDriver : DisplayDriver<TaxJurisdiction>
+{
+    private readonly ITaxJurisdictionStore _jurisdictionStore;
+
+    public TaxJurisdictionDisplayDriver(ITaxJurisdictionStore jurisdictionStore)
+    {
+        _jurisdictionStore = jurisdictionStore;
+    }
+
+    public override Task<IDisplayResult> DisplayAsync(TaxJurisdiction jurisdiction, BuildDisplayContext context)
+    {
+        return CombineAsync(
+            View("TaxJurisdiction_Fields_SummaryAdmin", jurisdiction)
+                .Location(OrchardCoreConstants.DisplayType.SummaryAdmin, "Content:1"),
+            View("TaxJurisdiction_Buttons_SummaryAdmin", jurisdiction)
+                .Location(OrchardCoreConstants.DisplayType.SummaryAdmin, "Actions:5"),
+            View("TaxJurisdiction_DefaultMeta_SummaryAdmin", jurisdiction)
+                .Location(OrchardCoreConstants.DisplayType.SummaryAdmin, "Meta:5")
+        );
+    }
+
+    public override IDisplayResult Edit(TaxJurisdiction jurisdiction, BuildEditorContext context)
+    {
+        return Initialize<TaxJurisdictionViewModel>("TaxJurisdictionFields_Edit", async model =>
+        {
+            model.IsNew = context.IsNew;
+            model.Name = jurisdiction.Name;
+            model.Code = jurisdiction.Code;
+            model.Level = jurisdiction.Level;
+            model.Country = jurisdiction.Country;
+            model.Region = jurisdiction.Region;
+            model.County = jurisdiction.County;
+            model.City = jurisdiction.City;
+            model.PostalCode = jurisdiction.PostalCode;
+            model.ParentId = jurisdiction.ParentId;
+            model.EffectiveFromUtc = jurisdiction.EffectiveFromUtc;
+            model.EffectiveToUtc = jurisdiction.EffectiveToUtc;
+
+            model.Levels = Enum.GetValues<JurisdictionLevel>()
+                .Select(level => new SelectListItem(level.ToString(), level.ToString()))
+                .ToList();
+
+            var jurisdictions = await _jurisdictionStore.GetAllAsync();
+
+            model.Parents = jurisdictions
+                .Where(j => !string.Equals(j.ItemId, jurisdiction.ItemId, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(j => j.Name)
+                .Select(j => new SelectListItem(j.Name, j.ItemId))
+                .ToList();
+        }).Location("Content:1");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(TaxJurisdiction jurisdiction, UpdateEditorContext context)
+    {
+        var model = new TaxJurisdictionViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (context.IsNew)
+        {
+            jurisdiction.Name = model.Name?.Trim();
+        }
+
+        jurisdiction.Code = model.Code?.Trim();
+        jurisdiction.Level = model.Level;
+        jurisdiction.Country = model.Country?.Trim();
+        jurisdiction.Region = model.Region?.Trim();
+        jurisdiction.County = model.County?.Trim();
+        jurisdiction.City = model.City?.Trim();
+        jurisdiction.PostalCode = model.PostalCode?.Trim();
+        jurisdiction.ParentId = string.IsNullOrEmpty(model.ParentId) ? null : model.ParentId;
+        jurisdiction.EffectiveFromUtc = model.EffectiveFromUtc;
+        jurisdiction.EffectiveToUtc = model.EffectiveToUtc;
+
+        return Edit(jurisdiction, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxRuleDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxRuleDisplayDriver.cs
@@ -1,0 +1,160 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using CrestApps.OrchardCore.Taxation.ViewModels;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Localization;
+using OrchardCore;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.Taxation.Drivers;
+
+internal sealed class TaxRuleDisplayDriver : DisplayDriver<TaxRule>
+{
+    private static readonly string[] _taxTypes =
+    [
+        TaxTypeNames.SalesTax,
+        TaxTypeNames.Vat,
+        TaxTypeNames.Gst,
+        TaxTypeNames.Hst,
+        TaxTypeNames.Pst,
+        TaxTypeNames.Qst,
+        TaxTypeNames.ExciseTax,
+        TaxTypeNames.AlcoholTax,
+        TaxTypeNames.TobaccoTax,
+        TaxTypeNames.TourismTax,
+        TaxTypeNames.LodgingTax,
+        TaxTypeNames.EnvironmentalTax,
+        TaxTypeNames.DigitalServicesTax,
+        TaxTypeNames.Other,
+    ];
+
+    private readonly ITaxJurisdictionStore _jurisdictionStore;
+    private readonly ITaxCategoryStore _categoryStore;
+    private readonly IEnumerable<ITaxCalculationMethod> _calculationMethods;
+
+    internal readonly IStringLocalizer S;
+
+    public TaxRuleDisplayDriver(
+        ITaxJurisdictionStore jurisdictionStore,
+        ITaxCategoryStore categoryStore,
+        IEnumerable<ITaxCalculationMethod> calculationMethods,
+        IStringLocalizer<TaxRuleDisplayDriver> stringLocalizer)
+    {
+        _jurisdictionStore = jurisdictionStore;
+        _categoryStore = categoryStore;
+        _calculationMethods = calculationMethods;
+        S = stringLocalizer;
+    }
+
+    public override Task<IDisplayResult> DisplayAsync(TaxRule rule, BuildDisplayContext context)
+    {
+        return CombineAsync(
+            View("TaxRule_Fields_SummaryAdmin", rule)
+                .Location(OrchardCoreConstants.DisplayType.SummaryAdmin, "Content:1"),
+            View("TaxRule_Buttons_SummaryAdmin", rule)
+                .Location(OrchardCoreConstants.DisplayType.SummaryAdmin, "Actions:5"),
+            View("TaxRule_DefaultMeta_SummaryAdmin", rule)
+                .Location(OrchardCoreConstants.DisplayType.SummaryAdmin, "Meta:5")
+        );
+    }
+
+    public override IDisplayResult Edit(TaxRule rule, BuildEditorContext context)
+    {
+        return Initialize<TaxRuleViewModel>("TaxRuleFields_Edit", async model =>
+        {
+            model.IsNew = context.IsNew;
+            model.Name = rule.Name;
+            model.Enabled = rule.Enabled;
+            model.Priority = rule.Priority;
+            model.TaxType = rule.TaxType;
+            model.TaxName = rule.TaxName;
+            model.TaxCode = rule.TaxCode;
+            model.JurisdictionId = rule.JurisdictionId;
+            model.CategoryCode = rule.CategoryCode;
+            model.CustomerType = rule.CustomerType;
+            model.CalculationMethod = rule.CalculationMethod;
+            model.Rate = rule.Rate;
+            model.FixedAmount = rule.FixedAmount;
+            model.IncludedInPrice = rule.IncludedInPrice;
+            model.IsCompound = rule.IsCompound;
+            model.AppliesToShipping = rule.AppliesToShipping;
+            model.MinimumAmount = rule.MinimumAmount;
+            model.MaximumAmount = rule.MaximumAmount;
+            model.EffectiveFromUtc = rule.EffectiveFromUtc;
+            model.EffectiveToUtc = rule.EffectiveToUtc;
+
+            model.TaxTypes = _taxTypes
+                .Select(type => new SelectListItem(type, type))
+                .ToList();
+
+            model.CalculationMethods = _calculationMethods
+                .Select(method => method.Name)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(name => name)
+                .Select(name => new SelectListItem(name, name))
+                .ToList();
+
+            model.CustomerTypes =
+            [
+                new SelectListItem(S["Any customer"], string.Empty),
+                .. Enum.GetValues<CustomerTaxType>()
+                    .Select(type => new SelectListItem(type.ToString(), type.ToString())),
+            ];
+
+            var jurisdictions = await _jurisdictionStore.GetAllAsync();
+
+            model.Jurisdictions =
+            [
+                new SelectListItem(S["Any jurisdiction"], string.Empty),
+                .. jurisdictions
+                    .OrderBy(j => j.Name)
+                    .Select(j => new SelectListItem(j.Name, j.ItemId)),
+            ];
+
+            var categories = await _categoryStore.GetAllAsync();
+
+            model.Categories =
+            [
+                new SelectListItem(S["Any category"], string.Empty),
+                .. categories
+                    .Where(c => !string.IsNullOrEmpty(c.Code))
+                    .OrderBy(c => c.Name)
+                    .Select(c => new SelectListItem($"{c.Name} ({c.Code})", c.Code)),
+            ];
+        }).Location("Content:1");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(TaxRule rule, UpdateEditorContext context)
+    {
+        var model = new TaxRuleViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (context.IsNew)
+        {
+            rule.Name = model.Name?.Trim();
+        }
+
+        rule.Enabled = model.Enabled;
+        rule.Priority = model.Priority;
+        rule.TaxType = model.TaxType?.Trim();
+        rule.TaxName = model.TaxName?.Trim();
+        rule.TaxCode = model.TaxCode?.Trim();
+        rule.JurisdictionId = string.IsNullOrEmpty(model.JurisdictionId) ? null : model.JurisdictionId;
+        rule.CategoryCode = string.IsNullOrEmpty(model.CategoryCode) ? null : model.CategoryCode.Trim();
+        rule.CustomerType = model.CustomerType;
+        rule.CalculationMethod = model.CalculationMethod?.Trim();
+        rule.Rate = model.Rate;
+        rule.FixedAmount = model.FixedAmount;
+        rule.IncludedInPrice = model.IncludedInPrice;
+        rule.IsCompound = model.IsCompound;
+        rule.AppliesToShipping = model.AppliesToShipping;
+        rule.MinimumAmount = model.MinimumAmount;
+        rule.MaximumAmount = model.MaximumAmount;
+        rule.EffectiveFromUtc = model.EffectiveFromUtc;
+        rule.EffectiveToUtc = model.EffectiveToUtc;
+
+        return Edit(rule, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxationPartDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxationPartDisplayDriver.cs
@@ -1,6 +1,11 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
 using CrestApps.OrchardCore.Taxation.ViewModels;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Localization;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -13,18 +18,35 @@ namespace CrestApps.OrchardCore.Taxation.Drivers;
 /// </summary>
 public sealed class TaxationPartDisplayDriver : ContentPartDisplayDriver<TaxationPart>
 {
+    private readonly ITaxCategoryStore _categoryStore;
+
+    internal readonly IStringLocalizer S;
+
+    public TaxationPartDisplayDriver(
+        ITaxCategoryStore categoryStore,
+        IStringLocalizer<TaxationPartDisplayDriver> stringLocalizer)
+    {
+        _categoryStore = categoryStore;
+        S = stringLocalizer;
+    }
+
     /// <inheritdoc />
     public override IDisplayResult Edit(TaxationPart part, BuildPartEditorContext context)
     {
         var settings = context.TypePartDefinition.GetSettings<TaxationPartSettings>();
 
-        return Initialize<TaxationPartViewModel>(GetEditorShapeType(context), model =>
+        return Initialize<TaxationPartViewModel>(GetEditorShapeType(context), async model =>
         {
             model.Taxable = context.IsNew ? true : part.Taxable;
             model.TaxCategoryCode = context.IsNew ? settings.DefaultTaxCategoryCode : part.TaxCategoryCode;
             model.TaxClassificationCode = context.IsNew ? settings.DefaultTaxClassificationCode : part.TaxClassificationCode;
             model.ExternalTaxCode = part.ExternalTaxCode;
             model.AllowClassificationOverride = settings.AllowClassificationOverride;
+
+            if (settings.AllowClassificationOverride)
+            {
+                model.TaxCategories = await BuildCategoryListAsync();
+            }
         });
     }
 
@@ -52,5 +74,19 @@ public sealed class TaxationPartDisplayDriver : ContentPartDisplayDriver<Taxatio
         }
 
         return Edit(part, context);
+    }
+
+    private async Task<IList<SelectListItem>> BuildCategoryListAsync()
+    {
+        var categories = await _categoryStore.GetAllAsync();
+
+        return
+        [
+            new SelectListItem(S["None"], string.Empty),
+            .. categories
+                .Where(category => !string.IsNullOrEmpty(category.Code))
+                .OrderBy(category => category.Name)
+                .Select(category => new SelectListItem($"{category.Name} ({category.Code})", category.Code)),
+        ];
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxationPartSettingsDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Drivers/TaxationPartSettingsDisplayDriver.cs
@@ -1,6 +1,11 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
 using CrestApps.OrchardCore.Taxation.ViewModels;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Localization;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.DisplayManagement.Handlers;
@@ -13,16 +18,29 @@ namespace CrestApps.OrchardCore.Taxation.Drivers;
 /// </summary>
 public sealed class TaxationPartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver<TaxationPart>
 {
+    private readonly ITaxCategoryStore _categoryStore;
+
+    internal readonly IStringLocalizer S;
+
+    public TaxationPartSettingsDisplayDriver(
+        ITaxCategoryStore categoryStore,
+        IStringLocalizer<TaxationPartSettingsDisplayDriver> stringLocalizer)
+    {
+        _categoryStore = categoryStore;
+        S = stringLocalizer;
+    }
+
     /// <inheritdoc />
     public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, BuildEditorContext context)
     {
-        return Initialize<TaxationPartSettingsViewModel>("TaxationPartSettings_Edit", model =>
+        return Initialize<TaxationPartSettingsViewModel>("TaxationPartSettings_Edit", async model =>
         {
             var settings = contentTypePartDefinition.GetSettings<TaxationPartSettings>();
 
             model.DefaultTaxCategoryCode = settings.DefaultTaxCategoryCode;
             model.DefaultTaxClassificationCode = settings.DefaultTaxClassificationCode;
             model.AllowClassificationOverride = settings.AllowClassificationOverride;
+            model.TaxCategories = await BuildCategoryListAsync();
         }).Location("Content");
     }
 
@@ -41,5 +59,19 @@ public sealed class TaxationPartSettingsDisplayDriver : ContentTypePartDefinitio
         });
 
         return Edit(contentTypePartDefinition, context);
+    }
+
+    private async Task<IList<SelectListItem>> BuildCategoryListAsync()
+    {
+        var categories = await _categoryStore.GetAllAsync();
+
+        return
+        [
+            new SelectListItem(S["None"], string.Empty),
+            .. categories
+                .Where(category => !string.IsNullOrEmpty(category.Code))
+                .OrderBy(category => category.Name)
+                .Select(category => new SelectListItem($"{category.Name} ({category.Code})", category.Code)),
+        ];
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxCategoryHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxCategoryHandler.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+using CrestApps.Core.Handlers;
+using CrestApps.Core.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Taxation.Handlers;
+
+internal sealed class TaxCategoryHandler : CatalogEntryHandlerBase<TaxCategory>
+{
+    private readonly IClock _clock;
+
+    internal readonly IStringLocalizer S;
+
+    public TaxCategoryHandler(
+        IClock clock,
+        IStringLocalizer<TaxCategoryHandler> stringLocalizer)
+    {
+        _clock = clock;
+        S = stringLocalizer;
+    }
+
+    public override Task UpdatingAsync(UpdatingContext<TaxCategory> context, CancellationToken cancellationToken = default)
+    {
+        context.Model.ModifiedUtc = _clock.UtcNow;
+
+        return Task.CompletedTask;
+    }
+
+    public override Task ValidatingAsync(ValidatingContext<TaxCategory> context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Model.Name))
+        {
+            context.Result.Fail(new ValidationResult(S["Name is required."], [nameof(TaxCategory.Name)]));
+        }
+
+        if (string.IsNullOrWhiteSpace(context.Model.Code))
+        {
+            context.Result.Fail(new ValidationResult(S["Code is required."], [nameof(TaxCategory.Code)]));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxCategoryHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxCategoryHandler.cs
@@ -1,7 +1,10 @@
 using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
 using CrestApps.Core.Handlers;
 using CrestApps.Core.Models;
+using CrestApps.OrchardCore.Taxation.Deployments;
 using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Modules;
 
@@ -9,21 +12,48 @@ namespace CrestApps.OrchardCore.Taxation.Handlers;
 
 internal sealed class TaxCategoryHandler : CatalogEntryHandlerBase<TaxCategory>
 {
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IClock _clock;
 
     internal readonly IStringLocalizer S;
 
     public TaxCategoryHandler(
+        IHttpContextAccessor httpContextAccessor,
         IClock clock,
         IStringLocalizer<TaxCategoryHandler> stringLocalizer)
     {
+        _httpContextAccessor = httpContextAccessor;
         _clock = clock;
         S = stringLocalizer;
+    }
+
+    public override Task InitializingAsync(InitializingContext<TaxCategory> context, CancellationToken cancellationToken = default)
+    {
+        TaxationDeploymentSerializer.Populate(context.Model, context.Data);
+
+        return Task.CompletedTask;
     }
 
     public override Task UpdatingAsync(UpdatingContext<TaxCategory> context, CancellationToken cancellationToken = default)
     {
         context.Model.ModifiedUtc = _clock.UtcNow;
+
+        TaxationDeploymentSerializer.Populate(context.Model, context.Data);
+
+        return Task.CompletedTask;
+    }
+
+    public override Task InitializedAsync(InitializedContext<TaxCategory> context, CancellationToken cancellationToken = default)
+    {
+        context.Model.CreatedUtc = _clock.UtcNow;
+
+        var user = _httpContextAccessor.HttpContext?.User;
+
+        if (user is not null)
+        {
+            context.Model.OwnerId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            context.Model.Author = user.Identity?.Name;
+        }
 
         return Task.CompletedTask;
     }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxJurisdictionHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxJurisdictionHandler.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using CrestApps.Core.Handlers;
+using CrestApps.Core.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Taxation.Handlers;
+
+internal sealed class TaxJurisdictionHandler : CatalogEntryHandlerBase<TaxJurisdiction>
+{
+    private readonly IClock _clock;
+
+    internal readonly IStringLocalizer S;
+
+    public TaxJurisdictionHandler(
+        IClock clock,
+        IStringLocalizer<TaxJurisdictionHandler> stringLocalizer)
+    {
+        _clock = clock;
+        S = stringLocalizer;
+    }
+
+    public override Task UpdatingAsync(UpdatingContext<TaxJurisdiction> context, CancellationToken cancellationToken = default)
+    {
+        context.Model.ModifiedUtc = _clock.UtcNow;
+
+        return Task.CompletedTask;
+    }
+
+    public override Task ValidatingAsync(ValidatingContext<TaxJurisdiction> context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Model.Name))
+        {
+            context.Result.Fail(new ValidationResult(S["Name is required."], [nameof(TaxJurisdiction.Name)]));
+        }
+
+        if (string.IsNullOrWhiteSpace(context.Model.Code))
+        {
+            context.Result.Fail(new ValidationResult(S["Code is required."], [nameof(TaxJurisdiction.Code)]));
+        }
+
+        if (context.Model.EffectiveFromUtc.HasValue &&
+            context.Model.EffectiveToUtc.HasValue &&
+            context.Model.EffectiveToUtc.Value < context.Model.EffectiveFromUtc.Value)
+        {
+            context.Result.Fail(new ValidationResult(S["The effective end date cannot be earlier than the effective start date."], [nameof(TaxJurisdiction.EffectiveToUtc)]));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxJurisdictionHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxJurisdictionHandler.cs
@@ -1,7 +1,10 @@
 using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
 using CrestApps.Core.Handlers;
 using CrestApps.Core.Models;
+using CrestApps.OrchardCore.Taxation.Deployments;
 using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Modules;
 
@@ -9,21 +12,48 @@ namespace CrestApps.OrchardCore.Taxation.Handlers;
 
 internal sealed class TaxJurisdictionHandler : CatalogEntryHandlerBase<TaxJurisdiction>
 {
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IClock _clock;
 
     internal readonly IStringLocalizer S;
 
     public TaxJurisdictionHandler(
+        IHttpContextAccessor httpContextAccessor,
         IClock clock,
         IStringLocalizer<TaxJurisdictionHandler> stringLocalizer)
     {
+        _httpContextAccessor = httpContextAccessor;
         _clock = clock;
         S = stringLocalizer;
+    }
+
+    public override Task InitializingAsync(InitializingContext<TaxJurisdiction> context, CancellationToken cancellationToken = default)
+    {
+        TaxationDeploymentSerializer.Populate(context.Model, context.Data);
+
+        return Task.CompletedTask;
     }
 
     public override Task UpdatingAsync(UpdatingContext<TaxJurisdiction> context, CancellationToken cancellationToken = default)
     {
         context.Model.ModifiedUtc = _clock.UtcNow;
+
+        TaxationDeploymentSerializer.Populate(context.Model, context.Data);
+
+        return Task.CompletedTask;
+    }
+
+    public override Task InitializedAsync(InitializedContext<TaxJurisdiction> context, CancellationToken cancellationToken = default)
+    {
+        context.Model.CreatedUtc = _clock.UtcNow;
+
+        var user = _httpContextAccessor.HttpContext?.User;
+
+        if (user is not null)
+        {
+            context.Model.OwnerId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            context.Model.Author = user.Identity?.Name;
+        }
 
         return Task.CompletedTask;
     }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxRuleHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxRuleHandler.cs
@@ -1,7 +1,10 @@
 using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
 using CrestApps.Core.Handlers;
 using CrestApps.Core.Models;
+using CrestApps.OrchardCore.Taxation.Deployments;
 using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Modules;
 
@@ -9,21 +12,48 @@ namespace CrestApps.OrchardCore.Taxation.Handlers;
 
 internal sealed class TaxRuleHandler : CatalogEntryHandlerBase<TaxRule>
 {
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IClock _clock;
 
     internal readonly IStringLocalizer S;
 
     public TaxRuleHandler(
+        IHttpContextAccessor httpContextAccessor,
         IClock clock,
         IStringLocalizer<TaxRuleHandler> stringLocalizer)
     {
+        _httpContextAccessor = httpContextAccessor;
         _clock = clock;
         S = stringLocalizer;
+    }
+
+    public override Task InitializingAsync(InitializingContext<TaxRule> context, CancellationToken cancellationToken = default)
+    {
+        TaxationDeploymentSerializer.Populate(context.Model, context.Data);
+
+        return Task.CompletedTask;
     }
 
     public override Task UpdatingAsync(UpdatingContext<TaxRule> context, CancellationToken cancellationToken = default)
     {
         context.Model.ModifiedUtc = _clock.UtcNow;
+
+        TaxationDeploymentSerializer.Populate(context.Model, context.Data);
+
+        return Task.CompletedTask;
+    }
+
+    public override Task InitializedAsync(InitializedContext<TaxRule> context, CancellationToken cancellationToken = default)
+    {
+        context.Model.CreatedUtc = _clock.UtcNow;
+
+        var user = _httpContextAccessor.HttpContext?.User;
+
+        if (user is not null)
+        {
+            context.Model.OwnerId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            context.Model.Author = user.Identity?.Name;
+        }
 
         return Task.CompletedTask;
     }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxRuleHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Handlers/TaxRuleHandler.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel.DataAnnotations;
+using CrestApps.Core.Handlers;
+using CrestApps.Core.Models;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Taxation.Handlers;
+
+internal sealed class TaxRuleHandler : CatalogEntryHandlerBase<TaxRule>
+{
+    private readonly IClock _clock;
+
+    internal readonly IStringLocalizer S;
+
+    public TaxRuleHandler(
+        IClock clock,
+        IStringLocalizer<TaxRuleHandler> stringLocalizer)
+    {
+        _clock = clock;
+        S = stringLocalizer;
+    }
+
+    public override Task UpdatingAsync(UpdatingContext<TaxRule> context, CancellationToken cancellationToken = default)
+    {
+        context.Model.ModifiedUtc = _clock.UtcNow;
+
+        return Task.CompletedTask;
+    }
+
+    public override Task ValidatingAsync(ValidatingContext<TaxRule> context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Model.Name))
+        {
+            context.Result.Fail(new ValidationResult(S["Name is required."], [nameof(TaxRule.Name)]));
+        }
+
+        if (string.IsNullOrWhiteSpace(context.Model.TaxType))
+        {
+            context.Result.Fail(new ValidationResult(S["Tax type is required."], [nameof(TaxRule.TaxType)]));
+        }
+
+        if (string.IsNullOrWhiteSpace(context.Model.CalculationMethod))
+        {
+            context.Result.Fail(new ValidationResult(S["Calculation method is required."], [nameof(TaxRule.CalculationMethod)]));
+        }
+
+        if (context.Model.MinimumAmount.HasValue &&
+            context.Model.MaximumAmount.HasValue &&
+            context.Model.MaximumAmount.Value < context.Model.MinimumAmount.Value)
+        {
+            context.Result.Fail(new ValidationResult(S["The maximum amount cannot be smaller than the minimum amount."], [nameof(TaxRule.MaximumAmount)]));
+        }
+
+        if (context.Model.EffectiveFromUtc.HasValue &&
+            context.Model.EffectiveToUtc.HasValue &&
+            context.Model.EffectiveToUtc.Value < context.Model.EffectiveFromUtc.Value)
+        {
+            context.Result.Fail(new ValidationResult(S["The effective end date cannot be earlier than the effective start date."], [nameof(TaxRule.EffectiveToUtc)]));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Models/TaxClassification.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Models/TaxClassification.cs
@@ -1,0 +1,24 @@
+namespace CrestApps.OrchardCore.Taxation.Models;
+
+/// <summary>
+/// Represents a tax classification resolved for a content item. A classification carries the tax
+/// category and, optionally, a refining classification code and an external provider code. It never
+/// carries a rate; the taxation engine determines the applicable tax from this classification.
+/// </summary>
+public sealed class TaxClassification
+{
+    /// <summary>
+    /// Gets or sets the tax category code (for example <c>Electronics</c>).
+    /// </summary>
+    public string TaxCategoryCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tax classification code that refines the category.
+    /// </summary>
+    public string TaxClassificationCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional external or provider-specific tax code.
+    /// </summary>
+    public string ExternalTaxCode { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Recipes/TaxCategoryStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Recipes/TaxCategoryStep.cs
@@ -1,0 +1,86 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Deployments;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Recipes.Models;
+using OrchardCore.Recipes.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Recipes;
+
+/// <summary>
+/// Imports tax categories carried by a recipe step, creating entries that do not exist and updating those that do.
+/// </summary>
+internal sealed class TaxCategoryStep : NamedRecipeStepHandler
+{
+    private readonly INamedCatalogManager<TaxCategory> _manager;
+
+    internal readonly IStringLocalizer S;
+
+    public TaxCategoryStep(
+        INamedCatalogManager<TaxCategory> manager,
+        IStringLocalizer<TaxCategoryStep> stringLocalizer)
+        : base(TaxationDeploymentSteps.TaxCategory)
+    {
+        _manager = manager;
+        S = stringLocalizer;
+    }
+
+    protected override async Task HandleAsync(RecipeExecutionContext context)
+    {
+        var model = context.Step.ToObject<TaxCategoryStepModel>();
+        var tokens = model.TaxCategories?.OfType<JsonObject>() ?? [];
+
+        foreach (var token in tokens)
+        {
+            TaxCategory entry = null;
+            var isNew = false;
+
+            var id = token[nameof(TaxCategory.ItemId)]?.GetValue<string>();
+            var hasId = !string.IsNullOrEmpty(id);
+
+            if (hasId)
+            {
+                entry = await _manager.FindByIdAsync(id);
+            }
+
+            if (entry is not null)
+            {
+                await _manager.UpdateAsync(entry, token);
+            }
+            else
+            {
+                isNew = true;
+                entry = await _manager.NewAsync(token);
+
+                if (hasId && UniqueId.IsValid(id))
+                {
+                    entry.ItemId = id;
+                }
+            }
+
+            var validationResult = await _manager.ValidateAsync(entry);
+
+            if (!validationResult.Succeeded)
+            {
+                foreach (var error in validationResult.Errors)
+                {
+                    context.Errors.Add(error.ErrorMessage);
+                }
+
+                continue;
+            }
+
+            if (isNew)
+            {
+                await _manager.CreateAsync(entry);
+            }
+        }
+    }
+
+    private sealed class TaxCategoryStepModel
+    {
+        public JsonArray TaxCategories { get; set; }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Recipes/TaxJurisdictionStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Recipes/TaxJurisdictionStep.cs
@@ -1,0 +1,86 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Deployments;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Recipes.Models;
+using OrchardCore.Recipes.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Recipes;
+
+/// <summary>
+/// Imports tax jurisdictions carried by a recipe step, creating entries that do not exist and updating those that do.
+/// </summary>
+internal sealed class TaxJurisdictionStep : NamedRecipeStepHandler
+{
+    private readonly INamedCatalogManager<TaxJurisdiction> _manager;
+
+    internal readonly IStringLocalizer S;
+
+    public TaxJurisdictionStep(
+        INamedCatalogManager<TaxJurisdiction> manager,
+        IStringLocalizer<TaxJurisdictionStep> stringLocalizer)
+        : base(TaxationDeploymentSteps.TaxJurisdiction)
+    {
+        _manager = manager;
+        S = stringLocalizer;
+    }
+
+    protected override async Task HandleAsync(RecipeExecutionContext context)
+    {
+        var model = context.Step.ToObject<TaxJurisdictionStepModel>();
+        var tokens = model.TaxJurisdictions?.OfType<JsonObject>() ?? [];
+
+        foreach (var token in tokens)
+        {
+            TaxJurisdiction entry = null;
+            var isNew = false;
+
+            var id = token[nameof(TaxJurisdiction.ItemId)]?.GetValue<string>();
+            var hasId = !string.IsNullOrEmpty(id);
+
+            if (hasId)
+            {
+                entry = await _manager.FindByIdAsync(id);
+            }
+
+            if (entry is not null)
+            {
+                await _manager.UpdateAsync(entry, token);
+            }
+            else
+            {
+                isNew = true;
+                entry = await _manager.NewAsync(token);
+
+                if (hasId && UniqueId.IsValid(id))
+                {
+                    entry.ItemId = id;
+                }
+            }
+
+            var validationResult = await _manager.ValidateAsync(entry);
+
+            if (!validationResult.Succeeded)
+            {
+                foreach (var error in validationResult.Errors)
+                {
+                    context.Errors.Add(error.ErrorMessage);
+                }
+
+                continue;
+            }
+
+            if (isNew)
+            {
+                await _manager.CreateAsync(entry);
+            }
+        }
+    }
+
+    private sealed class TaxJurisdictionStepModel
+    {
+        public JsonArray TaxJurisdictions { get; set; }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Recipes/TaxRuleStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Recipes/TaxRuleStep.cs
@@ -1,0 +1,86 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.Taxation.Deployments;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Recipes.Models;
+using OrchardCore.Recipes.Services;
+
+namespace CrestApps.OrchardCore.Taxation.Recipes;
+
+/// <summary>
+/// Imports tax rules carried by a recipe step, creating entries that do not exist and updating those that do.
+/// </summary>
+internal sealed class TaxRuleStep : NamedRecipeStepHandler
+{
+    private readonly INamedCatalogManager<TaxRule> _manager;
+
+    internal readonly IStringLocalizer S;
+
+    public TaxRuleStep(
+        INamedCatalogManager<TaxRule> manager,
+        IStringLocalizer<TaxRuleStep> stringLocalizer)
+        : base(TaxationDeploymentSteps.TaxRule)
+    {
+        _manager = manager;
+        S = stringLocalizer;
+    }
+
+    protected override async Task HandleAsync(RecipeExecutionContext context)
+    {
+        var model = context.Step.ToObject<TaxRuleStepModel>();
+        var tokens = model.TaxRules?.OfType<JsonObject>() ?? [];
+
+        foreach (var token in tokens)
+        {
+            TaxRule entry = null;
+            var isNew = false;
+
+            var id = token[nameof(TaxRule.ItemId)]?.GetValue<string>();
+            var hasId = !string.IsNullOrEmpty(id);
+
+            if (hasId)
+            {
+                entry = await _manager.FindByIdAsync(id);
+            }
+
+            if (entry is not null)
+            {
+                await _manager.UpdateAsync(entry, token);
+            }
+            else
+            {
+                isNew = true;
+                entry = await _manager.NewAsync(token);
+
+                if (hasId && UniqueId.IsValid(id))
+                {
+                    entry.ItemId = id;
+                }
+            }
+
+            var validationResult = await _manager.ValidateAsync(entry);
+
+            if (!validationResult.Succeeded)
+            {
+                foreach (var error in validationResult.Errors)
+                {
+                    context.Errors.Add(error.ErrorMessage);
+                }
+
+                continue;
+            }
+
+            if (isNew)
+            {
+                await _manager.CreateAsync(entry);
+            }
+        }
+    }
+
+    private sealed class TaxRuleStepModel
+    {
+        public JsonArray TaxRules { get; set; }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/RecipesSchemaStartup.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/RecipesSchemaStartup.cs
@@ -1,0 +1,23 @@
+using CrestApps.OrchardCore.Recipes.Core;
+using CrestApps.OrchardCore.Taxation.Schemas;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Registers recipe schema contributors for the taxation feature.
+/// </summary>
+[RequireFeatures("CrestApps.OrchardCore.Recipes")]
+public sealed class RecipesSchemaStartup : StartupBase
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IRecipeStep, TaxCategoryRecipeStep>();
+        services.AddScoped<IRecipeStep, TaxJurisdictionRecipeStep>();
+        services.AddScoped<IRecipeStep, TaxRuleRecipeStep>();
+
+        services.AddScoped<IContentSchemaDefinition, TaxationPartSchemaDefinition>();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Schemas/TaxCategoryRecipeStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Schemas/TaxCategoryRecipeStep.cs
@@ -1,0 +1,55 @@
+using CrestApps.OrchardCore.Recipes.Core;
+using CrestApps.OrchardCore.Taxation.Deployments;
+using Json.Schema;
+
+namespace CrestApps.OrchardCore.Taxation.Schemas;
+
+/// <summary>
+/// Schema for the "TaxCategory" recipe step — creates or updates tax categories.
+/// </summary>
+public sealed class TaxCategoryRecipeStep : IRecipeStep
+{
+    private JsonSchema _cached;
+
+    /// <inheritdoc />
+    public string Name => TaxationDeploymentSteps.TaxCategory;
+
+    /// <inheritdoc />
+    public ValueTask<JsonSchema> GetSchemaAsync(CancellationToken cancellationToken = default)
+    {
+        _cached ??= CreateSchema();
+
+        return ValueTask.FromResult(_cached);
+    }
+
+    private static JsonSchema CreateSchema()
+    {
+        var itemSchema = new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("ItemId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The stable identifier of the category. Preserved across environments.")),
+                ("Name", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The display name of the category.")),
+                ("Code", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The unique code of the category (for example 'Electronics').")),
+                ("ParentCode", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The code of the parent category, forming a hierarchy.")),
+                ("Description", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("A description of the category.")),
+                ("ExternalCodes", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.Object)
+                    .AdditionalProperties(new JsonSchemaBuilder().Type(SchemaValueType.String))
+                    .Description("Provider-specific tax codes keyed by provider name.")))
+            .Required("Name", "Code")
+            .AdditionalProperties(true);
+
+        return new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("name", new JsonSchemaBuilder().Type(SchemaValueType.String).Const(TaxationDeploymentSteps.TaxCategory).Description($"Recipe step discriminator. Must be '{TaxationDeploymentSteps.TaxCategory}'.")),
+                ("TaxCategories", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.Array)
+                    .Items(itemSchema)
+                    .MinItems(1)
+                    .Description("The tax categories to create or update.")))
+            .Required("name", "TaxCategories")
+            .AdditionalProperties(true)
+            .Build();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Schemas/TaxJurisdictionRecipeStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Schemas/TaxJurisdictionRecipeStep.cs
@@ -1,0 +1,69 @@
+using CrestApps.OrchardCore.Recipes.Core;
+using CrestApps.OrchardCore.Taxation.Deployments;
+using Json.Schema;
+
+namespace CrestApps.OrchardCore.Taxation.Schemas;
+
+/// <summary>
+/// Schema for the "TaxJurisdiction" recipe step — creates or updates tax jurisdictions.
+/// </summary>
+public sealed class TaxJurisdictionRecipeStep : IRecipeStep
+{
+    private JsonSchema _cached;
+
+    /// <inheritdoc />
+    public string Name => TaxationDeploymentSteps.TaxJurisdiction;
+
+    /// <inheritdoc />
+    public ValueTask<JsonSchema> GetSchemaAsync(CancellationToken cancellationToken = default)
+    {
+        _cached ??= CreateSchema();
+
+        return ValueTask.FromResult(_cached);
+    }
+
+    private static JsonSchema CreateSchema()
+    {
+        var levelSchema = new JsonSchemaBuilder().AnyOf(
+            new JsonSchemaBuilder()
+                .Type(SchemaValueType.String)
+                .Enum("Country", "State", "Province", "Region", "County", "City", "Special", "Other"),
+            new JsonSchemaBuilder().Type(SchemaValueType.Integer))
+            .Description("The administrative level of the jurisdiction.");
+
+        var dateSchema = new JsonSchemaBuilder().AnyOf(
+            new JsonSchemaBuilder().Type(SchemaValueType.String),
+            new JsonSchemaBuilder().Type(SchemaValueType.Null));
+
+        var itemSchema = new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("ItemId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The stable identifier of the jurisdiction. Preserved across environments.")),
+                ("Name", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The display name of the jurisdiction.")),
+                ("Code", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The code of the jurisdiction.")),
+                ("Level", levelSchema),
+                ("Country", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The ISO country code the jurisdiction belongs to.")),
+                ("Region", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The state, province, or region code the jurisdiction belongs to.")),
+                ("County", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The county the jurisdiction belongs to.")),
+                ("City", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The city the jurisdiction belongs to.")),
+                ("PostalCode", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The postal code the jurisdiction covers.")),
+                ("ParentId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The identifier of the parent jurisdiction, forming a hierarchy.")),
+                ("EffectiveFromUtc", dateSchema.Description("The UTC date the jurisdiction becomes effective.")),
+                ("EffectiveToUtc", dateSchema.Description("The UTC date the jurisdiction stops being effective.")))
+            .Required("Name", "Code")
+            .AdditionalProperties(true);
+
+        return new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("name", new JsonSchemaBuilder().Type(SchemaValueType.String).Const(TaxationDeploymentSteps.TaxJurisdiction).Description($"Recipe step discriminator. Must be '{TaxationDeploymentSteps.TaxJurisdiction}'.")),
+                ("TaxJurisdictions", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.Array)
+                    .Items(itemSchema)
+                    .MinItems(1)
+                    .Description("The tax jurisdictions to create or update.")))
+            .Required("name", "TaxJurisdictions")
+            .AdditionalProperties(true)
+            .Build();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Schemas/TaxRuleRecipeStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Schemas/TaxRuleRecipeStep.cs
@@ -1,0 +1,82 @@
+using CrestApps.OrchardCore.Recipes.Core;
+using CrestApps.OrchardCore.Taxation.Deployments;
+using Json.Schema;
+
+namespace CrestApps.OrchardCore.Taxation.Schemas;
+
+/// <summary>
+/// Schema for the "TaxRule" recipe step — creates or updates tax rules.
+/// </summary>
+public sealed class TaxRuleRecipeStep : IRecipeStep
+{
+    private JsonSchema _cached;
+
+    /// <inheritdoc />
+    public string Name => TaxationDeploymentSteps.TaxRule;
+
+    /// <inheritdoc />
+    public ValueTask<JsonSchema> GetSchemaAsync(CancellationToken cancellationToken = default)
+    {
+        _cached ??= CreateSchema();
+
+        return ValueTask.FromResult(_cached);
+    }
+
+    private static JsonSchema CreateSchema()
+    {
+        var customerTypeSchema = new JsonSchemaBuilder().AnyOf(
+            new JsonSchemaBuilder().Type(SchemaValueType.String).Enum("B2C", "B2B"),
+            new JsonSchemaBuilder().Type(SchemaValueType.Integer),
+            new JsonSchemaBuilder().Type(SchemaValueType.Null))
+            .Description("The customer classification the rule applies to. Omit to match every customer type.");
+
+        var number = new JsonSchemaBuilder().AnyOf(
+            new JsonSchemaBuilder().Type(SchemaValueType.Number),
+            new JsonSchemaBuilder().Type(SchemaValueType.Null));
+
+        var dateSchema = new JsonSchemaBuilder().AnyOf(
+            new JsonSchemaBuilder().Type(SchemaValueType.String),
+            new JsonSchemaBuilder().Type(SchemaValueType.Null));
+
+        var itemSchema = new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("ItemId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The stable identifier of the rule. Preserved across environments.")),
+                ("Name", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The display name of the rule.")),
+                ("Version", new JsonSchemaBuilder().Type(SchemaValueType.Integer).Description("The version of the rule.")),
+                ("Enabled", new JsonSchemaBuilder().Type(SchemaValueType.Boolean).Description("Whether the rule is enabled.")),
+                ("Priority", new JsonSchemaBuilder().Type(SchemaValueType.Integer).Description("The evaluation priority. Lower values are evaluated first.")),
+                ("TaxType", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The type of tax the rule produces (for example 'SalesTax').")),
+                ("TaxName", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The human readable name of the tax the rule produces.")),
+                ("TaxCode", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The code of the tax the rule produces.")),
+                ("JurisdictionId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The identifier of the jurisdiction the rule belongs to.")),
+                ("CategoryCode", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The tax category code the rule applies to. Omit to match every category.")),
+                ("CustomerType", customerTypeSchema),
+                ("CalculationMethod", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The calculation method used by the rule (for example 'Percentage').")),
+                ("Rate", number.Description("The rate applied by the rule, expressed as a fraction (for example 0.2 for 20%).")),
+                ("FixedAmount", number.Description("The fixed amount applied by the rule, when the method is amount based.")),
+                ("TaxTableId", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("The identifier of the tax table the rule uses, when the method is table based.")),
+                ("IncludedInPrice", new JsonSchemaBuilder().Type(SchemaValueType.Boolean).Description("Whether the produced tax is included in the item price.")),
+                ("IsCompound", new JsonSchemaBuilder().Type(SchemaValueType.Boolean).Description("Whether the produced tax is compound (calculated on top of other taxes).")),
+                ("AppliesToShipping", new JsonSchemaBuilder().Type(SchemaValueType.Boolean).Description("Whether the rule applies to shipping charges.")),
+                ("MinimumAmount", number.Description("The inclusive minimum taxable amount the rule applies to.")),
+                ("MaximumAmount", number.Description("The exclusive maximum taxable amount the rule applies to.")),
+                ("EffectiveFromUtc", dateSchema.Description("The UTC date the rule becomes effective.")),
+                ("EffectiveToUtc", dateSchema.Description("The UTC date the rule stops being effective.")))
+            .Required("Name")
+            .AdditionalProperties(true);
+
+        return new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("name", new JsonSchemaBuilder().Type(SchemaValueType.String).Const(TaxationDeploymentSteps.TaxRule).Description($"Recipe step discriminator. Must be '{TaxationDeploymentSteps.TaxRule}'.")),
+                ("TaxRules", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.Array)
+                    .Items(itemSchema)
+                    .MinItems(1)
+                    .Description("The tax rules to create or update.")))
+            .Required("name", "TaxRules")
+            .AdditionalProperties(true)
+            .Build();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Schemas/TaxationPartSchemaDefinition.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Schemas/TaxationPartSchemaDefinition.cs
@@ -1,0 +1,54 @@
+using CrestApps.OrchardCore.Recipes.Core.Schemas;
+using CrestApps.OrchardCore.Recipes.Core.Schemas.Parts;
+using Json.Schema;
+
+namespace CrestApps.OrchardCore.Taxation.Schemas;
+
+/// <summary>
+/// Provides recipe schema support for the taxation content part.
+/// </summary>
+public sealed class TaxationPartSchemaDefinition : PartSchemaDefinitionBase
+{
+    /// <inheritdoc />
+    public override string Name => TaxationConstants.Parts.TaxationPart;
+
+    /// <inheritdoc />
+    protected override JsonSchemaBuilder BuildSettingsCore()
+        => new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("TaxationPartSettings", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.Object)
+                    .Properties(
+                        ("DefaultTaxCategoryCode", new JsonSchemaBuilder()
+                            .Type(SchemaValueType.String)
+                            .Description("The default tax category code applied to new content items.")),
+                        ("DefaultTaxClassificationCode", new JsonSchemaBuilder()
+                            .Type(SchemaValueType.String)
+                            .Description("The default tax classification code applied to new content items.")),
+                        ("AllowClassificationOverride", new JsonSchemaBuilder()
+                            .Type(SchemaValueType.Boolean)
+                            .Default(true)
+                            .Description("Whether the tax classification fields are shown to editors.")))
+                    .AdditionalProperties(false)))
+            .AdditionalProperties(true);
+
+    /// <inheritdoc />
+    protected override JsonSchemaBuilder BuildPartSchemaCore()
+        => new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("Taxable", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.Boolean)
+                    .Description("Whether the content item is taxable.")),
+                ("TaxCategoryCode", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.String)
+                    .Description("The tax category code (for example 'Electronics').")),
+                ("TaxClassificationCode", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.String)
+                    .Description("The tax classification code that refines the category.")),
+                ("ExternalTaxCode", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.String)
+                    .Description("An optional external or provider-specific tax code.")))
+            .AdditionalProperties(true);
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Services/ContentItemTaxableItemProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Services/ContentItemTaxableItemProvider.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,8 +14,23 @@ namespace CrestApps.OrchardCore.Taxation.Services;
 /// The amount is read generically from a well-known <c>ProductPart.Price</c> location when present so
 /// that the taxation module stays decoupled from any particular commerce module.
 /// </summary>
+/// <remarks>
+/// When the item does not classify itself (its <see cref="TaxationPart.TaxCategoryCode"/> is empty), the
+/// registered <see cref="ITaxClassificationProvider"/> instances are consulted in order so that the item
+/// can inherit its classification, for example from the taxonomy terms (product categories) it belongs to.
+/// An explicit item classification always overrides an inherited one.
+/// </remarks>
 public sealed class ContentItemTaxableItemProvider : ITaxableItemProvider
 {
+    private readonly ITaxClassificationProvider[] _classificationProviders;
+
+    public ContentItemTaxableItemProvider(IEnumerable<ITaxClassificationProvider> classificationProviders)
+    {
+        _classificationProviders = classificationProviders
+            .OrderBy(provider => provider.Order)
+            .ToArray();
+    }
+
     /// <inheritdoc />
     public int Order => 0;
 
@@ -22,18 +39,51 @@ public sealed class ContentItemTaxableItemProvider : ITaxableItemProvider
         => source is ContentItem contentItem && contentItem.Has<TaxationPart>();
 
     /// <inheritdoc />
-    public ValueTask<ITaxableItem> CreateAsync(object source, CancellationToken cancellationToken = default)
+    public async ValueTask<ITaxableItem> CreateAsync(object source, CancellationToken cancellationToken = default)
     {
         if (source is not ContentItem contentItem)
         {
-            return ValueTask.FromResult<ITaxableItem>(null);
+            return null;
         }
 
         var part = contentItem.Get<TaxationPart>(nameof(TaxationPart));
 
         if (part is null || !part.Taxable)
         {
-            return ValueTask.FromResult<ITaxableItem>(null);
+            return null;
+        }
+
+        var categoryCode = part.TaxCategoryCode;
+        var classificationCode = part.TaxClassificationCode;
+        var externalTaxCode = part.ExternalTaxCode;
+
+        // An explicit classification on the item wins. Otherwise inherit from the registered providers
+        // (for example, the taxonomy terms the item belongs to).
+        if (string.IsNullOrEmpty(categoryCode))
+        {
+            foreach (var provider in _classificationProviders)
+            {
+                var classification = await provider.GetClassificationAsync(contentItem, cancellationToken);
+
+                if (classification is null || string.IsNullOrEmpty(classification.TaxCategoryCode))
+                {
+                    continue;
+                }
+
+                categoryCode = classification.TaxCategoryCode;
+
+                if (string.IsNullOrEmpty(classificationCode))
+                {
+                    classificationCode = classification.TaxClassificationCode;
+                }
+
+                if (string.IsNullOrEmpty(externalTaxCode))
+                {
+                    externalTaxCode = classification.ExternalTaxCode;
+                }
+
+                break;
+            }
         }
 
         var item = new TaxableItem
@@ -41,14 +91,14 @@ public sealed class ContentItemTaxableItemProvider : ITaxableItemProvider
             Id = contentItem.ContentItemId,
             UnitPrice = ReadPrice(contentItem),
             Quantity = 1m,
-            TaxCategoryCode = part.TaxCategoryCode,
-            TaxClassificationCode = part.TaxClassificationCode,
-            ExternalTaxCode = part.ExternalTaxCode,
+            TaxCategoryCode = categoryCode,
+            TaxClassificationCode = classificationCode,
+            ExternalTaxCode = externalTaxCode,
         };
 
         item.Metadata["ContentType"] = contentItem.ContentType;
 
-        return ValueTask.FromResult<ITaxableItem>(item);
+        return item;
     }
 
     private static decimal ReadPrice(ContentItem contentItem)

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Services/ITaxClassificationProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Services/ITaxClassificationProvider.cs
@@ -1,0 +1,31 @@
+using CrestApps.OrchardCore.Taxation.Models;
+using OrchardCore.ContentManagement;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Resolves an inherited tax classification for a content item from a source other than the item's own
+/// <see cref="TaxationPart"/>. Providers let a content item inherit its classification, for example from
+/// the taxonomy terms (product categories) it belongs to, so that tax codes can be managed per category
+/// rather than repeated on every item.
+/// </summary>
+/// <remarks>
+/// A classification set explicitly on the item's own <see cref="TaxationPart"/> always takes precedence.
+/// Providers are consulted in ascending <see cref="Order"/> only when the item does not classify itself,
+/// and the first provider that yields a category wins.
+/// </remarks>
+public interface ITaxClassificationProvider
+{
+    /// <summary>
+    /// Gets the relative order in which the provider is consulted. Lower values are consulted first.
+    /// </summary>
+    int Order { get; }
+
+    /// <summary>
+    /// Resolves the inherited tax classification for the supplied content item.
+    /// </summary>
+    /// <param name="contentItem">The content item to resolve the classification for.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The resolved classification, or <see langword="null"/> when the provider cannot classify the item.</returns>
+    ValueTask<TaxClassification> GetClassificationAsync(ContentItem contentItem, CancellationToken cancellationToken = default);
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxationAdminMenu.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxationAdminMenu.cs
@@ -1,3 +1,4 @@
+using CrestApps.OrchardCore.Taxation.Core;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Navigation;
 

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxationAdminMenu.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxationAdminMenu.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Localization;
+using OrchardCore.Navigation;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+internal sealed class TaxationAdminMenu : AdminNavigationProvider
+{
+    internal readonly IStringLocalizer S;
+
+    public TaxationAdminMenu(IStringLocalizer<TaxationAdminMenu> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    protected override ValueTask BuildAsync(NavigationBuilder builder)
+    {
+        builder
+            .Add(S["Commerce"], commerce => commerce
+                .Add(S["Taxation"], S["Taxation"].PrefixPosition(), taxation => taxation
+                    .AddClass("taxation")
+                    .Id("taxation")
+                    .Add(S["Categories"], S["Categories"].PrefixPosition(), categories => categories
+                        .AddClass("taxation-categories")
+                        .Id("taxationCategories")
+                        .Action("Index", "TaxCategories", "CrestApps.OrchardCore.Taxation")
+                        .Permission(TaxationPermissions.ManageTaxation)
+                        .LocalNav())
+                    .Add(S["Jurisdictions"], S["Jurisdictions"].PrefixPosition(), jurisdictions => jurisdictions
+                        .AddClass("taxation-jurisdictions")
+                        .Id("taxationJurisdictions")
+                        .Action("Index", "TaxJurisdictions", "CrestApps.OrchardCore.Taxation")
+                        .Permission(TaxationPermissions.ManageTaxation)
+                        .LocalNav())
+                    .Add(S["Rules"], S["Rules"].PrefixPosition(), rules => rules
+                        .AddClass("taxation-rules")
+                        .Id("taxationRules")
+                        .Action("Index", "TaxRules", "CrestApps.OrchardCore.Taxation")
+                        .Permission(TaxationPermissions.ManageTaxation)
+                        .LocalNav())));
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxationPermissionsProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxationPermissionsProvider.cs
@@ -1,0 +1,24 @@
+using OrchardCore;
+using OrchardCore.Security.Permissions;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+internal sealed class TaxationPermissionsProvider : IPermissionProvider
+{
+    private readonly IEnumerable<Permission> _allPermissions =
+    [
+        TaxationPermissions.ManageTaxation,
+    ];
+
+    public Task<IEnumerable<Permission>> GetPermissionsAsync()
+        => Task.FromResult(_allPermissions);
+
+    public IEnumerable<PermissionStereotype> GetDefaultStereotypes() =>
+    [
+        new PermissionStereotype
+        {
+            Name = OrchardCoreConstants.Roles.Administrator,
+            Permissions = _allPermissions,
+        },
+    ];
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxationPermissionsProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxationPermissionsProvider.cs
@@ -1,3 +1,4 @@
+using CrestApps.OrchardCore.Taxation.Core;
 using OrchardCore;
 using OrchardCore.Security.Permissions;
 

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxonomyTaxClassificationProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Services/TaxonomyTaxClassificationProvider.cs
@@ -1,0 +1,106 @@
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using CrestApps.OrchardCore.Taxation.Models;
+using OrchardCore;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.Taxonomies;
+using OrchardCore.Taxonomies.Fields;
+
+namespace CrestApps.OrchardCore.Taxation.Services;
+
+/// <summary>
+/// Inherits a content item's tax classification from the taxonomy terms (product categories) it belongs to.
+/// Each taxonomy term can carry its own <see cref="TaxationPart"/>, so tax codes are managed per category
+/// and every item categorized under a term inherits that term's classification unless it classifies itself.
+/// </summary>
+/// <remarks>
+/// The provider inspects every <see cref="TaxonomyField"/> attached to the item's content type, walks the
+/// selected terms in order, and returns the first term that carries a taxable classification with a category
+/// code. This keeps taxation decoupled from taxonomies: it only participates when the
+/// <c>OrchardCore.Taxonomies</c> feature is enabled.
+/// </remarks>
+internal sealed class TaxonomyTaxClassificationProvider : ITaxClassificationProvider
+{
+    private readonly IContentDefinitionManager _contentDefinitionManager;
+    private readonly IOrchardHelper _orchardHelper;
+
+    public TaxonomyTaxClassificationProvider(
+        IContentDefinitionManager contentDefinitionManager,
+        IOrchardHelper orchardHelper)
+    {
+        _contentDefinitionManager = contentDefinitionManager;
+        _orchardHelper = orchardHelper;
+    }
+
+    /// <inheritdoc />
+    public int Order => 0;
+
+    /// <inheritdoc />
+    public async ValueTask<TaxClassification> GetClassificationAsync(ContentItem contentItem, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(contentItem);
+
+        var definition = await _contentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
+
+        if (definition?.Parts is null)
+        {
+            return null;
+        }
+
+        foreach (var partDefinition in definition.Parts)
+        {
+            var fields = partDefinition.PartDefinition?.Fields;
+
+            if (fields is null)
+            {
+                continue;
+            }
+
+            foreach (var fieldDefinition in fields)
+            {
+                if (!string.Equals(fieldDefinition.FieldDefinition?.Name, nameof(TaxonomyField), StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                JsonObject content = contentItem.Content;
+                var field = content?[partDefinition.Name]?[fieldDefinition.Name]?.ToObject<TaxonomyField>();
+
+                if (field is null ||
+                    string.IsNullOrEmpty(field.TaxonomyContentItemId) ||
+                    field.TermContentItemIds is null ||
+                    field.TermContentItemIds.Length == 0)
+                {
+                    continue;
+                }
+
+                foreach (var termId in field.TermContentItemIds)
+                {
+                    if (string.IsNullOrEmpty(termId))
+                    {
+                        continue;
+                    }
+
+                    var term = await _orchardHelper.GetTaxonomyTermAsync(field.TaxonomyContentItemId, termId);
+
+                    var part = term?.Get<TaxationPart>(nameof(TaxationPart));
+
+                    if (part is not null && part.Taxable && !string.IsNullOrEmpty(part.TaxCategoryCode))
+                    {
+                        return new TaxClassification
+                        {
+                            TaxCategoryCode = part.TaxCategoryCode,
+                            TaxClassificationCode = part.TaxClassificationCode,
+                            ExternalTaxCode = part.ExternalTaxCode,
+                        };
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Startup.cs
@@ -1,5 +1,7 @@
+using CrestApps.Core.Services;
 using CrestApps.OrchardCore.Taxation.Core;
 using CrestApps.OrchardCore.Taxation.Drivers;
+using CrestApps.OrchardCore.Taxation.Handlers;
 using CrestApps.OrchardCore.Taxation.Migrations;
 using CrestApps.OrchardCore.Taxation.Models;
 using CrestApps.OrchardCore.Taxation.Services;
@@ -8,7 +10,10 @@ using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data.Migration;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
+using OrchardCore.Navigation;
+using OrchardCore.Security.Permissions;
 
 namespace CrestApps.OrchardCore.Taxation;
 
@@ -31,5 +36,21 @@ public sealed class Startup : StartupBase
         services.AddDataMigration<TaxationPartMigrations>();
 
         services.AddTaxableItemProvider<ContentItemTaxableItemProvider>();
+
+        // Admin management UI for tax catalog entities (categories, jurisdictions, rules).
+        services
+            .AddDisplayDriver<TaxCategory, TaxCategoryDisplayDriver>()
+            .AddScoped<ICatalogEntryHandler<TaxCategory>, TaxCategoryHandler>();
+
+        services
+            .AddDisplayDriver<TaxJurisdiction, TaxJurisdictionDisplayDriver>()
+            .AddScoped<ICatalogEntryHandler<TaxJurisdiction>, TaxJurisdictionHandler>();
+
+        services
+            .AddDisplayDriver<TaxRule, TaxRuleDisplayDriver>()
+            .AddScoped<ICatalogEntryHandler<TaxRule>, TaxRuleHandler>();
+
+        services.AddNavigationProvider<TaxationAdminMenu>();
+        services.AddPermissionProvider<TaxationPermissionsProvider>();
     }
 }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/TaxationPermissions.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/TaxationPermissions.cs
@@ -1,0 +1,14 @@
+using OrchardCore.Security.Permissions;
+
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Represents the permissions exposed by the taxation module.
+/// </summary>
+public static class TaxationPermissions
+{
+    /// <summary>
+    /// Grants access to manage tax categories, jurisdictions, and rules.
+    /// </summary>
+    public static readonly Permission ManageTaxation = new("ManageTaxation", "Manage taxation");
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/TaxonomiesStartup.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/TaxonomiesStartup.cs
@@ -1,0 +1,20 @@
+using CrestApps.OrchardCore.Taxation.Services;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Modules;
+
+namespace CrestApps.OrchardCore.Taxation;
+
+/// <summary>
+/// Registers taxonomy-driven tax classification inheritance. When the Taxonomies feature is enabled, a
+/// content item can inherit its tax classification from the taxonomy terms (product categories) it belongs
+/// to, so tax codes are managed per category rather than repeated on every item.
+/// </summary>
+[RequireFeatures("OrchardCore.Taxonomies")]
+public sealed class TaxonomiesStartup : StartupBase
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<ITaxClassificationProvider, TaxonomyTaxClassificationProvider>();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxCategoryViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxCategoryViewModel.cs
@@ -1,0 +1,14 @@
+namespace CrestApps.OrchardCore.Taxation.ViewModels;
+
+public sealed class TaxCategoryViewModel
+{
+    public bool IsNew { get; set; }
+
+    public string Name { get; set; }
+
+    public string Code { get; set; }
+
+    public string ParentCode { get; set; }
+
+    public string Description { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxJurisdictionViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxJurisdictionViewModel.cs
@@ -1,0 +1,39 @@
+using System;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CrestApps.OrchardCore.Taxation.ViewModels;
+
+public sealed class TaxJurisdictionViewModel
+{
+    public bool IsNew { get; set; }
+
+    public string Name { get; set; }
+
+    public string Code { get; set; }
+
+    public JurisdictionLevel Level { get; set; }
+
+    public string Country { get; set; }
+
+    public string Region { get; set; }
+
+    public string County { get; set; }
+
+    public string City { get; set; }
+
+    public string PostalCode { get; set; }
+
+    public string ParentId { get; set; }
+
+    public DateTime? EffectiveFromUtc { get; set; }
+
+    public DateTime? EffectiveToUtc { get; set; }
+
+    [BindNever]
+    public IList<SelectListItem> Levels { get; set; } = [];
+
+    [BindNever]
+    public IList<SelectListItem> Parents { get; set; } = [];
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxRuleViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxRuleViewModel.cs
@@ -1,0 +1,64 @@
+using System;
+using CrestApps.OrchardCore.Taxation.Models;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CrestApps.OrchardCore.Taxation.ViewModels;
+
+public sealed class TaxRuleViewModel
+{
+    public bool IsNew { get; set; }
+
+    public string Name { get; set; }
+
+    public bool Enabled { get; set; } = true;
+
+    public int Priority { get; set; }
+
+    public string TaxType { get; set; }
+
+    public string TaxName { get; set; }
+
+    public string TaxCode { get; set; }
+
+    public string JurisdictionId { get; set; }
+
+    public string CategoryCode { get; set; }
+
+    public CustomerTaxType? CustomerType { get; set; }
+
+    public string CalculationMethod { get; set; }
+
+    public decimal? Rate { get; set; }
+
+    public decimal? FixedAmount { get; set; }
+
+    public bool IncludedInPrice { get; set; }
+
+    public bool IsCompound { get; set; }
+
+    public bool AppliesToShipping { get; set; }
+
+    public decimal? MinimumAmount { get; set; }
+
+    public decimal? MaximumAmount { get; set; }
+
+    public DateTime? EffectiveFromUtc { get; set; }
+
+    public DateTime? EffectiveToUtc { get; set; }
+
+    [BindNever]
+    public IList<SelectListItem> TaxTypes { get; set; } = [];
+
+    [BindNever]
+    public IList<SelectListItem> CalculationMethods { get; set; } = [];
+
+    [BindNever]
+    public IList<SelectListItem> CustomerTypes { get; set; } = [];
+
+    [BindNever]
+    public IList<SelectListItem> Jurisdictions { get; set; } = [];
+
+    [BindNever]
+    public IList<SelectListItem> Categories { get; set; } = [];
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxationPartSettingsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxationPartSettingsViewModel.cs
@@ -1,5 +1,9 @@
 namespace CrestApps.OrchardCore.Taxation.ViewModels;
 
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
 /// <summary>
 /// The settings editor view model for a <see cref="Models.TaxationPart"/>.
 /// </summary>
@@ -19,4 +23,11 @@ public class TaxationPartSettingsViewModel
     /// Gets or sets a value indicating whether editors can override the classification codes.
     /// </summary>
     public bool AllowClassificationOverride { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of available tax categories used to populate the category and
+    /// classification dropdowns.
+    /// </summary>
+    [BindNever]
+    public IList<SelectListItem> TaxCategories { get; set; } = [];
 }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxationPartViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/ViewModels/TaxationPartViewModel.cs
@@ -1,5 +1,9 @@
 namespace CrestApps.OrchardCore.Taxation.ViewModels;
 
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
 /// <summary>
 /// The editor view model for a <see cref="Models.TaxationPart"/>.
 /// </summary>
@@ -29,4 +33,11 @@ public class TaxationPartViewModel
     /// Gets or sets a value indicating whether editors can override the classification codes.
     /// </summary>
     public bool AllowClassificationOverride { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of available tax categories used to populate the category and
+    /// classification dropdowns.
+    /// </summary>
+    [BindNever]
+    public IList<SelectListItem> TaxCategories { get; set; } = [];
 }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategory.Buttons.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategory.Buttons.SummaryAdmin.cshtml
@@ -1,0 +1,12 @@
+@model ShapeViewModel<TaxCategory>
+
+<a asp-action="Edit"
+   asp-route-id="@Model.Value.ItemId"
+   class="btn btn-primary btn-sm">@T["Edit"]</a>
+
+<a asp-action="Delete"
+   asp-route-id="@Model.Value.ItemId"
+   class="btn btn-danger btn-sm"
+   data-title="@T["Delete"]"
+   data-message="@T["Are you sure you want to delete this tax category?"]"
+   data-url-af="RemoveUrl UnsafeUrl">@T["Delete"]</a>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategory.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategory.DefaultMeta.SummaryAdmin.cshtml
@@ -1,0 +1,9 @@
+@model ShapeViewModel<TaxCategory>
+
+@if (Model.Value.ModifiedUtc.HasValue)
+{
+    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.ModifiedUtc.Value, Format: "g"))">
+        <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i>
+        @await DisplayAsync(await New.Timespan(Utc: Model.Value.ModifiedUtc.Value))
+    </span>
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategory.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategory.DefaultMeta.SummaryAdmin.cshtml
@@ -1,9 +1,18 @@
 @model ShapeViewModel<TaxCategory>
 
-@if (Model.Value.ModifiedUtc.HasValue)
+@{
+    var modifiedAt = Model.Value.ModifiedUtc ?? (Model.Value.CreatedUtc == default ? (DateTime?)null : Model.Value.CreatedUtc);
+}
+
+@if (modifiedAt.HasValue)
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.ModifiedUtc.Value, Format: "g"))">
+    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: modifiedAt.Value, Format: "g"))">
         <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i>
-        @await DisplayAsync(await New.Timespan(Utc: Model.Value.ModifiedUtc.Value))
+        @await DisplayAsync(await New.Timespan(Utc: modifiedAt.Value))
     </span>
+}
+
+@if (!string.IsNullOrEmpty(Model.Value.Author))
+{
+    <user-display-name user-name="@(Model.Value.Author)" display-type="SummaryAdmin" cache-id="user-display-name-author" />
 }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategory.Fields.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategory.Fields.SummaryAdmin.cshtml
@@ -1,0 +1,14 @@
+@model ShapeViewModel<TaxCategory>
+
+<h5 class="mb-0">@Model.Value.Name</h5>
+<small class="text-muted">
+    @T["Code:"] <code>@Model.Value.Code</code>
+    @if (!string.IsNullOrEmpty(Model.Value.ParentCode))
+    {
+        <span class="ms-1">@T["Parent:"] <code>@Model.Value.ParentCode</code></span>
+    }
+    @if (!string.IsNullOrEmpty(Model.Value.Description))
+    {
+        <span class="d-block">@Model.Value.Description</span>
+    }
+</small>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategoryDeploymentStep.Summary.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategoryDeploymentStep.Summary.cshtml
@@ -1,0 +1,8 @@
+@using CrestApps.OrchardCore.Taxation.Deployments.Steps
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<TaxCategoryDeploymentStep>
+
+<h5>@T["Tax Categories"]</h5>
+
+<span class="badge text-bg-success">@T["All tax categories"]</span>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategoryDeploymentStep.Thumbnail.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxCategoryDeploymentStep.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+<h4 class="card-title">@T["Tax Categories"]</h4>
+<p>@T["Export all tax categories."]</p>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdiction.Buttons.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdiction.Buttons.SummaryAdmin.cshtml
@@ -1,0 +1,12 @@
+@model ShapeViewModel<TaxJurisdiction>
+
+<a asp-action="Edit"
+   asp-route-id="@Model.Value.ItemId"
+   class="btn btn-primary btn-sm">@T["Edit"]</a>
+
+<a asp-action="Delete"
+   asp-route-id="@Model.Value.ItemId"
+   class="btn btn-danger btn-sm"
+   data-title="@T["Delete"]"
+   data-message="@T["Are you sure you want to delete this tax jurisdiction?"]"
+   data-url-af="RemoveUrl UnsafeUrl">@T["Delete"]</a>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdiction.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdiction.DefaultMeta.SummaryAdmin.cshtml
@@ -1,9 +1,18 @@
 @model ShapeViewModel<TaxJurisdiction>
 
-@if (Model.Value.ModifiedUtc.HasValue)
+@{
+    var modifiedAt = Model.Value.ModifiedUtc ?? (Model.Value.CreatedUtc == default ? (DateTime?)null : Model.Value.CreatedUtc);
+}
+
+@if (modifiedAt.HasValue)
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.ModifiedUtc.Value, Format: "g"))">
+    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: modifiedAt.Value, Format: "g"))">
         <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i>
-        @await DisplayAsync(await New.Timespan(Utc: Model.Value.ModifiedUtc.Value))
+        @await DisplayAsync(await New.Timespan(Utc: modifiedAt.Value))
     </span>
+}
+
+@if (!string.IsNullOrEmpty(Model.Value.Author))
+{
+    <user-display-name user-name="@(Model.Value.Author)" display-type="SummaryAdmin" cache-id="user-display-name-author" />
 }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdiction.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdiction.DefaultMeta.SummaryAdmin.cshtml
@@ -1,0 +1,9 @@
+@model ShapeViewModel<TaxJurisdiction>
+
+@if (Model.Value.ModifiedUtc.HasValue)
+{
+    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.ModifiedUtc.Value, Format: "g"))">
+        <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i>
+        @await DisplayAsync(await New.Timespan(Utc: Model.Value.ModifiedUtc.Value))
+    </span>
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdiction.Fields.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdiction.Fields.SummaryAdmin.cshtml
@@ -1,0 +1,17 @@
+@model ShapeViewModel<TaxJurisdiction>
+
+<h5 class="mb-0">
+    @Model.Value.Name
+    <span class="badge bg-secondary">@Model.Value.Level</span>
+</h5>
+<small class="text-muted">
+    @T["Code:"] <code>@Model.Value.Code</code>
+    @if (!string.IsNullOrEmpty(Model.Value.Country))
+    {
+        <span class="ms-1">@T["Country:"] @Model.Value.Country</span>
+    }
+    @if (!string.IsNullOrEmpty(Model.Value.Region))
+    {
+        <span class="ms-1">@T["Region:"] @Model.Value.Region</span>
+    }
+</small>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdictionDeploymentStep.Summary.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdictionDeploymentStep.Summary.cshtml
@@ -1,0 +1,8 @@
+@using CrestApps.OrchardCore.Taxation.Deployments.Steps
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<TaxJurisdictionDeploymentStep>
+
+<h5>@T["Tax Jurisdictions"]</h5>
+
+<span class="badge text-bg-success">@T["All tax jurisdictions"]</span>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdictionDeploymentStep.Thumbnail.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxJurisdictionDeploymentStep.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+<h4 class="card-title">@T["Tax Jurisdictions"]</h4>
+<p>@T["Export all tax jurisdictions."]</p>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRule.Buttons.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRule.Buttons.SummaryAdmin.cshtml
@@ -1,0 +1,12 @@
+@model ShapeViewModel<TaxRule>
+
+<a asp-action="Edit"
+   asp-route-id="@Model.Value.ItemId"
+   class="btn btn-primary btn-sm">@T["Edit"]</a>
+
+<a asp-action="Delete"
+   asp-route-id="@Model.Value.ItemId"
+   class="btn btn-danger btn-sm"
+   data-title="@T["Delete"]"
+   data-message="@T["Are you sure you want to delete this tax rule?"]"
+   data-url-af="RemoveUrl UnsafeUrl">@T["Delete"]</a>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRule.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRule.DefaultMeta.SummaryAdmin.cshtml
@@ -1,9 +1,18 @@
 @model ShapeViewModel<TaxRule>
 
-@if (Model.Value.ModifiedUtc.HasValue)
+@{
+    var modifiedAt = Model.Value.ModifiedUtc ?? (Model.Value.CreatedUtc == default ? (DateTime?)null : Model.Value.CreatedUtc);
+}
+
+@if (modifiedAt.HasValue)
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.ModifiedUtc.Value, Format: "g"))">
+    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: modifiedAt.Value, Format: "g"))">
         <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i>
-        @await DisplayAsync(await New.Timespan(Utc: Model.Value.ModifiedUtc.Value))
+        @await DisplayAsync(await New.Timespan(Utc: modifiedAt.Value))
     </span>
+}
+
+@if (!string.IsNullOrEmpty(Model.Value.Author))
+{
+    <user-display-name user-name="@(Model.Value.Author)" display-type="SummaryAdmin" cache-id="user-display-name-author" />
 }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRule.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRule.DefaultMeta.SummaryAdmin.cshtml
@@ -1,0 +1,9 @@
+@model ShapeViewModel<TaxRule>
+
+@if (Model.Value.ModifiedUtc.HasValue)
+{
+    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.ModifiedUtc.Value, Format: "g"))">
+        <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i>
+        @await DisplayAsync(await New.Timespan(Utc: Model.Value.ModifiedUtc.Value))
+    </span>
+}

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRule.Fields.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRule.Fields.SummaryAdmin.cshtml
@@ -1,0 +1,22 @@
+@model ShapeViewModel<TaxRule>
+
+<h5 class="mb-0">
+    @Model.Value.Name
+    @if (!Model.Value.Enabled)
+    {
+        <span class="badge bg-warning text-dark">@T["Disabled"]</span>
+    }
+</h5>
+<small class="text-muted">
+    <span class="badge bg-secondary">@Model.Value.TaxType</span>
+    <span class="ms-1">@T["Method:"] @Model.Value.CalculationMethod</span>
+    @if (Model.Value.Rate.HasValue)
+    {
+        <span class="ms-1">@T["Rate:"] @Model.Value.Rate.Value.ToString("P2")</span>
+    }
+    @if (Model.Value.FixedAmount.HasValue)
+    {
+        <span class="ms-1">@T["Amount:"] @Model.Value.FixedAmount.Value.ToString("N2")</span>
+    }
+    <span class="ms-1">@T["Priority:"] @Model.Value.Priority</span>
+</small>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRuleDeploymentStep.Summary.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRuleDeploymentStep.Summary.cshtml
@@ -1,0 +1,8 @@
+@using CrestApps.OrchardCore.Taxation.Deployments.Steps
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<TaxRuleDeploymentStep>
+
+<h5>@T["Tax Rules"]</h5>
+
+<span class="badge text-bg-success">@T["All tax rules"]</span>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRuleDeploymentStep.Thumbnail.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/Items/TaxRuleDeploymentStep.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+<h4 class="card-title">@T["Tax Rules"]</h4>
+<p>@T["Export all tax rules."]</p>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategories/Create.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategories/Create.cshtml
@@ -1,0 +1,17 @@
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["Create {0}", Model.DisplayName])</h1>
+</zone>
+
+<form method="post" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <div class="ocat-wrapper">
+        <div class="ocat-end-offset">
+            <button class="btn btn-primary" type="submit">@T["Save"]</button>
+            <a class="btn btn-secondary cancel" role="button" asp-action="Index">@T["Cancel"]</a>
+        </div>
+    </div>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategories/Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategories/Edit.cshtml
@@ -1,0 +1,17 @@
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["Edit {0}", Model.DisplayName])</h1>
+</zone>
+
+<form method="post" asp-route-id="@ViewContext.HttpContext.Request.RouteValues["id"]" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <div class="ocat-wrapper">
+        <div class="ocat-end-offset">
+            <button class="btn btn-primary" type="submit">@T["Save"]</button>
+            <a class="btn btn-secondary cancel" role="button" asp-action="Index">@T["Cancel"]</a>
+        </div>
+    </div>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategories/Index.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategories/Index.cshtml
@@ -1,0 +1,46 @@
+@model ListCatalogEntryViewModel<CatalogEntryViewModel<TaxCategory>>
+
+<zone Name="Title"><h1>@RenderTitleSegments(T["Tax Categories"])</h1></zone>
+
+@* The post form provides the antiforgery token used by the delete action. *@
+<form asp-action="Index" method="post" class="no-multisubmit">
+    <input type="submit" name="submit.Filter" id="submitFilter" class="visually-hidden" />
+
+    <div class="card text-bg-theme mb-3 position-sticky action-bar">
+        <div class="card-body">
+            <div class="row gx-1">
+                <div class="col">
+                    <div class="has-search">
+                        <i class="fa-solid fa-search form-control-feedback" aria-hidden="true"></i>
+                        <input id="search-box" asp-for="Options.Search" class="form-control" placeholder="@T["Search"]" type="search" autofocus autocomplete="off" />
+                    </div>
+                </div>
+                <div class="col-auto">
+                    <a class="btn btn-secondary create" role="button" asp-action="Create">@T["Add Tax Category"]</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <ul class="list-group">
+        @if (Model.Models.Count > 0)
+        {
+            foreach (var entry in Model.Models)
+            {
+                <li class="list-group-item item" data-filter-value="@entry.Model.Name?.ToLowerInvariant()">
+                    <div class="flex-grow-1">
+                        @await DisplayAsync(entry.Shape)
+                    </div>
+                </li>
+            }
+        }
+        else
+        {
+            <li class="list-group-item list-group-item-info text-center">
+                @T["<strong>Nothing here!</strong> There are no tax categories at the moment."]
+            </li>
+        }
+    </ul>
+</form>
+
+@await DisplayAsync(Model.Pager)

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategory.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategory.Edit.cshtml
@@ -1,0 +1,1 @@
+@await DisplayAsync(Model.Content)

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategory.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategory.SummaryAdmin.cshtml
@@ -1,0 +1,28 @@
+<div class="row g-0">
+    <div class="col-lg col-12 title d-flex align-items-center">
+        <div class="summary">
+            <div class="d-flex flex-column flex-md-row align-items-md-center">
+                <div class="me-2">
+                    @if (Model.Content != null)
+                    {
+                        @await DisplayAsync(Model.Content)
+                    }
+                </div>
+                @if (Model.Meta != null)
+                {
+                    <div class="metadata me-1">
+                        @await DisplayAsync(Model.Meta)
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-auto col-12 d-flex justify-content-end align-items-center">
+        <div class="actions">
+            @if (Model.Actions != null)
+            {
+                @await DisplayAsync(Model.Actions)
+            }
+        </div>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategoryFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxCategoryFields.Edit.cshtml
@@ -1,0 +1,44 @@
+@model TaxCategoryViewModel
+
+<div class="ocat-wrapper">
+    <label asp-for="Name" class="ocat-label">@T["Name"]</label>
+    <div class="ocat-end">
+        @if (Model.IsNew)
+        {
+            <input asp-for="Name" class="form-control" />
+        }
+        else
+        {
+            <input value="@Model.Name" class="form-control" readonly />
+            <input asp-for="Name" type="hidden" />
+            <span class="hint">@T["The name is fixed after creation."]</span>
+        }
+        <span asp-validation-for="Name" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="Code" class="ocat-label">@T["Code"]</label>
+    <div class="ocat-end">
+        <input asp-for="Code" class="form-control" />
+        <span class="hint">@T["The unique code of the category, for example Electronics or Television."]</span>
+        <span asp-validation-for="Code" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="ParentCode" class="ocat-label">@T["Parent code"]</label>
+    <div class="ocat-end">
+        <input asp-for="ParentCode" class="form-control" />
+        <span class="hint">@T["The code of the parent category, forming a hierarchy. Leave empty for a top-level category."]</span>
+        <span asp-validation-for="ParentCode" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="Description" class="ocat-label">@T["Description"]</label>
+    <div class="ocat-end">
+        <textarea asp-for="Description" class="form-control" rows="3"></textarea>
+        <span asp-validation-for="Description" class="text-danger"></span>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdiction.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdiction.Edit.cshtml
@@ -1,0 +1,1 @@
+@await DisplayAsync(Model.Content)

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdiction.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdiction.SummaryAdmin.cshtml
@@ -1,0 +1,28 @@
+<div class="row g-0">
+    <div class="col-lg col-12 title d-flex align-items-center">
+        <div class="summary">
+            <div class="d-flex flex-column flex-md-row align-items-md-center">
+                <div class="me-2">
+                    @if (Model.Content != null)
+                    {
+                        @await DisplayAsync(Model.Content)
+                    }
+                </div>
+                @if (Model.Meta != null)
+                {
+                    <div class="metadata me-1">
+                        @await DisplayAsync(Model.Meta)
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-auto col-12 d-flex justify-content-end align-items-center">
+        <div class="actions">
+            @if (Model.Actions != null)
+            {
+                @await DisplayAsync(Model.Actions)
+            }
+        </div>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdictionFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdictionFields.Edit.cshtml
@@ -1,0 +1,102 @@
+@model TaxJurisdictionViewModel
+
+<div class="ocat-wrapper">
+    <label asp-for="Name" class="ocat-label">@T["Name"]</label>
+    <div class="ocat-end">
+        @if (Model.IsNew)
+        {
+            <input asp-for="Name" class="form-control" />
+        }
+        else
+        {
+            <input value="@Model.Name" class="form-control" readonly />
+            <input asp-for="Name" type="hidden" />
+            <span class="hint">@T["The name is fixed after creation."]</span>
+        }
+        <span asp-validation-for="Name" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="Code" class="ocat-label">@T["Code"]</label>
+    <div class="ocat-end">
+        <input asp-for="Code" class="form-control" />
+        <span asp-validation-for="Code" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="Level" class="ocat-label">@T["Level"]</label>
+    <div class="ocat-end">
+        <select asp-for="Level" asp-items="Model.Levels" class="form-select"></select>
+        <span asp-validation-for="Level" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="ParentId" class="ocat-label">@T["Parent jurisdiction"]</label>
+    <div class="ocat-end">
+        <select asp-for="ParentId" asp-items="Model.Parents" class="form-select">
+            <option value="">@T["— None —"]</option>
+        </select>
+        <span class="hint">@T["The parent jurisdiction, forming a hierarchy. Leave empty for a top-level jurisdiction."]</span>
+        <span asp-validation-for="ParentId" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="Country" class="ocat-label">@T["Country"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="Country" class="form-control ocat-limited" />
+        <span class="hint">@T["The ISO country code, for example US or CA."]</span>
+        <span asp-validation-for="Country" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="Region" class="ocat-label">@T["Region"]</label>
+    <div class="ocat-end">
+        <input asp-for="Region" class="form-control" />
+        <span asp-validation-for="Region" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="County" class="ocat-label">@T["County"]</label>
+    <div class="ocat-end">
+        <input asp-for="County" class="form-control" />
+        <span asp-validation-for="County" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="City" class="ocat-label">@T["City"]</label>
+    <div class="ocat-end">
+        <input asp-for="City" class="form-control" />
+        <span asp-validation-for="City" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="PostalCode" class="ocat-label">@T["Postal code"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="PostalCode" class="form-control ocat-limited" />
+        <span asp-validation-for="PostalCode" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="EffectiveFromUtc" class="ocat-label">@T["Effective from (UTC)"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="EffectiveFromUtc" type="datetime-local" class="form-control ocat-limited" />
+        <span asp-validation-for="EffectiveFromUtc" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="EffectiveToUtc" class="ocat-label">@T["Effective to (UTC)"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="EffectiveToUtc" type="datetime-local" class="form-control ocat-limited" />
+        <span asp-validation-for="EffectiveToUtc" class="text-danger"></span>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdictions/Create.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdictions/Create.cshtml
@@ -1,0 +1,17 @@
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["Create {0}", Model.DisplayName])</h1>
+</zone>
+
+<form method="post" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <div class="ocat-wrapper">
+        <div class="ocat-end-offset">
+            <button class="btn btn-primary" type="submit">@T["Save"]</button>
+            <a class="btn btn-secondary cancel" role="button" asp-action="Index">@T["Cancel"]</a>
+        </div>
+    </div>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdictions/Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdictions/Edit.cshtml
@@ -1,0 +1,17 @@
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["Edit {0}", Model.DisplayName])</h1>
+</zone>
+
+<form method="post" asp-route-id="@ViewContext.HttpContext.Request.RouteValues["id"]" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <div class="ocat-wrapper">
+        <div class="ocat-end-offset">
+            <button class="btn btn-primary" type="submit">@T["Save"]</button>
+            <a class="btn btn-secondary cancel" role="button" asp-action="Index">@T["Cancel"]</a>
+        </div>
+    </div>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdictions/Index.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxJurisdictions/Index.cshtml
@@ -1,0 +1,46 @@
+@model ListCatalogEntryViewModel<CatalogEntryViewModel<TaxJurisdiction>>
+
+<zone Name="Title"><h1>@RenderTitleSegments(T["Tax Jurisdictions"])</h1></zone>
+
+@* The post form provides the antiforgery token used by the delete action. *@
+<form asp-action="Index" method="post" class="no-multisubmit">
+    <input type="submit" name="submit.Filter" id="submitFilter" class="visually-hidden" />
+
+    <div class="card text-bg-theme mb-3 position-sticky action-bar">
+        <div class="card-body">
+            <div class="row gx-1">
+                <div class="col">
+                    <div class="has-search">
+                        <i class="fa-solid fa-search form-control-feedback" aria-hidden="true"></i>
+                        <input id="search-box" asp-for="Options.Search" class="form-control" placeholder="@T["Search"]" type="search" autofocus autocomplete="off" />
+                    </div>
+                </div>
+                <div class="col-auto">
+                    <a class="btn btn-secondary create" role="button" asp-action="Create">@T["Add Tax Jurisdiction"]</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <ul class="list-group">
+        @if (Model.Models.Count > 0)
+        {
+            foreach (var entry in Model.Models)
+            {
+                <li class="list-group-item item" data-filter-value="@entry.Model.Name?.ToLowerInvariant()">
+                    <div class="flex-grow-1">
+                        @await DisplayAsync(entry.Shape)
+                    </div>
+                </li>
+            }
+        }
+        else
+        {
+            <li class="list-group-item list-group-item-info text-center">
+                @T["<strong>Nothing here!</strong> There are no tax jurisdictions at the moment."]
+            </li>
+        }
+    </ul>
+</form>
+
+@await DisplayAsync(Model.Pager)

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRule.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRule.Edit.cshtml
@@ -1,0 +1,1 @@
+@await DisplayAsync(Model.Content)

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRule.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRule.SummaryAdmin.cshtml
@@ -1,0 +1,28 @@
+<div class="row g-0">
+    <div class="col-lg col-12 title d-flex align-items-center">
+        <div class="summary">
+            <div class="d-flex flex-column flex-md-row align-items-md-center">
+                <div class="me-2">
+                    @if (Model.Content != null)
+                    {
+                        @await DisplayAsync(Model.Content)
+                    }
+                </div>
+                @if (Model.Meta != null)
+                {
+                    <div class="metadata me-1">
+                        @await DisplayAsync(Model.Meta)
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-auto col-12 d-flex justify-content-end align-items-center">
+        <div class="actions">
+            @if (Model.Actions != null)
+            {
+                @await DisplayAsync(Model.Actions)
+            }
+        </div>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRuleFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRuleFields.Edit.cshtml
@@ -1,0 +1,162 @@
+@model TaxRuleViewModel
+
+<div class="ocat-wrapper">
+    <label asp-for="Name" class="ocat-label">@T["Name"]</label>
+    <div class="ocat-end">
+        @if (Model.IsNew)
+        {
+            <input asp-for="Name" class="form-control" />
+        }
+        else
+        {
+            <input value="@Model.Name" class="form-control" readonly />
+            <input asp-for="Name" type="hidden" />
+            <span class="hint">@T["The name is fixed after creation."]</span>
+        }
+        <span asp-validation-for="Name" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <div class="ocat-end-offset">
+        <div class="form-check">
+            <input asp-for="Enabled" class="form-check-input" type="checkbox" />
+            <label asp-for="Enabled" class="form-check-label">@T["Enabled"]</label>
+        </div>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="Priority" class="ocat-label">@T["Priority"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="Priority" type="number" class="form-control ocat-limited" />
+        <span class="hint">@T["Lower values are evaluated first."]</span>
+        <span asp-validation-for="Priority" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="TaxType" class="ocat-label">@T["Tax type"]</label>
+    <div class="ocat-end">
+        <select asp-for="TaxType" asp-items="Model.TaxTypes" class="form-select"></select>
+        <span asp-validation-for="TaxType" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="TaxName" class="ocat-label">@T["Tax name"]</label>
+    <div class="ocat-end">
+        <input asp-for="TaxName" class="form-control" />
+        <span class="hint">@T["The human readable name of the tax the rule produces."]</span>
+        <span asp-validation-for="TaxName" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="TaxCode" class="ocat-label">@T["Tax code"]</label>
+    <div class="ocat-end">
+        <input asp-for="TaxCode" class="form-control" />
+        <span asp-validation-for="TaxCode" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="JurisdictionId" class="ocat-label">@T["Jurisdiction"]</label>
+    <div class="ocat-end">
+        <select asp-for="JurisdictionId" asp-items="Model.Jurisdictions" class="form-select"></select>
+        <span class="hint">@T["The jurisdiction the rule belongs to."]</span>
+        <span asp-validation-for="JurisdictionId" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="CategoryCode" class="ocat-label">@T["Category"]</label>
+    <div class="ocat-end">
+        <select asp-for="CategoryCode" asp-items="Model.Categories" class="form-select"></select>
+        <span class="hint">@T["The tax category the rule applies to. Leave as Any category to match every category."]</span>
+        <span asp-validation-for="CategoryCode" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="CustomerType" class="ocat-label">@T["Customer type"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <select asp-for="CustomerType" asp-items="Model.CustomerTypes" class="form-select ocat-limited"></select>
+        <span asp-validation-for="CustomerType" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="CalculationMethod" class="ocat-label">@T["Calculation method"]</label>
+    <div class="ocat-end">
+        <select asp-for="CalculationMethod" asp-items="Model.CalculationMethods" class="form-select"></select>
+        <span asp-validation-for="CalculationMethod" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="Rate" class="ocat-label">@T["Rate"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="Rate" type="number" step="0.0001" class="form-control ocat-limited" />
+        <span class="hint">@T["Expressed as a fraction, for example 0.2 for 20%."]</span>
+        <span asp-validation-for="Rate" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="FixedAmount" class="ocat-label">@T["Fixed amount"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="FixedAmount" type="number" step="0.01" class="form-control ocat-limited" />
+        <span class="hint">@T["Used when the calculation method is amount based."]</span>
+        <span asp-validation-for="FixedAmount" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="MinimumAmount" class="ocat-label">@T["Minimum amount"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="MinimumAmount" type="number" step="0.01" class="form-control ocat-limited" />
+        <span asp-validation-for="MinimumAmount" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="MaximumAmount" class="ocat-label">@T["Maximum amount"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="MaximumAmount" type="number" step="0.01" class="form-control ocat-limited" />
+        <span asp-validation-for="MaximumAmount" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <div class="ocat-end-offset">
+        <div class="form-check">
+            <input asp-for="IncludedInPrice" class="form-check-input" type="checkbox" />
+            <label asp-for="IncludedInPrice" class="form-check-label">@T["Tax is included in the item price"]</label>
+        </div>
+        <div class="form-check">
+            <input asp-for="IsCompound" class="form-check-input" type="checkbox" />
+            <label asp-for="IsCompound" class="form-check-label">@T["Tax is compound (calculated on top of other taxes)"]</label>
+        </div>
+        <div class="form-check">
+            <input asp-for="AppliesToShipping" class="form-check-input" type="checkbox" />
+            <label asp-for="AppliesToShipping" class="form-check-label">@T["Applies to shipping charges"]</label>
+        </div>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="EffectiveFromUtc" class="ocat-label">@T["Effective from (UTC)"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="EffectiveFromUtc" type="datetime-local" class="form-control ocat-limited" />
+        <span asp-validation-for="EffectiveFromUtc" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="EffectiveToUtc" class="ocat-label">@T["Effective to (UTC)"]</label>
+    <div class="ocat-end ocat-limited-wrapper">
+        <input asp-for="EffectiveToUtc" type="datetime-local" class="form-control ocat-limited" />
+        <span asp-validation-for="EffectiveToUtc" class="text-danger"></span>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRules/Create.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRules/Create.cshtml
@@ -1,0 +1,17 @@
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["Create {0}", Model.DisplayName])</h1>
+</zone>
+
+<form method="post" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <div class="ocat-wrapper">
+        <div class="ocat-end-offset">
+            <button class="btn btn-primary" type="submit">@T["Save"]</button>
+            <a class="btn btn-secondary cancel" role="button" asp-action="Index">@T["Cancel"]</a>
+        </div>
+    </div>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRules/Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRules/Edit.cshtml
@@ -1,0 +1,17 @@
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["Edit {0}", Model.DisplayName])</h1>
+</zone>
+
+<form method="post" asp-route-id="@ViewContext.HttpContext.Request.RouteValues["id"]" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <div class="ocat-wrapper">
+        <div class="ocat-end-offset">
+            <button class="btn btn-primary" type="submit">@T["Save"]</button>
+            <a class="btn btn-secondary cancel" role="button" asp-action="Index">@T["Cancel"]</a>
+        </div>
+    </div>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRules/Index.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxRules/Index.cshtml
@@ -1,0 +1,46 @@
+@model ListCatalogEntryViewModel<CatalogEntryViewModel<TaxRule>>
+
+<zone Name="Title"><h1>@RenderTitleSegments(T["Tax Rules"])</h1></zone>
+
+@* The post form provides the antiforgery token used by the delete action. *@
+<form asp-action="Index" method="post" class="no-multisubmit">
+    <input type="submit" name="submit.Filter" id="submitFilter" class="visually-hidden" />
+
+    <div class="card text-bg-theme mb-3 position-sticky action-bar">
+        <div class="card-body">
+            <div class="row gx-1">
+                <div class="col">
+                    <div class="has-search">
+                        <i class="fa-solid fa-search form-control-feedback" aria-hidden="true"></i>
+                        <input id="search-box" asp-for="Options.Search" class="form-control" placeholder="@T["Search"]" type="search" autofocus autocomplete="off" />
+                    </div>
+                </div>
+                <div class="col-auto">
+                    <a class="btn btn-secondary create" role="button" asp-action="Create">@T["Add Tax Rule"]</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <ul class="list-group">
+        @if (Model.Models.Count > 0)
+        {
+            foreach (var entry in Model.Models)
+            {
+                <li class="list-group-item item" data-filter-value="@entry.Model.Name?.ToLowerInvariant()">
+                    <div class="flex-grow-1">
+                        @await DisplayAsync(entry.Shape)
+                    </div>
+                </li>
+            }
+        }
+        else
+        {
+            <li class="list-group-item list-group-item-info text-center">
+                @T["<strong>Nothing here!</strong> There are no tax rules at the moment."]
+            </li>
+        }
+    </ul>
+</form>
+
+@await DisplayAsync(Model.Pager)

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxationPart.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxationPart.Edit.cshtml
@@ -17,18 +17,18 @@
     <div class="ocat-wrapper" asp-validation-class-for="TaxCategoryCode">
         <label asp-for="TaxCategoryCode" class="ocat-label">@T["Tax category"]</label>
         <div class="ocat-end">
-            <input type="text" asp-for="TaxCategoryCode" class="form-control" />
+            <select asp-for="TaxCategoryCode" asp-items="Model.TaxCategories" class="form-select"></select>
             <span asp-validation-for="TaxCategoryCode"></span>
-            <span class="hint">@T["The tax category code, for example Electronics."]</span>
+            <span class="hint">@T["The tax category this item belongs to, for example Electronics."]</span>
         </div>
     </div>
 
     <div class="ocat-wrapper" asp-validation-class-for="TaxClassificationCode">
         <label asp-for="TaxClassificationCode" class="ocat-label">@T["Tax classification"]</label>
         <div class="ocat-end">
-            <input type="text" asp-for="TaxClassificationCode" class="form-control" />
+            <select asp-for="TaxClassificationCode" asp-items="Model.TaxCategories" class="form-select"></select>
             <span asp-validation-for="TaxClassificationCode"></span>
-            <span class="hint">@T["The tax classification code that refines the category, for example Television."]</span>
+            <span class="hint">@T["An optional, more specific category that refines the tax category, for example Television."]</span>
         </div>
     </div>
 }

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxationPartSettings.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/TaxationPartSettings.Edit.cshtml
@@ -5,18 +5,18 @@
 <div class="ocat-wrapper" asp-validation-class-for="DefaultTaxCategoryCode">
     <label asp-for="DefaultTaxCategoryCode" class="ocat-label">@T["Default tax category"]</label>
     <div class="ocat-end">
-        <input type="text" asp-for="DefaultTaxCategoryCode" class="form-control" />
+        <select asp-for="DefaultTaxCategoryCode" asp-items="Model.TaxCategories" class="form-select"></select>
         <span asp-validation-for="DefaultTaxCategoryCode"></span>
-        <span class="hint">@T["The default tax category code applied to new content items."]</span>
+        <span class="hint">@T["The default tax category applied to new content items. Categories are managed under Commerce → Taxation → Categories."]</span>
     </div>
 </div>
 
 <div class="ocat-wrapper" asp-validation-class-for="DefaultTaxClassificationCode">
     <label asp-for="DefaultTaxClassificationCode" class="ocat-label">@T["Default tax classification"]</label>
     <div class="ocat-end">
-        <input type="text" asp-for="DefaultTaxClassificationCode" class="form-control" />
+        <select asp-for="DefaultTaxClassificationCode" asp-items="Model.TaxCategories" class="form-select"></select>
         <span asp-validation-for="DefaultTaxClassificationCode"></span>
-        <span class="hint">@T["The default tax classification code applied to new content items."]</span>
+        <span class="hint">@T["An optional, more specific category that refines the default tax category for new content items."]</span>
     </div>
 </div>
 

--- a/src/Modules/CrestApps.OrchardCore.Taxation/Views/_ViewImports.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.Taxation/Views/_ViewImports.cshtml
@@ -1,6 +1,10 @@
 @inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>
 
 @using OrchardCore.DisplayManagement.Views
+@using CrestApps.Core.Models
+@using CrestApps.OrchardCore.Core.Models
+@using CrestApps.OrchardCore.Taxation.Models
+@using CrestApps.OrchardCore.Taxation.ViewModels
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, OrchardCore.DisplayManagement

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/TaxClassificationInheritanceTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/TaxClassificationInheritanceTests.cs
@@ -1,0 +1,153 @@
+using System.Text.Json.Nodes;
+using CrestApps.OrchardCore.Taxation.Models;
+using CrestApps.OrchardCore.Taxation.Services;
+using OrchardCore.ContentManagement;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class TaxClassificationInheritanceTests
+{
+    private static ContentItem CreateProduct(TaxationPart part, decimal price = 100m)
+    {
+        var contentItem = new ContentItem
+        {
+            ContentType = "Product",
+            ContentItemId = "product-1",
+        };
+
+        contentItem.Weld(nameof(TaxationPart), part);
+
+        contentItem.Content["ProductPart"] = new JsonObject
+        {
+            ["Price"] = JsonValue.Create(price),
+        };
+
+        return contentItem;
+    }
+
+    [Fact]
+    public async Task Item_WithoutOwnCategory_InheritsClassificationFromProvider()
+    {
+        var provider = new ContentItemTaxableItemProvider(
+        [
+            new FakeClassificationProvider(new TaxClassification
+            {
+                TaxCategoryCode = "Tobacco",
+                TaxClassificationCode = "Cigarettes",
+                ExternalTaxCode = "TX-99",
+            }),
+        ]);
+
+        var product = CreateProduct(new TaxationPart { Taxable = true });
+
+        var item = await provider.CreateAsync(product, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(item);
+        Assert.Equal("Tobacco", item.TaxCategoryCode);
+        Assert.Equal("Cigarettes", item.TaxClassificationCode);
+        Assert.Equal("TX-99", item.ExternalTaxCode);
+    }
+
+    [Fact]
+    public async Task Item_WithOwnCategory_OverridesProvider()
+    {
+        var provider = new ContentItemTaxableItemProvider(
+        [
+            new FakeClassificationProvider(new TaxClassification
+            {
+                TaxCategoryCode = "Tobacco",
+                TaxClassificationCode = "Cigarettes",
+            }),
+        ]);
+
+        var product = CreateProduct(new TaxationPart
+        {
+            Taxable = true,
+            TaxCategoryCode = "Electronics",
+            TaxClassificationCode = "Television",
+        });
+
+        var item = await provider.CreateAsync(product, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(item);
+        Assert.Equal("Electronics", item.TaxCategoryCode);
+        Assert.Equal("Television", item.TaxClassificationCode);
+    }
+
+    [Fact]
+    public async Task Providers_AreConsultedInOrder_FirstWithCategoryWins()
+    {
+        var provider = new ContentItemTaxableItemProvider(
+        [
+            new FakeClassificationProvider(classification: null, order: 5),
+            new FakeClassificationProvider(new TaxClassification { TaxCategoryCode = "Tobacco" }, order: 10),
+            new FakeClassificationProvider(new TaxClassification { TaxCategoryCode = "Alcohol" }, order: 20),
+        ]);
+
+        var product = CreateProduct(new TaxationPart { Taxable = true });
+
+        var item = await provider.CreateAsync(product, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(item);
+        Assert.Equal("Tobacco", item.TaxCategoryCode);
+    }
+
+    [Fact]
+    public async Task Item_KeepsOwnClassificationCode_WhenInheritingOnlyCategory()
+    {
+        var provider = new ContentItemTaxableItemProvider(
+        [
+            new FakeClassificationProvider(new TaxClassification
+            {
+                TaxCategoryCode = "Tobacco",
+                TaxClassificationCode = "Cigarettes",
+            }),
+        ]);
+
+        // The item declares a classification code but no category code; the category is inherited while the
+        // explicit classification code is preserved.
+        var product = CreateProduct(new TaxationPart
+        {
+            Taxable = true,
+            TaxClassificationCode = "Premium",
+        });
+
+        var item = await provider.CreateAsync(product, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(item);
+        Assert.Equal("Tobacco", item.TaxCategoryCode);
+        Assert.Equal("Premium", item.TaxClassificationCode);
+    }
+
+    [Fact]
+    public async Task NonTaxableItem_IsNeverResolved_EvenWithProvider()
+    {
+        var provider = new ContentItemTaxableItemProvider(
+        [
+            new FakeClassificationProvider(new TaxClassification { TaxCategoryCode = "Tobacco" }),
+        ]);
+
+        var product = CreateProduct(new TaxationPart { Taxable = false });
+
+        var item = await provider.CreateAsync(product, TestContext.Current.CancellationToken);
+
+        Assert.Null(item);
+    }
+
+    private sealed class FakeClassificationProvider : ITaxClassificationProvider
+    {
+        private readonly TaxClassification _classification;
+
+        public FakeClassificationProvider(TaxClassification classification, int order = 0)
+        {
+            _classification = classification;
+            Order = order;
+        }
+
+        public int Order { get; }
+
+        public ValueTask<TaxClassification> GetClassificationAsync(ContentItem contentItem, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(_classification);
+    }
+}

--- a/tests/CrestApps.OrchardCore.Tests/Taxation/TaxationDeploymentSerializerTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Taxation/TaxationDeploymentSerializerTests.cs
@@ -1,0 +1,99 @@
+using CrestApps.OrchardCore.Taxation.Deployments;
+using CrestApps.OrchardCore.Taxation.Models;
+using Xunit;
+
+namespace CrestApps.OrchardCore.Tests.Taxation;
+
+public sealed class TaxationDeploymentSerializerTests
+{
+    [Fact]
+    public void Export_OmitsEnvironmentOwnedMembers_ButKeepsIdentityAndConfiguration()
+    {
+        var category = new TaxCategory
+        {
+            ItemId = "cat-1",
+            Name = "Electronics",
+            Code = "ELEC",
+            ParentCode = "GOODS",
+            Description = "Electronic goods",
+            CreatedUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ModifiedUtc = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Author = "admin",
+            OwnerId = "owner-1",
+        };
+
+        var node = TaxationDeploymentSerializer.Export(category);
+
+        Assert.Equal("cat-1", (string)node["ItemId"]);
+        Assert.Equal("Electronics", (string)node["Name"]);
+        Assert.Equal("ELEC", (string)node["Code"]);
+        Assert.Equal("GOODS", (string)node["ParentCode"]);
+
+        Assert.False(node.ContainsKey("CreatedUtc"));
+        Assert.False(node.ContainsKey("ModifiedUtc"));
+        Assert.False(node.ContainsKey("Author"));
+        Assert.False(node.ContainsKey("OwnerId"));
+    }
+
+    [Fact]
+    public void Populate_AppliesConfiguration_ButNeverIdentityOrEnvironmentOwnedMembers()
+    {
+        var source = new TaxCategory
+        {
+            ItemId = "cat-1",
+            Name = "Electronics",
+            Code = "ELEC",
+            CreatedUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ModifiedUtc = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Author = "admin",
+            OwnerId = "owner-1",
+        };
+
+        var data = TaxationDeploymentSerializer.Export(source);
+
+        // Simulate an existing target entry that keeps its own identity and audit stamps.
+        var target = new TaxCategory
+        {
+            ItemId = "existing-id",
+            Author = "existing-author",
+            OwnerId = "existing-owner",
+            CreatedUtc = new DateTime(2019, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        TaxationDeploymentSerializer.Populate(target, data);
+
+        Assert.Equal("Electronics", target.Name);
+        Assert.Equal("ELEC", target.Code);
+
+        // Identity and environment-owned members are preserved on the target.
+        Assert.Equal("existing-id", target.ItemId);
+        Assert.Equal("existing-author", target.Author);
+        Assert.Equal("existing-owner", target.OwnerId);
+        Assert.Equal(new DateTime(2019, 1, 1, 0, 0, 0, DateTimeKind.Utc), target.CreatedUtc);
+    }
+
+    [Fact]
+    public void Populate_ClearsValuesThatWereClearedInTheSource()
+    {
+        var source = new TaxCategory
+        {
+            Name = "Electronics",
+            Code = "ELEC",
+            ParentCode = null,
+        };
+
+        var data = TaxationDeploymentSerializer.Export(source);
+
+        var target = new TaxCategory
+        {
+            Name = "Old",
+            Code = "OLD",
+            ParentCode = "STALE",
+        };
+
+        TaxationDeploymentSerializer.Populate(target, data);
+
+        Assert.Equal("Electronics", target.Name);
+        Assert.Null(target.ParentCode);
+    }
+}


### PR DESCRIPTION
…ules

Implements extensible CRUD admin management for tax categories, jurisdictions, and rules using OrchardCore display management (drivers, shapes, and display manager) rather than static HTML tables, mirroring the catalog-CRUD pattern.

- Adds display drivers, catalog entry handlers, and admin controllers for each tax entity, guarded by a new ManageTaxation permission.
- Adds a Commerce > Taxation admin menu with Categories, Jurisdictions, and Rules nodes.
- Renders list, create, and edit views through the display system with ocat-* admin styling.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
