### PR TITLE
Add import/export for AI tool instances and fix sitemap editor buttons

### DIFF
--- a/src/Core/CrestApps.OrchardCore.Recipes.Core/Schemas/Steps/AIToolInstanceRecipeStep.cs
+++ b/src/Core/CrestApps.OrchardCore.Recipes.Core/Schemas/Steps/AIToolInstanceRecipeStep.cs
@@ -1,0 +1,137 @@
+using CrestApps.Core.AI;
+using Json.Schema;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.OrchardCore.Recipes.Core.Schemas.Steps;
+
+/// <summary>
+/// Schema for the "AIToolInstances" recipe step — creates or updates AI tool instances.
+/// </summary>
+public sealed class AIToolInstanceRecipeStep : IRecipeStep
+{
+    private readonly AIOptions _aiOptions;
+    private JsonSchema _cached;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIToolInstanceRecipeStep"/> class.
+    /// </summary>
+    /// <param name="aiOptions">The AI options.</param>
+    public AIToolInstanceRecipeStep(IOptions<AIOptions> aiOptions)
+    {
+        _aiOptions = aiOptions.Value;
+    }
+
+    public string Name => "AIToolInstances";
+
+    /// <summary>
+    /// Retrieves the schema async.
+    /// </summary>
+    public ValueTask<JsonSchema> GetSchemaAsync(CancellationToken cancellationToken = default)
+    {
+        _cached ??= CreateSchema();
+
+        return ValueTask.FromResult(_cached);
+    }
+
+    private JsonSchema CreateSchema()
+    {
+        var sources = _aiOptions.ToolInstanceSources.Keys
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var sourceSchema = new JsonSchemaBuilder()
+            .Type(SchemaValueType.String)
+            .Description("Tool instance source identifier that defines the shape of the instance. Required when creating a new instance.");
+
+        if (sources.Length > 0)
+        {
+            sourceSchema = sourceSchema.WithSuggestions(sources);
+        }
+
+        var propertiesSchema = new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("HttpApiRequestToolSettings", BuildHttpApiRequestSettingsSchema().Description("Settings for the built-in 'http-api-request' source.")),
+                ("SitemapDocumentationToolSettings", BuildSitemapSettingsSchema().Description("Settings for the built-in sitemap documentation search source.")),
+                ("SearchIndexDocumentationToolSettings", BuildSearchIndexSettingsSchema().Description("Settings for the built-in prebuilt search index documentation source.")),
+                ("AlgoliaDocumentationToolSettings", BuildAlgoliaSettingsSchema().Description("Settings for the built-in Algolia DocSearch documentation source.")))
+            .AdditionalProperties(true)
+            .Description("Source-specific tool instance settings, grouped by settings object name. Secrets are stored encrypted at rest.");
+
+        var instanceSchema = new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("ItemId", RecipeStepSchemaBuilders.String().Description("Optional unique identifier. When supplied and found, the existing instance is updated.")),
+                ("Source", sourceSchema),
+                ("Name", RecipeStepSchemaBuilders.String().Description("Unique tool instance name. Used to derive the function name exposed to the AI model and cannot change once created.")),
+                ("Description", RecipeStepSchemaBuilders.String().Description("Description the AI model uses to decide when to call the instance.")),
+                ("CreatedUtc", RecipeStepSchemaBuilders.String().Description("Optional creation timestamp to preserve during import.")),
+                ("OwnerId", RecipeStepSchemaBuilders.String().Description("Optional owner user identifier.")),
+                ("Author", RecipeStepSchemaBuilders.String().Description("Optional author name recorded with the instance.")),
+                ("Properties", propertiesSchema))
+            .Required("Name")
+            .AdditionalProperties(true);
+
+        return RecipeStepSchemaBuilders.BuildNamedStep(
+            "AIToolInstances",
+            [("instances", RecipeStepSchemaBuilders.Array(instanceSchema, 1).Description("The AI tool instances to create or update."))],
+            ["instances"]);
+    }
+
+    private static JsonSchemaBuilder BuildHttpApiRequestSettingsSchema()
+        => new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("BaseUrl", RecipeStepSchemaBuilders.String().Description("Absolute HTTP or HTTPS URL the request targets.")),
+                ("HttpMethod", RecipeStepSchemaBuilders.String().Description("HTTP method: GET, POST, PUT, PATCH, or DELETE.")),
+                ("AuthenticationType", RecipeStepSchemaBuilders.String().Description("Authentication type: None, ApiKey, Basic, or OAuth2.")),
+                ("ApiKeyHeaderName", RecipeStepSchemaBuilders.String().Description("Header name used to send the API key when AuthenticationType is ApiKey.")),
+                ("ApiKey", RecipeStepSchemaBuilders.String().Description("API key credential. Stored encrypted at rest.")),
+                ("BearerToken", RecipeStepSchemaBuilders.String().Description("Bearer token credential. Stored encrypted at rest.")),
+                ("Username", RecipeStepSchemaBuilders.String().Description("Basic authentication user name.")),
+                ("Password", RecipeStepSchemaBuilders.String().Description("Basic authentication password. Stored encrypted at rest.")),
+                ("TokenEndpoint", RecipeStepSchemaBuilders.String().Description("OAuth 2.0 token endpoint.")),
+                ("ClientId", RecipeStepSchemaBuilders.String().Description("OAuth 2.0 client identifier.")),
+                ("ClientSecret", RecipeStepSchemaBuilders.String().Description("OAuth 2.0 client secret. Stored encrypted at rest.")),
+                ("Scope", RecipeStepSchemaBuilders.String().Description("OAuth 2.0 scope.")),
+                ("DefaultHeaders", new JsonSchemaBuilder()
+                    .Type(SchemaValueType.Object)
+                    .AdditionalProperties(RecipeStepSchemaBuilders.String())
+                    .Description("Static headers always added to the request.")),
+                ("AllowModelProvidedPath", RecipeStepSchemaBuilders.Boolean().Description("Whether the AI model may supply a relative path.")),
+                ("AllowModelProvidedQuery", RecipeStepSchemaBuilders.Boolean().Description("Whether the AI model may supply query string parameters.")),
+                ("AllowModelProvidedBody", RecipeStepSchemaBuilders.Boolean().Description("Whether the AI model may supply a request body.")),
+                ("TimeoutSeconds", RecipeStepSchemaBuilders.Integer().Description("Per-request timeout in seconds. Leave empty to use the default.")))
+            .AdditionalProperties(true);
+
+    private static JsonSchemaBuilder BuildSitemapSettingsSchema()
+        => new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("BaseUrl", RecipeStepSchemaBuilders.String().Description("Root URL of the documentation site.")),
+                ("SitemapUrl", RecipeStepSchemaBuilders.String().Description("Explicit sitemap URL. Leave empty to derive it from the base URL.")),
+                ("MaxResults", RecipeStepSchemaBuilders.Integer().Description("Maximum passages returned for a single search.")),
+                ("MaxPages", RecipeStepSchemaBuilders.Integer().Description("Maximum pages the crawler indexes for this site.")))
+            .AdditionalProperties(true);
+
+    private static JsonSchemaBuilder BuildSearchIndexSettingsSchema()
+        => new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("BaseUrl", RecipeStepSchemaBuilders.String().Description("Root URL of the documentation site.")),
+                ("IndexUrl", RecipeStepSchemaBuilders.String().Description("Explicit prebuilt search index URL. Leave empty to derive it from the base URL.")),
+                ("MaxResults", RecipeStepSchemaBuilders.Integer().Description("Maximum passages returned for a single search.")))
+            .AdditionalProperties(true);
+
+    private static JsonSchemaBuilder BuildAlgoliaSettingsSchema()
+        => new JsonSchemaBuilder()
+            .Type(SchemaValueType.Object)
+            .Properties(
+                ("ApplicationId", RecipeStepSchemaBuilders.String().Description("Algolia application identifier.")),
+                ("ApiKey", RecipeStepSchemaBuilders.String().Description("Algolia search-only API key. Stored encrypted at rest.")),
+                ("IndexName", RecipeStepSchemaBuilders.String().Description("Algolia index name.")),
+                ("MaxResults", RecipeStepSchemaBuilders.Integer().Description("Maximum passages returned for a single search.")))
+            .AdditionalProperties(true);
+}

