### PR TITLE
Add 2.1.1 release notes

### DIFF
--- a/src/CrestApps.Docs/versioned_docs/version-2.1/ai/tool-instances.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/ai/tool-instances.md
@@ -96,6 +96,42 @@ Only `ManageAIToolInstances` is ever checked to decide whether the user may reac
 
 In addition, every configured instance produces a dynamic `AccessAITool_{functionName}` permission, exactly like a regular AI tool. The feature replaces the default tool instance registry with a permission-aware one, so an instance is only surfaced to the AI model when the current user is authorized for that instance.
 
+## Importing and exporting
+
+Tool instances can be moved between tenants with the standard Orchard Core deployment and recipe pipeline.
+
+### Deployment plan
+
+Enable **OrchardCore.Deployment** together with **AI Tool Instances**. The **AI Tool Instances** deployment step then becomes available when you build a deployment plan under **Configuration → Deployment Plans**. The step exports either every tool instance or only the instances you select. Each exported instance keeps its source, name, description, owner, and source-specific settings.
+
+Secrets are never written to the export. During export, each source can remove its own sensitive data through an `IAIToolInstanceHandler`. The built-in sources use this to strip their credentials: the **HTTP API request** source clears the API key, bearer token, password, client secret, and any cached OAuth tokens, and the **Algolia** source clears the search-only API key. After importing on the target tenant, edit the instance and re-enter the required credentials.
+
+### Recipe step
+
+The deployment step emits an `AIToolInstances` recipe step, which is also the step you author by hand in a recipe. On import, each entry is matched by `ItemId` first and then by `Name`; a matching instance is updated in place, otherwise a new instance is created from its `Source`. The source must be registered on the target tenant, so enable the feature that provides it before running the recipe.
+
+```json
+{
+  "steps": [
+    {
+      "name": "AIToolInstances",
+      "instances": [
+        {
+          "Source": "http-api-request",
+          "Name": "Order Lookup API",
+          "Description": "Looks up a customer's order status by order identifier.",
+          "Properties": {
+            "HttpApiRequestToolSettings": {
+              "BaseUrl": "https://api.example.com/orders"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## Registering a custom source
 
 A tool instance source is an `IAIToolInstanceSource` that turns an `AIToolInstance` into an `AITool`. Register it with `AddAIToolInstanceSource<TSource>` from your own feature's startup:

--- a/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.0.0.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.0.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.0.0 Release Notes
-sidebar_position: 2
+sidebar_position: 3
 title: "Version 2.0.0 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.0.0, including the platform upgrade, major new features, and upgrade guidance.
 ---

--- a/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.0.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.1.0 Release Notes
-sidebar_position: 1
+sidebar_position: 2
 title: "Version 2.1.0 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.1.0, including MCP Server breaking changes, recipe schema expansion, Omnichannel fixes, and module improvements.
 ---

--- a/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.1.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.1.md
@@ -1,0 +1,46 @@
+---
+sidebar_label: 2.1.1 Release Notes
+sidebar_position: 1
+title: "Version 2.1.1 Release Notes"
+description: Release notes for CrestApps.OrchardCore 2.1.1, including AI tool instance import and export support and a documentation search (sitemap) tool instance editor fix.
+---
+
+# Version 2.1.1 Release Notes
+
+**Release date:** August 16, 2026
+
+Version `2.1.1` is a patch release for the .NET 10 and Orchard Core 3.0 line. It keeps the Orchard Core package range at `>= 3.0.0` and `< 3.1.0` and the CrestApps.Core package line at stable `1.2.0`. This release adds import and export support for AI tool instances and fixes the documentation search (sitemap) tool instance editor.
+
+## At a glance
+
+| Area | 2.1.1 focus |
+| --- | --- |
+| AI Tool Instances | New deployment step and recipe step for importing and exporting tool instances, with an `IAIToolInstanceHandler` extension point that strips credentials from exports. |
+| Bug fixes | The documentation search (sitemap) tool instance editor now renders its **Save** and **Cancel** buttons. |
+
+## New additions
+
+### Import and export AI tool instances
+
+The **AI Tool Instances** feature can now move tool instances between tenants with the standard Orchard Core deployment and recipe pipeline.
+
+- **Deployment step.** With **OrchardCore.Deployment** and **AI Tool Instances** enabled, a new **AI Tool Instances** deployment step is available under **Configuration → Deployment Plans**. The step exports every tool instance or only the instances you select.
+- **Recipe step.** The deployment step emits an `AIToolInstances` recipe step that you can also author by hand. On import, each entry is matched by `ItemId` first and then by `Name`; a matching instance is updated in place, otherwise a new instance is created from its `Source`. The source must be registered on the target tenant, so enable the feature that provides it before running the recipe.
+- **Recipe schema.** The `AIToolInstances` step is now described by a recipe schema, so it is discoverable and validated when authoring recipes with the CrestApps Recipes tooling.
+
+#### Credentials are stripped from exports
+
+Secrets are never written to an export. During export, each source can remove its own sensitive data through the new `IAIToolInstanceHandler` extension point. The built-in sources use it to strip their credentials:
+
+- The **HTTP API request** source clears the API key, bearer token, password, client secret, and any cached OAuth tokens.
+- The **Algolia** documentation search source clears the search-only API key.
+
+After importing on the target tenant, edit the instance and re-enter the required credentials. Custom sources that store secrets can register their own `IAIToolInstanceHandler` to participate in this behavior.
+
+See [AI Tool Instances](../ai/tool-instances.md#importing-and-exporting) for details.
+
+## Bug fixes
+
+### Documentation search (sitemap) tool instance editor
+
+Creating or editing a **Documentation search (sitemap)** tool instance did not render the **Save** and **Cancel** buttons, which made it impossible to add or update an instance from that source. The editor hint referenced a `{BaseUrl}` token that the localizer interpreted as a composite-format placeholder, which threw at render time and aborted the rest of the form. The hint now passes the token as a localized argument, so the editor renders completely and the buttons are available again.

--- a/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/index.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/index.md
@@ -11,5 +11,6 @@ This section contains release notes and version highlights for **CrestApps.Orcha
 
 | Version | Highlights |
 | --- | --- |
+| [2.1.1](2.1.1) | Import and export for AI tool instances with credential-stripping export handlers, and a documentation search (sitemap) tool instance editor fix |
 | [2.1.0](2.1.0) | Stable CrestApps.Core 1.2.0 package line, opt-in MCP Server tool exposure, MCP Server admin settings, and documentation search tool instances |
 | [2.0.0](2.0.0) | Complete rewrite for .NET 10 and Orchard Core 3.0.x, official documentation launch, new AI platform, Omnichannel, phone verification, telephony, Content Transfer, reports, and recipes |


### PR DESCRIPTION
Document the 2.1.1 patch release for the 2.1 line: import and export support for AI tool instances (deployment step, recipe step, recipe schema, and credential-stripping export handlers) and the documentation search (sitemap) tool instance editor fix that restores the Save and Cancel buttons.

Also backport the tool instances import/export documentation section to the version-2.1 docs so the release-notes link resolves.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
