### PR TITLE
Fix AI email tool using logged-in user as sender

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI.Agent/Communications/SendEmailTool.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Agent/Communications/SendEmailTool.cs
@@ -1,12 +1,9 @@
 using System.Text.Json;
 using CrestApps.Core.AI.Extensions;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OrchardCore.Email;
-using OrchardCore.Users;
 
 namespace CrestApps.OrchardCore.AI.Agent.Communications;
 
@@ -109,33 +106,12 @@ public sealed class SendEmailTool : AIFunction
             return "Unable to find a body argument in the function arguments.";
         }
 
-        string senderEmail = null;
-
-        // HttpContext may be null when invoked from a background task (e.g., post-session processing).
-        var httpContextAccessor = arguments.Services.GetService<IHttpContextAccessor>();
-
-        var principal = httpContextAccessor?.HttpContext?.User;
-
-        if (principal is not null)
-        {
-            var userManager = arguments.Services.GetService<UserManager<IUser>>();
-
-            var user = await userManager?.GetUserAsync(principal);
-
-            if (user is not null)
-            {
-                senderEmail = await userManager.GetEmailAsync(user);
-            }
-        }
-
+        // Leave From and Sender unset for the configured provider default; do not derive ReplyTo from the current user.
         var message = new MailMessage
         {
             To = to,
             Subject = subject,
             HtmlBody = body,
-            Sender = senderEmail,
-            From = senderEmail,
-            ReplyTo = senderEmail,
         };
 
         if (arguments.TryGetFirstString("cc", out var cc))

--- a/src/Modules/CrestApps.OrchardCore.AI.Agent/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Agent/Startup.cs
@@ -489,7 +489,7 @@ public sealed class EmailStartup : StartupBase
     {
         services.AddCoreAITool<SendEmailTool>(SendEmailTool.TheName)
             .WithTitle(S["Send Emails"])
-            .WithDescription(S["Sends a email message on the behalf of the logged user."])
+            .WithDescription(S["Sends an email using the configured email provider."])
             .WithCategory(S["Communications"])
             .Selectable();
     }

--- a/tests/CrestApps.OrchardCore.Tests/Agent/Communications/SendEmailToolTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Agent/Communications/SendEmailToolTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using OrchardCore.Email;
 using OrchardCore.Infrastructure;
 using OrchardCore.Users;
+using System.Security.Claims;
 
 namespace CrestApps.OrchardCore.Tests.Agent.Communications;
 
@@ -50,14 +51,15 @@ public sealed class SendEmailToolTests
                     && m.Subject == "Test Subject"
                     && m.HtmlBody == "<p>Test body</p>"
                     && m.Sender == null
-                    && m.From == null),
+                    && m.From == null
+                    && m.ReplyTo == null),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     [Fact]
-    public async Task InvokeAsync_WithHttpContext_ShouldSendEmailWithSenderFromUser()
+    public async Task InvokeAsync_WithHttpContext_ShouldSendEmailWithoutSenderOrReplyTo()
     {
         // Arrange
         var emailService = new Mock<IEmailService>();
@@ -74,7 +76,10 @@ public sealed class SendEmailToolTests
             .Setup(x => x.GetEmailAsync(mockUser.Object))
             .ReturnsAsync("sender@example.com");
 
-        var httpContext = new DefaultHttpContext();
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, "user-id")], "TestAuthentication")),
+        };
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
@@ -98,11 +103,14 @@ public sealed class SendEmailToolTests
         emailService.Verify(
             x => x.SendAsync(
                 It.Is<MailMessage>(m =>
-                    m.Sender == "sender@example.com"
-                    && m.From == "sender@example.com"),
+                    m.Sender == null
+                    && m.From == null
+                    && m.ReplyTo == null),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+
+        userManager.Verify(x => x.GetUserAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
“Why remove ReplyTo too?”
      - Because this tool should not put the logged-in user into any email header. A reply should go to the configured sender
        unless a separate, approved reply-address feature is added.

  - “Does this work for SMTP and Azure Email?”
      - The provider should fail with a configuration error. Falling back to the logged-in user would recreate the SendAs bug.

  - “Why remove the user lookup entirely?”
      - It had one purpose: writing the user’s address into From, Sender, and ReplyTo. That is the defect. Keeping the lookup
       
  - “Does the test really cover the production case?”
      - Yes. It now has an authenticated HTTP user, a resolvable user email, and verifies that From, Sender, and ReplyTo remain
        null. Reintroducing the old code fails the test.

      - This PR fixes message construction. The unit test proves the tool hands the provider the correct empty identity fields;
        a real Exchange test requires tenant credentials/configuration and is deployment verification, not a normal repository

  - “What if the tenant has multiple approved sender accounts?”
  
      - This tool uses the tenant’s configured default provider/account. Selecting among accounts needs a separate, allowlisted
        email-profile feature—not AI-controlled raw From or SMTP settings.