--- a/src/CrestApps.Docs/docs/ai/tool-instances.md
+++ b/src/CrestApps.Docs/docs/ai/tool-instances.md
@@ -102,6 +102,40 @@ Only `ManageAIToolInstances` is ever checked to decide whether the user may reac
 
 In addition, every configured instance produces a dynamic `AccessAITool_{functionName}` permission, exactly like a regular AI tool. The feature replaces the default tool instance registry with a permission-aware one, so an instance is only surfaced to the AI model when the current user is authorized for that instance.
 
+## Importing and exporting
+
+Tool instances can be moved between tenants with the standard Orchard Core deployment and recipe pipeline.
+
+### Deployment plan
+
+Enable **OrchardCore.Deployment** together with **AI Tool Instances**. The **AI Tool Instances** deployment step then becomes available when you build a deployment plan under **Configuration → Deployment Plans**. The step exports either every tool instance or only the instances you select. Each exported instance keeps its source, name, description, owner, and all source-specific settings (including secrets that were stored encrypted).
+
+### Recipe step
+
+The deployment step emits an `AIToolInstances` recipe step, which is also the step you author by hand in a recipe. On import, each entry is matched by `ItemId` first and then by `Name`; a matching instance is updated in place, otherwise a new instance is created from its `Source`. The source must be registered on the target tenant, so enable the feature that provides it before running the recipe.
+
+```json
+{
+  "steps": [
+    {
+      "name": "AIToolInstances",
+      "instances": [
+        {
+          "Source": "http-api-request",
+          "Name": "Order Lookup API",
+          "Description": "Looks up a customer's order status by order identifier.",
+          "Properties": {
+            "HttpApiRequestToolSettings": {
+              "BaseUrl": "https://api.example.com/orders"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## Registering a custom source
 
 A tool instance source is an `IAIToolInstanceSource` that turns an `AIToolInstance` into an `AITool`. Register it with `AddAIToolInstanceSource<TSource>` from your own feature's startup:

--- a/src/CrestApps.Docs/docs/ai/tool-instances.md
+++ b/src/CrestApps.Docs/docs/ai/tool-instances.md
@@ -65,7 +65,7 @@ Pick the source that matches how the site publishes its content:
 
 All three sources carry the **Knowledgebase** category. Each source captures its own fields:
 
-- **Sitemap** — a **Base URL** (the site root, for example `https://core.crestapps.com`), an optional **Sitemap URL** (defaults to `{BaseUrl}/sitemap.xml`), an optional **Maximum results**, and an optional **Maximum pages**.
+- **Sitemap** — a **Base URL** (the site root, for example `https://example.com`), an optional **Sitemap URL** (defaults to `{BaseUrl}/sitemap.xml`), an optional **Maximum results**, and an optional **Maximum pages**.
 - **Search index** — a **Base URL** (used to resolve relative links and the default index URL), an optional **Index URL** (defaults to `{BaseUrl}/search/search_index.json`), and an optional **Maximum results**.
 - **Algolia** — an **Application id**, a **search-only API key** (never a write key), an **Index name**, and an optional **Maximum results**. The API key is encrypted with ASP.NET Core data protection before it is stored; when you edit an existing instance, leaving the API key field empty keeps the previously stored key.
 

