### PR TITLE
[release/2.1] Update the AgentSkills package to 1.1.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Miscellaneous Packages -->
-    <PackageVersion Include="CrestApps.AgentSkills.Mcp.OrchardCore" Version="1.1.0" />
+    <PackageVersion Include="CrestApps.AgentSkills.Mcp.OrchardCore" Version="1.1.1" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.19.23" />
     <PackageVersion Include="Fluid.Core" Version="2.31.0" />

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Drivers/McpServerSettingsDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Drivers/McpServerSettingsDisplayDriver.cs
@@ -1,4 +1,3 @@
-using CrestApps.Core;
 using CrestApps.Core.AI.Mcp.Models;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Tooling;
@@ -87,7 +86,7 @@ public sealed class McpServerSettingsDisplayDriver : SiteDisplayDriver<McpServer
                 [
                     new SelectListItem(S["OpenID Connect"], nameof(McpServerAuthenticationType.OpenId)),
                     new SelectListItem(S["API key"], nameof(McpServerAuthenticationType.ApiKey)),
-                    new SelectListItem(S["None (development only)"], nameof(McpServerAuthenticationType.None)),
+                    new SelectListItem(S["None (Anonymous access)"], nameof(McpServerAuthenticationType.None)),
                 ];
             }).Location("Content:1%MCP Server;1")
             .OnGroup(SettingsGroupId),


### PR DESCRIPTION
Backport of #619 to `release/2.1`.

## Why this matters for 2.1.x

`release/2.1` currently pins `CrestApps.AgentSkills.Mcp.OrchardCore` at **1.1.0**, which does not deliver agent skills to sites that consume `CrestApps.OrchardCore.AI.Mcp` as a NuGet package.

Versions up to 1.1.0 shipped the skills as NuGet `contentFiles`. NuGet only applies `contentFiles` to **direct** package references and to project-reference chains, and silently drops them through a transitive **package** dependency. A site that references `CrestApps.OrchardCore.AI.Mcp` therefore publishes with no `.agents/skills` folder, and the MCP server exposes no skill resources at all. This is what happens on `mcp.orchardcore.net` today, which runs 2.1.1.

AgentSkills 1.1.1 ships the skills under `skills/` plus a `buildTransitive` targets file, which flows through transitive package references.

## Verified against the published packages

Measured with a consumer that references a module package, which is the published-site shape:

| AgentSkills version | Skill files in publish output |
| --- | --- |
| 1.1.0 | 0 |
| 1.1.1 | 229 (169 skill folders, loaded at runtime) |

The direct-reference case was also re-checked and still yields 229 files, so there is no regression for projects that reference the package directly.

## Changes

- `Directory.Packages.props`: `CrestApps.AgentSkills.Mcp.OrchardCore` `1.1.0` -> `1.1.1`
- `McpServerSettingsDisplayDriver`: relabel the `None` authentication option to **None (Anonymous access)** and drop the now unused `using CrestApps.Core;`

## Follow-up

A 2.1.2 release is needed before `mcp.orchardcore.net` can be updated to pick this up.