### PR TITLE
Add 2.1.2 release notes

### DIFF
--- a/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.0.0.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.0.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.0.0 Release Notes
-sidebar_position: 3
+sidebar_position: 4
 title: "Version 2.0.0 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.0.0, including the platform upgrade, major new features, and upgrade guidance.
 ---

--- a/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.0.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.1.0 Release Notes
-sidebar_position: 2
+sidebar_position: 3
 title: "Version 2.1.0 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.1.0, including MCP Server breaking changes, recipe schema expansion, Omnichannel fixes, and module improvements.
 ---

--- a/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.1.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.1.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.1.1 Release Notes
-sidebar_position: 1
+sidebar_position: 2
 title: "Version 2.1.1 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.1.1, including AI tool instance import and export support and a documentation search (sitemap) tool instance editor fix.
 ---

--- a/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.2.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/2.1.2.md
@@ -1,0 +1,50 @@
+---
+sidebar_label: 2.1.2 Release Notes
+sidebar_position: 1
+title: "Version 2.1.2 Release Notes"
+description: Release notes for CrestApps.OrchardCore 2.1.2, including agent skills that are now published with MCP Server sites and a fix for the AI email tool that used the logged-in user as the sender.
+---
+
+# Version 2.1.2 Release Notes
+
+**Release date:** August 18, 2026
+
+Version `2.1.2` is a patch release for the .NET 10 and Orchard Core 3.0 line. It keeps the Orchard Core package range at `>= 3.0.0` and `< 3.1.0` and the CrestApps.Core package line at stable `1.2.0`. This release fixes two defects: agent skills were missing from published MCP Server sites, and the AI email tool sent messages with the logged-in user as the sender.
+
+## At a glance
+
+| Area | 2.1.2 focus |
+| --- | --- |
+| MCP Server | Agent skills are now included when you publish a site that installs the module from NuGet, so the server exposes skill prompts and resources. |
+| AI Agent | The **Send Emails** tool no longer writes the logged-in user into the `From`, `Sender`, or `Reply-To` headers. |
+| MCP Server settings | The `None` authentication option is now labeled **None (Anonymous access)**. |
+
+## Bug fixes
+
+### Agent skills are missing from published MCP Server sites
+
+A site that installed **CrestApps.OrchardCore.AI.Mcp** from NuGet published without any agent skills. The MCP server started correctly and exposed the selected tools, but `ListResources` and `ListPrompts` returned no skills. The problem did not occur during local development, which made it difficult to find.
+
+The cause was the packaging format of the `CrestApps.AgentSkills.Mcp.OrchardCore` dependency. Up to version `1.1.0`, that package shipped the skills as NuGet `contentFiles`. NuGet applies `contentFiles` only to **direct** package references and to project-reference chains. NuGet removes them when the package arrives through another package, which is a transitive package reference. Local development uses project references and therefore worked, but a published site references the module as a package and received no skill files. The runtime loader then found an empty `.agents/skills` directory and registered nothing.
+
+This release updates the dependency to `CrestApps.AgentSkills.Mcp.OrchardCore` `1.1.1`. That version ships the skills under `skills/` together with a `buildTransitive` MSBuild targets file. Assets in `buildTransitive` flow through transitive package references, so the skills are copied to the build output and the publish output at `.agents/skills/` for every consumer, at any depth in the dependency graph.
+
+No configuration change is required. Update to `2.1.2`, publish the site again, and the MCP server exposes the skills as prompts and resources.
+
+:::note
+If your application supplies its own skills directory, you can prevent the packaged skills from being copied. Set the `IncludeCrestAppsAgentSkills` MSBuild property to `false` in your project.
+:::
+
+### The AI email tool used the logged-in user as the sender
+
+The **Send Emails** tool wrote the address of the logged-in user into the `From`, `Sender`, and `Reply-To` headers of the message. Mail providers that only permit approved sender addresses rejected these messages, and the behavior let an email appear to come from a user who did not send it.
+
+The tool now leaves these headers empty and lets the configured email provider apply the tenant default sender. If a provider has no sender configured, it fails with a configuration error instead of falling back to the logged-in user.
+
+The tool description also changed from *Sends a email message on the behalf of the logged user* to **Sends an email using the configured email provider**, which describes the corrected behavior.
+
+## Improvements
+
+### Clearer MCP Server authentication label
+
+In **Settings → Artificial Intelligence → MCP Server**, the authentication option named *None (development only)* is now named **None (Anonymous access)**. The option is unchanged. The new label describes what the option does, because some deployments intentionally expose an anonymous MCP endpoint.

--- a/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/index.md
+++ b/src/CrestApps.Docs/versioned_docs/version-2.1/changelog/index.md
@@ -11,6 +11,7 @@ This section contains release notes and version highlights for **CrestApps.Orcha
 
 | Version | Highlights |
 | --- | --- |
+| [2.1.2](2.1.2) | Agent skills are now published with MCP Server sites, and the AI email tool no longer uses the logged-in user as the sender |
 | [2.1.1](2.1.1) | Import and export for AI tool instances with credential-stripping export handlers, and a documentation search (sitemap) tool instance editor fix |
 | [2.1.0](2.1.0) | Stable CrestApps.Core 1.2.0 package line, opt-in MCP Server tool exposure, MCP Server admin settings, and documentation search tool instances |
 | [2.0.0](2.0.0) | Complete rewrite for .NET 10 and Orchard Core 3.0.x, official documentation launch, new AI platform, Omnichannel, phone verification, telephony, Content Transfer, reports, and recipes |


### PR DESCRIPTION
Adds the release notes for the upcoming **2.1.2** patch release.

## Placement

The 2.1.x notes live under `versioned_docs/version-2.1/changelog/` on `main`, next to `2.1.0.md` and `2.1.1.md`. `2.1` is a built version in `versions.json`, so the changelog overview link resolves. This follows the correction made in 8e75694, where the 2.1.1 notes had to be moved out of an unbuilt version directory to pass docs link validation.

## Contents of 2.1.2

| Change | Backport |
| --- | --- |
| Agent skills are missing from published MCP Server sites | #619 -> #621 |
| The AI email tool used the logged-in user as the sender | #618 -> #620 |
| MCP Server authentication option relabeled to **None (Anonymous access)** | #619 -> #621 |

The skills entry explains the root cause, because it was hard to diagnose: up to `CrestApps.AgentSkills.Mcp.OrchardCore` 1.1.0 the skills shipped as NuGet `contentFiles`, which NuGet applies only to direct package references and project-reference chains. They are dropped through a transitive package reference, so local development worked while a published site received no skill files. Version 1.1.1 delivers them with a `buildTransitive` targets file instead.

## Changes

- Add `versioned_docs/version-2.1/changelog/2.1.2.md`
- Add the 2.1.2 row to `versioned_docs/version-2.1/changelog/index.md`
- Shift `sidebar_position` on 2.1.1, 2.1.0, and 2.0.0 so the newest release stays first

## Validation

`npm run build` in `src/CrestApps.Docs` completes successfully, with no broken links. The page renders at `/docs/2.1/changelog/2.1.2` and the overview links to it.

## Note

The release date is set to **August 18, 2026**. Please adjust it if the release slips.