--- a/src/CrestApps.Docs/docs/ai/tool-instances.md
+++ b/src/CrestApps.Docs/docs/ai/tool-instances.md
@@ -108,7 +108,9 @@ Tool instances can be moved between tenants with the standard Orchard Core deplo
 
 ### Deployment plan
 
-Enable **OrchardCore.Deployment** together with **AI Tool Instances**. The **AI Tool Instances** deployment step then becomes available when you build a deployment plan under **Configuration → Deployment Plans**. The step exports either every tool instance or only the instances you select. Each exported instance keeps its source, name, description, owner, and all source-specific settings (including secrets that were stored encrypted).
+Enable **OrchardCore.Deployment** together with **AI Tool Instances**. The **AI Tool Instances** deployment step then becomes available when you build a deployment plan under **Configuration → Deployment Plans**. The step exports either every tool instance or only the instances you select. Each exported instance keeps its source, name, description, owner, and source-specific settings.
+
+Secrets are never written to the export. During export, each source can remove its own sensitive data through an `IAIToolInstanceHandler`. The built-in sources use this to strip their credentials: the **HTTP API request** source clears the API key, bearer token, password, client secret, and any cached OAuth tokens, and the **Algolia** source clears the search-only API key. After importing on the target tenant, edit the instance and re-enter the required credentials.
 
 ### Recipe step
 
@@ -201,6 +203,36 @@ internal sealed class WeatherToolInstanceDisplayDriver : DisplayDriver<AIToolIns
 ```
 
 Register the driver with `services.AddDisplayDriver<AIToolInstance, WeatherToolInstanceDisplayDriver>();`. Use `Content:1` for the shared name and description fields, and anything after it for source-specific fields, so the shared fields always render first.
+
+### Removing secrets from exports
+
+If your source stores credentials, add an `IAIToolInstanceHandler` so those secrets are removed from the deployment and recipe export. Gate the handler on your source name and clear the sensitive properties from `ExportData`:
+
+```csharp
+using CrestApps.OrchardCore.AI.Tools.Handlers;
+
+internal sealed class WeatherToolInstanceExportHandler : IAIToolInstanceHandler
+{
+    public void Exporting(ExportingAIToolInstanceContext context)
+    {
+        if (!string.Equals(context.Instance.Source, "weather", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var settingsNode = context.ExportData["Properties"]?[nameof(WeatherToolSettings)]?.AsObject();
+
+        if (settingsNode is null)
+        {
+            return;
+        }
+
+        settingsNode[nameof(WeatherToolSettings.ApiKey)] = string.Empty;
+    }
+}
+```
+
+Register it with `services.TryAddEnumerable(ServiceDescriptor.Transient<IAIToolInstanceHandler, WeatherToolInstanceExportHandler>());`. The built-in HTTP API request and Algolia sources ship with their own handlers, so their credentials are stripped automatically.
 
 ## Exposing the selector on your own model
 

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -152,6 +152,25 @@ See [MCP Server](../ai/mcp/server#tool-exposure) and [AI Tool Instances](../ai/t
 
 -----
 
+#### Import and export AI tool instances
+
+The **AI Tool Instances** feature now participates in the Orchard Core deployment and recipe pipeline, so tool instances can be moved between tenants like other AI configuration.
+
+Highlights:
+
+- A new **AI Tool Instances** deployment step (available when **OrchardCore.Deployment** is enabled) exports all or selected tool instances, including their source, name, description, owner, and encrypted source-specific settings.
+- A matching `AIToolInstances` recipe step imports the instances, matching each entry by `ItemId` and then by `Name`. Existing instances are updated in place, and new ones are created from their registered `Source`.
+
+See [AI Tool Instances](../ai/tool-instances#importing-and-exporting) for details.
+
+-----
+
+#### Documentation search (sitemap) tool instance editor no longer hides the save buttons
+
+The editor for the **Documentation search (sitemap)** tool instance source rendered a hint that contained an unescaped `{BaseUrl}` token inside a localized string. Orchard Core treats `{...}` as a composite format placeholder, so rendering the hint threw a `FormatException` that aborted the rest of the form — including the **Save** and **Cancel** buttons — making it impossible to create or edit an instance from that source. The token is now escaped, so the full editor renders correctly.
+
+-----
+
 ### SignalR
 
 #### Orchard Core SignalR migration

--- a/src/CrestApps.Docs/docs/changelog/3.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/3.0.0.md
@@ -152,25 +152,6 @@ See [MCP Server](../ai/mcp/server#tool-exposure) and [AI Tool Instances](../ai/t
 
 -----
 
-#### Import and export AI tool instances
-
-The **AI Tool Instances** feature now participates in the Orchard Core deployment and recipe pipeline, so tool instances can be moved between tenants like other AI configuration.
-
-Highlights:
-
-- A new **AI Tool Instances** deployment step (available when **OrchardCore.Deployment** is enabled) exports all or selected tool instances, including their source, name, description, owner, and encrypted source-specific settings.
-- A matching `AIToolInstances` recipe step imports the instances, matching each entry by `ItemId` and then by `Name`. Existing instances are updated in place, and new ones are created from their registered `Source`.
-
-See [AI Tool Instances](../ai/tool-instances#importing-and-exporting) for details.
-
------
-
-#### Documentation search (sitemap) tool instance editor no longer hides the save buttons
-
-The editor for the **Documentation search (sitemap)** tool instance source rendered a hint that contained an unescaped `{BaseUrl}` token inside a localized string. Orchard Core treats `{...}` as a composite format placeholder, so rendering the hint threw a `FormatException` that aborted the rest of the form — including the **Save** and **Cancel** buttons — making it impossible to create or edit an instance from that source. The token is now escaped, so the full editor renders correctly.
-
------
-
 ### SignalR
 
 #### Orchard Core SignalR migration

--- a/src/Modules/CrestApps.OrchardCore.AI/Deployments/Drivers/AIToolInstanceDeploymentStepDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Deployments/Drivers/AIToolInstanceDeploymentStepDisplayDriver.cs
@@ -1,0 +1,82 @@
+using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.AI.Deployments.Steps;
+using CrestApps.OrchardCore.AI.Deployments.ViewModels;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Deployment;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Mvc.ModelBinding;
+
+namespace CrestApps.OrchardCore.AI.Deployments.Drivers;
+
+internal sealed class AIToolInstanceDeploymentStepDisplayDriver : DisplayDriver<DeploymentStep, AIToolInstanceDeploymentStep>
+{
+    private readonly INamedCatalog<AIToolInstance> _instancesCatalog;
+
+    internal readonly IStringLocalizer S;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIToolInstanceDeploymentStepDisplayDriver"/> class.
+    /// </summary>
+    /// <param name="instancesCatalog">The tool instances catalog.</param>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public AIToolInstanceDeploymentStepDisplayDriver(
+        INamedCatalog<AIToolInstance> instancesCatalog,
+        IStringLocalizer<AIToolInstanceDeploymentStepDisplayDriver> stringLocalizer)
+    {
+        _instancesCatalog = instancesCatalog;
+        S = stringLocalizer;
+    }
+
+    public override Task<IDisplayResult> DisplayAsync(AIToolInstanceDeploymentStep step, BuildDisplayContext context)
+    {
+        return
+        CombineAsync(
+            View("AIToolInstanceDeploymentStep_Summary", step).Location("Summary", "Content"),
+            View("AIToolInstanceDeploymentStep_Thumbnail", step).Location("Thumbnail", "Content")
+        );
+    }
+
+    public override IDisplayResult Edit(AIToolInstanceDeploymentStep step, BuildEditorContext context)
+    {
+        return Initialize<AIToolInstanceDeploymentStepViewModel>("AIToolInstanceDeploymentStep_Fields_Edit", async model =>
+        {
+            model.IncludeAll = step.IncludeAll;
+            model.Instances = (await _instancesCatalog.GetAllAsync()).Select(x => new AIToolInstanceEntryViewModel
+            {
+                ItemId = x.ItemId,
+                DisplayText = x.Name,
+                IsSelected = step.InstanceIds?.Contains(x.ItemId) ?? false,
+            }).OrderBy(x => x.DisplayText)
+            .ToArray();
+        }).Location("Content");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(AIToolInstanceDeploymentStep step, UpdateEditorContext context)
+    {
+        var model = new AIToolInstanceDeploymentStepViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix,
+        p => p.IncludeAll,
+        p => p.Instances);
+
+        if (model.IncludeAll)
+        {
+            step.IncludeAll = true;
+            step.InstanceIds = [];
+        }
+        else
+        {
+            if (model.Instances == null || model.Instances.Length == 0)
+            {
+                context.Updater.ModelState.AddModelError(Prefix, nameof(model.Instances), S["At least one tool instance is required."]);
+            }
+
+            step.IncludeAll = false;
+            step.InstanceIds = model.Instances.Where(x => x.IsSelected).Select(x => x.ItemId).ToArray();
+        }
+
+        return Edit(step, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIToolInstanceDeploymentSource.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIToolInstanceDeploymentSource.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.AI.Deployments.Steps;
+using OrchardCore.Deployment;
+
+namespace CrestApps.OrchardCore.AI.Deployments.Sources;
+
+internal sealed class AIToolInstanceDeploymentSource : DeploymentSourceBase<AIToolInstanceDeploymentStep>
+{
+    private readonly INamedCatalog<AIToolInstance> _instancesCatalog;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIToolInstanceDeploymentSource"/> class.
+    /// </summary>
+    /// <param name="instancesCatalog">The catalog used to retrieve the AI tool instances to export.</param>
+    public AIToolInstanceDeploymentSource(INamedCatalog<AIToolInstance> instancesCatalog)
+    {
+        _instancesCatalog = instancesCatalog;
+    }
+
+    protected override async Task ProcessAsync(AIToolInstanceDeploymentStep step, DeploymentPlanResult result)
+    {
+        var instances = await _instancesCatalog.GetAllAsync();
+
+        var instanceObjects = new JsonArray();
+
+        var instanceIds = step.IncludeAll
+        ? []
+        : step.InstanceIds ?? [];
+
+        foreach (var instance in instances)
+        {
+            if (instanceIds.Length > 0 && !instanceIds.Contains(instance.ItemId))
+            {
+                continue;
+            }
+
+            instanceObjects.Add(new JsonObject()
+            {
+                { "ItemId", instance.ItemId },
+                { "Source", instance.Source },
+                { "Name", instance.Name },
+                { "Description", instance.Description },
+                { "CreatedUtc", instance.CreatedUtc },
+                { "OwnerId", instance.OwnerId },
+                { "Author", instance.Author },
+                { "Properties", JsonSerializer.SerializeToNode(instance.Properties) },
+            });
+        }
+
+        result.Steps.Add(new JsonObject
+        {
+            ["name"] = step.Name,
+            ["instances"] = instanceObjects,
+        });
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIToolInstanceDeploymentSource.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Deployments/Sources/AIToolInstanceDeploymentSource.cs
@@ -3,21 +3,33 @@ using System.Text.Json.Nodes;
 using CrestApps.Core.AI.Tooling;
 using CrestApps.Core.Services;
 using CrestApps.OrchardCore.AI.Deployments.Steps;
+using CrestApps.OrchardCore.AI.Tools.Handlers;
+using Microsoft.Extensions.Logging;
 using OrchardCore.Deployment;
+using OrchardCore.Modules;
 
 namespace CrestApps.OrchardCore.AI.Deployments.Sources;
 
 internal sealed class AIToolInstanceDeploymentSource : DeploymentSourceBase<AIToolInstanceDeploymentStep>
 {
     private readonly INamedCatalog<AIToolInstance> _instancesCatalog;
+    private readonly IEnumerable<IAIToolInstanceHandler> _handlers;
+    private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AIToolInstanceDeploymentSource"/> class.
     /// </summary>
     /// <param name="instancesCatalog">The catalog used to retrieve the AI tool instances to export.</param>
-    public AIToolInstanceDeploymentSource(INamedCatalog<AIToolInstance> instancesCatalog)
+    /// <param name="handlers">The collection of handlers invoked while each tool instance is exported.</param>
+    /// <param name="logger">The logger instance for this source.</param>
+    public AIToolInstanceDeploymentSource(
+        INamedCatalog<AIToolInstance> instancesCatalog,
+        IEnumerable<IAIToolInstanceHandler> handlers,
+        ILogger<AIToolInstanceDeploymentSource> logger)
     {
         _instancesCatalog = instancesCatalog;
+        _handlers = handlers;
+        _logger = logger;
     }
 
     protected override async Task ProcessAsync(AIToolInstanceDeploymentStep step, DeploymentPlanResult result)
@@ -37,7 +49,7 @@ internal sealed class AIToolInstanceDeploymentSource : DeploymentSourceBase<AITo
                 continue;
             }
 
-            instanceObjects.Add(new JsonObject()
+            var instanceObject = new JsonObject()
             {
                 { "ItemId", instance.ItemId },
                 { "Source", instance.Source },
@@ -47,7 +59,13 @@ internal sealed class AIToolInstanceDeploymentSource : DeploymentSourceBase<AITo
                 { "OwnerId", instance.OwnerId },
                 { "Author", instance.Author },
                 { "Properties", JsonSerializer.SerializeToNode(instance.Properties) },
-            });
+            };
+
+            var exportingContext = new ExportingAIToolInstanceContext(instance, instanceObject);
+
+            _handlers.Invoke((handler, context) => handler.Exporting(context), exportingContext, _logger);
+
+            instanceObjects.Add(instanceObject);
         }
 
         result.Steps.Add(new JsonObject

--- a/src/Modules/CrestApps.OrchardCore.AI/Deployments/Steps/AIToolInstanceDeploymentStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Deployments/Steps/AIToolInstanceDeploymentStep.cs
@@ -1,0 +1,39 @@
+using CrestApps.OrchardCore.AI.Recipes;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Deployment;
+
+namespace CrestApps.OrchardCore.AI.Deployments.Steps;
+
+/// <summary>
+/// Represents a deployment step that exports AI tool instances.
+/// </summary>
+public sealed class AIToolInstanceDeploymentStep : DeploymentStep
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIToolInstanceDeploymentStep"/> class.
+    /// </summary>
+    public AIToolInstanceDeploymentStep()
+    {
+        Name = AIToolInstanceStep.StepKey;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIToolInstanceDeploymentStep"/> class.
+    /// </summary>
+    /// <param name="S">The string localizer.</param>
+    public AIToolInstanceDeploymentStep(IStringLocalizer<AIToolInstanceDeploymentStep> S)
+        : this()
+    {
+        Category = S["Artificial Intelligence"];
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether all tool instances are exported.
+    /// </summary>
+    public bool IncludeAll { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifiers of the tool instances to export.
+    /// </summary>
+    public string[] InstanceIds { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Deployments/ViewModels/AIToolInstanceDeploymentStepViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Deployments/ViewModels/AIToolInstanceDeploymentStepViewModel.cs
@@ -1,0 +1,17 @@
+namespace CrestApps.OrchardCore.AI.Deployments.ViewModels;
+
+/// <summary>
+/// Represents the view model for the AI tool instance deployment step.
+/// </summary>
+public class AIToolInstanceDeploymentStepViewModel
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether all tool instances are exported.
+    /// </summary>
+    public bool IncludeAll { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tool instances.
+    /// </summary>
+    public AIToolInstanceEntryViewModel[] Instances { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Deployments/ViewModels/AIToolInstanceEntryViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Deployments/ViewModels/AIToolInstanceEntryViewModel.cs
@@ -1,0 +1,22 @@
+namespace CrestApps.OrchardCore.AI.Deployments.ViewModels;
+
+/// <summary>
+/// Represents the view model for an AI tool instance entry.
+/// </summary>
+public class AIToolInstanceEntryViewModel
+{
+    /// <summary>
+    /// Gets or sets the item id.
+    /// </summary>
+    public string ItemId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display name.
+    /// </summary>
+    public string DisplayText { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the entry is selected.
+    /// </summary>
+    public bool IsSelected { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Recipes/AIToolInstanceStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Recipes/AIToolInstanceStep.cs
@@ -1,0 +1,134 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core;
+using CrestApps.Core.AI;
+using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.Services;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.Recipes.Models;
+using OrchardCore.Recipes.Services;
+
+namespace CrestApps.OrchardCore.AI.Recipes;
+
+internal sealed class AIToolInstanceStep : NamedRecipeStepHandler
+{
+    /// <summary>
+    /// The recipe step key used to identify this handler.
+    /// </summary>
+    public const string StepKey = "AIToolInstances";
+
+    private readonly ISourceCatalogManager<AIToolInstance> _manager;
+    private readonly INamedCatalog<AIToolInstance> _instancesCatalog;
+    private readonly AIOptions _aiOptions;
+
+    internal readonly IStringLocalizer S;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIToolInstanceStep"/> class.
+    /// </summary>
+    /// <param name="manager">The AI tool instance catalog manager.</param>
+    /// <param name="instancesCatalog">The named catalog used to resolve instances by name.</param>
+    /// <param name="aiOptions">The AI configuration options.</param>
+    /// <param name="stringLocalizer">The string localizer for error messages.</param>
+    public AIToolInstanceStep(
+        ISourceCatalogManager<AIToolInstance> manager,
+        INamedCatalog<AIToolInstance> instancesCatalog,
+        IOptions<AIOptions> aiOptions,
+        IStringLocalizer<AIToolInstanceStep> stringLocalizer)
+    : base(StepKey)
+    {
+        _manager = manager;
+        _instancesCatalog = instancesCatalog;
+        _aiOptions = aiOptions.Value;
+        S = stringLocalizer;
+    }
+
+    protected override async Task HandleAsync(RecipeExecutionContext context)
+    {
+        var model = context.Step.ToObject<AIToolInstanceStepModel>();
+        var tokens = model.Instances.Cast<JsonObject>() ?? [];
+
+        foreach (var token in tokens)
+        {
+            AIToolInstance instance = null;
+            var isNew = false;
+
+            var id = token[nameof(AIToolInstance.ItemId)]?.GetValue<string>();
+
+            var hasId = !string.IsNullOrEmpty(id);
+
+            if (hasId)
+            {
+                instance = await _manager.FindByIdAsync(id);
+            }
+
+            var sourceName = token[nameof(AIToolInstance.Source)]?.GetValue<string>();
+            var hasSource = !string.IsNullOrEmpty(sourceName);
+
+            if (instance is null)
+            {
+                var name = token[nameof(AIToolInstance.Name)]?.GetValue<string>()?.Trim();
+
+                if (!string.IsNullOrEmpty(name))
+                {
+                    instance = await _instancesCatalog.FindByNameAsync(name);
+                }
+            }
+
+            if (instance is not null)
+            {
+                await _manager.UpdateAsync(instance, token);
+            }
+            else
+            {
+                isNew = true;
+
+                if (!hasSource)
+                {
+                    context.Errors.Add(S["Could not find tool instance source value. The tool instance will not be imported."]);
+
+                    continue;
+                }
+
+                if (!_aiOptions.ToolInstanceSources.TryGetValue(sourceName, out _))
+                {
+                    context.Errors.Add(S["Unable to find a tool instance source that can handle the source '{0}'.", sourceName]);
+
+                    return;
+                }
+
+                instance = await _manager.NewAsync(sourceName, token);
+
+                if (hasId && UniqueId.IsValid(id))
+                {
+                    instance.ItemId = id;
+                }
+            }
+
+            var validationResult = await _manager.ValidateAsync(instance);
+
+            if (!validationResult.Succeeded)
+            {
+                foreach (var error in validationResult.Errors)
+                {
+                    context.Errors.Add(error.ErrorMessage);
+                }
+
+                continue;
+            }
+
+            if (isNew)
+            {
+                await _manager.CreateAsync(instance);
+            }
+        }
+    }
+
+    private sealed class AIToolInstanceStepModel
+    {
+        /// <summary>
+        /// Gets or sets the collection of AI tool instance definitions to import.
+        /// </summary>
+        public JsonArray Instances { get; set; }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
@@ -29,6 +29,7 @@ using CrestApps.OrchardCore.AI.Providers;
 using CrestApps.OrchardCore.AI.Recipes;
 using CrestApps.OrchardCore.AI.Services;
 using CrestApps.OrchardCore.AI.Tools.Drivers;
+using CrestApps.OrchardCore.AI.Tools.Handlers;
 using CrestApps.OrchardCore.AI.Tools.Services;
 using CrestApps.OrchardCore.AI.Workflows.Drivers;
 using CrestApps.OrchardCore.AI.Workflows.Models;
@@ -397,6 +398,12 @@ public sealed class ToolInstancesStartup : StartupBase
         );
 
         services.TryAddEnumerable(ServiceDescriptor.Scoped<IToolRegistryProvider, OrchardCoreToolInstanceRegistryProvider>());
+
+        services.TryAddEnumerable(
+        [
+            ServiceDescriptor.Transient<IAIToolInstanceHandler, AlgoliaDocumentationToolInstanceExportHandler>(),
+            ServiceDescriptor.Transient<IAIToolInstanceHandler, HttpApiRequestToolInstanceExportHandler>(),
+        ]);
 
         services
             .AddDataMigration<AIToolInstanceIndexMigrations>()

--- a/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Startup.cs
@@ -411,3 +411,29 @@ public sealed class ToolInstancesStartup : StartupBase
             .AddPermissionProvider<AIToolInstancePermissionsProvider>();
     }
 }
+
+/// <summary>
+/// Registers the recipe execution step for the ToolInstances feature.
+/// </summary>
+[Feature(AIConstants.Feature.ToolInstances)]
+[RequireFeatures("OrchardCore.Recipes.Core")]
+public sealed class ToolInstancesRecipesStartup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddRecipeExecutionStep<AIToolInstanceStep>();
+    }
+}
+
+/// <summary>
+/// Registers the deployment step for the ToolInstances feature.
+/// </summary>
+[Feature(AIConstants.Feature.ToolInstances)]
+[RequireFeatures("OrchardCore.Deployment")]
+public sealed class ToolInstancesOCDeploymentsStartup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddDeployment<AIToolInstanceDeploymentSource, AIToolInstanceDeploymentStep, AIToolInstanceDeploymentStepDisplayDriver>();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Tools/Handlers/AlgoliaDocumentationToolInstanceExportHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Tools/Handlers/AlgoliaDocumentationToolInstanceExportHandler.cs
@@ -1,0 +1,32 @@
+using CrestApps.Core.AI.Tooling.Instances.Documentation;
+
+namespace CrestApps.OrchardCore.AI.Tools.Handlers;
+
+/// <summary>
+/// Removes the Algolia search-only API key from the export payload of an Algolia documentation search tool
+/// instance so that the stored credential is never written to a deployment plan or recipe.
+/// </summary>
+internal sealed class AlgoliaDocumentationToolInstanceExportHandler : IAIToolInstanceHandler
+{
+    /// <summary>
+    /// Clears the Algolia API key from the export payload when the instance uses the Algolia documentation source.
+    /// </summary>
+    /// <param name="context">The context describing the tool instance being exported.</param>
+    public void Exporting(ExportingAIToolInstanceContext context)
+    {
+        if (!string.Equals(context.Instance.Source, DocumentationToolConstants.AlgoliaSourceName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var settingsNode = context.ExportData["Properties"]?[nameof(AlgoliaDocumentationToolSettings)]?.AsObject();
+
+        if (settingsNode is null || settingsNode.Count == 0)
+        {
+            return;
+        }
+
+        // Always clear the API key during export to prevent accidental exposure of sensitive data.
+        settingsNode[nameof(AlgoliaDocumentationToolSettings.ApiKey)] = string.Empty;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Tools/Handlers/ExportingAIToolInstanceContext.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Tools/Handlers/ExportingAIToolInstanceContext.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core.AI.Tooling;
+
+namespace CrestApps.OrchardCore.AI.Tools.Handlers;
+
+/// <summary>
+/// Represents the context provided to <see cref="IAIToolInstanceHandler"/> implementations while an AI tool
+/// instance is being exported, allowing a handler to remove sensitive data from the export payload.
+/// </summary>
+public sealed class ExportingAIToolInstanceContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExportingAIToolInstanceContext"/> class.
+    /// </summary>
+    /// <param name="instance">The tool instance being exported.</param>
+    /// <param name="exportData">The JSON object that represents the exported tool instance.</param>
+    public ExportingAIToolInstanceContext(
+        AIToolInstance instance,
+        JsonObject exportData)
+    {
+        Instance = instance;
+        ExportData = exportData;
+    }
+
+    /// <summary>
+    /// Gets the tool instance being exported.
+    /// </summary>
+    public AIToolInstance Instance { get; }
+
+    /// <summary>
+    /// Gets the JSON object that represents the exported tool instance.
+    /// </summary>
+    public JsonObject ExportData { get; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Tools/Handlers/HttpApiRequestToolInstanceExportHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Tools/Handlers/HttpApiRequestToolInstanceExportHandler.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core.AI.Tooling.Instances;
+
+namespace CrestApps.OrchardCore.AI.Tools.Handlers;
+
+/// <summary>
+/// Removes the credentials stored by an HTTP API request tool instance from the export payload so that secrets
+/// such as API keys, bearer tokens, passwords, client secrets, and cached OAuth tokens are never written to a
+/// deployment plan or recipe.
+/// </summary>
+internal sealed class HttpApiRequestToolInstanceExportHandler : IAIToolInstanceHandler
+{
+    /// <summary>
+    /// Clears the stored credentials from the export payload when the instance uses the HTTP API request source.
+    /// </summary>
+    /// <param name="context">The context describing the tool instance being exported.</param>
+    public void Exporting(ExportingAIToolInstanceContext context)
+    {
+        if (!string.Equals(context.Instance.Source, HttpApiRequestToolConstants.SourceName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var propertiesNode = context.ExportData["Properties"]?.AsObject();
+
+        if (propertiesNode is null)
+        {
+            return;
+        }
+
+        var settingsNode = propertiesNode[nameof(HttpApiRequestToolSettings)]?.AsObject();
+
+        if (settingsNode is not null)
+        {
+            Clear(settingsNode, nameof(HttpApiRequestToolSettings.ApiKey));
+            Clear(settingsNode, nameof(HttpApiRequestToolSettings.BearerToken));
+            Clear(settingsNode, nameof(HttpApiRequestToolSettings.Password));
+            Clear(settingsNode, nameof(HttpApiRequestToolSettings.ClientSecret));
+        }
+
+        var tokenStateNode = propertiesNode[nameof(HttpApiRequestTokenState)]?.AsObject();
+
+        if (tokenStateNode is not null)
+        {
+            Clear(tokenStateNode, nameof(HttpApiRequestTokenState.AccessToken));
+            Clear(tokenStateNode, nameof(HttpApiRequestTokenState.RefreshToken));
+        }
+    }
+
+    private static void Clear(JsonObject node, string propertyName)
+    {
+        if (node.ContainsKey(propertyName))
+        {
+            node[propertyName] = string.Empty;
+        }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Tools/Handlers/IAIToolInstanceHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI/Tools/Handlers/IAIToolInstanceHandler.cs
@@ -1,0 +1,14 @@
+namespace CrestApps.OrchardCore.AI.Tools.Handlers;
+
+/// <summary>
+/// Handles events raised for AI tool instances, such as removing sensitive data before an instance is exported.
+/// </summary>
+public interface IAIToolInstanceHandler
+{
+    /// <summary>
+    /// Invoked while a tool instance is being exported so an implementer can remove sensitive data, such as API
+    /// keys or other credentials, from the export payload before it is written to the deployment plan.
+    /// </summary>
+    /// <param name="context">The context describing the tool instance being exported.</param>
+    void Exporting(ExportingAIToolInstanceContext context);
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/Items/AIToolInstanceDeploymentStep.Fields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/Items/AIToolInstanceDeploymentStep.Fields.Edit.cshtml
@@ -1,0 +1,30 @@
+@using CrestApps.OrchardCore.AI.Deployments.ViewModels
+
+@model AIToolInstanceDeploymentStepViewModel
+
+<div class="ocat-wrapper">
+    <div class="ocat-label">@T["AI Tool Instances"]</div>
+    <div class="ocat-end">
+        <div class="form-check mb-3">
+            <label class="form-check-label">
+                <input class="form-check-input" asp-for="IncludeAll" data-bs-toggle="collapse" role="button" data-bs-target="#instances-list" aria-expanded="false" aria-controls="instances-list" />
+                @T["Include all tool instances"]
+            </label>
+        </div>
+
+        <div id="instances-list" class="collapse@(Model.IncludeAll ? string.Empty : " show")">
+            <div class="hint mb-1">@T["The tool instances to export as part of the plan."]</div>
+
+            <div class="mb-3">
+                @for (var i = 0; i < Model.Instances.Length; i++)
+                {
+                    <div class="form-check">
+                        <input type="hidden" asp-for="Instances[i].ItemId" />
+                        <input asp-for="Instances[i].IsSelected" type="checkbox" class="form-check-input">
+                        <label class="form-check-label" asp-for="Instances[i].IsSelected">@Model.Instances[i].DisplayText</label>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/Items/AIToolInstanceDeploymentStep.Summary.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/Items/AIToolInstanceDeploymentStep.Summary.cshtml
@@ -1,0 +1,20 @@
+@using CrestApps.OrchardCore.AI.Deployments.Steps
+@using Microsoft.AspNetCore.Mvc.Localization
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<AIToolInstanceDeploymentStep>
+
+<h5>@T["AI Tool Instances"]</h5>
+
+@if (Model.Value.IncludeAll)
+{
+    <span class="badge text-bg-success">@T["All tool instances"]</span>
+}
+else if (Model.Value.InstanceIds?.Length > 0)
+{
+    <span class="badge text-bg-warning">@T.Plural(Model.Value.InstanceIds.Length, "1 selected tool instance.", "{0} selected tool instances.", Model.Value.InstanceIds.Length)</span>
+}
+else
+{
+    <span class="badge text-bg-warning">@T["No selected tool instance."]</span>
+}

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/Items/AIToolInstanceDeploymentStep.Thumbnail.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/Items/AIToolInstanceDeploymentStep.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+<h4 class="card-title">@T["AI Tool Instances"]</h4>
+<p>@T["Export all or specified AI tool instances."]</p>

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/SitemapDocumentationToolInstance.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/SitemapDocumentationToolInstance.Edit.cshtml
@@ -16,7 +16,7 @@
     <div class="ocat-end">
         <input asp-for="SitemapUrl" class="form-control" placeholder="https://core.crestapps.com/sitemap.xml" />
         <span asp-validation-for="SitemapUrl" class="text-danger"></span>
-        <span class="hint">@T["An explicit sitemap URL. Leave it empty to derive it from the base URL as {{BaseUrl}}/sitemap.xml."]</span>
+        <span class="hint">@T["An explicit sitemap URL. Leave it empty to derive it from the base URL as <code>{0}</code>.", "{BaseUrl}/sitemap.xml"]</span>
     </div>
 </div>
 

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/SitemapDocumentationToolInstance.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/SitemapDocumentationToolInstance.Edit.cshtml
@@ -16,7 +16,7 @@
     <div class="ocat-end">
         <input asp-for="SitemapUrl" class="form-control" placeholder="https://core.crestapps.com/sitemap.xml" />
         <span asp-validation-for="SitemapUrl" class="text-danger"></span>
-        <span class="hint">@T["An explicit sitemap URL. Leave it empty to derive it from the base URL as {BaseUrl}/sitemap.xml."]</span>
+        <span class="hint">@T["An explicit sitemap URL. Leave it empty to derive it from the base URL as {{BaseUrl}}/sitemap.xml."]</span>
     </div>
 </div>
 

--- a/src/Modules/CrestApps.OrchardCore.AI/Views/SitemapDocumentationToolInstance.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI/Views/SitemapDocumentationToolInstance.Edit.cshtml
@@ -5,7 +5,7 @@
 <div class="ocat-wrapper">
     <label asp-for="BaseUrl" class="ocat-label">@T["Base URL"]</label>
     <div class="ocat-end">
-        <input asp-for="BaseUrl" class="form-control" placeholder="https://core.crestapps.com" />
+        <input asp-for="BaseUrl" class="form-control" placeholder="https://example.com" />
         <span asp-validation-for="BaseUrl" class="text-danger"></span>
         <span class="hint">@T["The root URL of the documentation site. The crawler discovers pages through the site's sitemap.xml."]</span>
     </div>
@@ -14,7 +14,7 @@
 <div class="ocat-wrapper">
     <label asp-for="SitemapUrl" class="ocat-label">@T["Sitemap URL"]</label>
     <div class="ocat-end">
-        <input asp-for="SitemapUrl" class="form-control" placeholder="https://core.crestapps.com/sitemap.xml" />
+        <input asp-for="SitemapUrl" class="form-control" placeholder="https://example.com/sitemap.xml" />
         <span asp-validation-for="SitemapUrl" class="text-danger"></span>
         <span class="hint">@T["An explicit sitemap URL. Leave it empty to derive it from the base URL as <code>{0}</code>.", "{BaseUrl}/sitemap.xml"]</span>
     </div>

--- a/src/Modules/CrestApps.OrchardCore.Recipes/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.Recipes/Startup.cs
@@ -1843,6 +1843,18 @@ public sealed class AIDataSourcesRecipeStartup : StartupBase
 }
 
 /// <summary>
+/// Registers services and configuration for the AI tool instances recipe feature.
+/// </summary>
+[RequireFeatures("CrestApps.OrchardCore.AI.ToolInstances")]
+public sealed class AIToolInstancesRecipeStartup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IRecipeStep, AIToolInstanceRecipeStep>();
+    }
+}
+
+/// <summary>
 /// Registers services and configuration for the MCP connection recipe feature.
 /// </summary>
 [RequireFeatures("CrestApps.OrchardCore.AI.Mcp")]


### PR DESCRIPTION
Add an AIToolInstances recipe step and an AI Tool Instances deployment step/source/driver so tool instances can be imported and exported across tenants. Fix the Documentation search (sitemap) editor hiding its Save and Cancel buttons by escaping the literal {{BaseUrl}} token in the localized hint, which otherwise threw a FormatException and aborted form rendering.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
