### PR TITLE
Author MCP prompt messages in admin, recipe, and deployment

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Deployments/Sources/McpPromptDeploymentSource.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Deployments/Sources/McpPromptDeploymentSource.cs
@@ -58,6 +58,17 @@ internal sealed class McpPromptDeploymentSource : DeploymentSourceBase<McpPrompt
                 { nameof(Prompt.Arguments), argumentsArray },
             };
 
+            var messagesArray = new JsonArray();
+
+            foreach (var message in entry.Messages ?? [])
+            {
+                messagesArray.Add(new JsonObject
+                {
+                    { nameof(McpPromptMessage.Role), message.Role },
+                    { nameof(McpPromptMessage.Content), message.Content },
+                });
+            }
+
             var deploymentInfo = new JsonObject()
             {
                 { nameof(McpPrompt.ItemId), entry.ItemId },
@@ -66,6 +77,7 @@ internal sealed class McpPromptDeploymentSource : DeploymentSourceBase<McpPrompt
                 { nameof(McpPrompt.CreatedUtc), entry.CreatedUtc },
                 { nameof(McpPrompt.OwnerId), entry.OwnerId },
                 { nameof(McpPrompt.Prompt), promptData },
+                { nameof(McpPrompt.Messages), messagesArray },
             };
 
             promptsData.Add(deploymentInfo);

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Drivers/McpPromptDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Drivers/McpPromptDisplayDriver.cs
@@ -51,6 +51,12 @@ internal sealed class McpPromptDisplayDriver : DisplayDriver<McpPrompt>
                     Required = a.Required ?? false,
                 }).ToList() ?? [];
             }
+
+            model.Messages = entry.Messages?.Select(m => new McpPromptMessageViewModel
+            {
+                Role = m.Role,
+                Content = m.Content,
+            }).ToList() ?? [];
         }).Location("Content:1");
     }
 
@@ -69,6 +75,22 @@ internal sealed class McpPromptDisplayDriver : DisplayDriver<McpPrompt>
         var validArguments = model.Arguments?
             .Where(a => !string.IsNullOrWhiteSpace(a.Name))
             .ToList() ?? [];
+
+        // Validate messages if provided. Keep rows that have content and default the role to
+        // "user" when it is empty; reject any explicitly supplied role other than user/assistant.
+        var validMessages = model.Messages?
+            .Where(m => !string.IsNullOrWhiteSpace(m.Content))
+            .ToList() ?? [];
+
+        for (var i = 0; i < validMessages.Count; i++)
+        {
+            var role = validMessages[i].Role;
+
+            if (!string.IsNullOrWhiteSpace(role) && !IsValidRole(role))
+            {
+                context.Updater.ModelState.AddModelError(Prefix, $"{nameof(model.Messages)}[{i}].{nameof(McpPromptMessageViewModel.Role)}", S["Message {0} must have a role of 'user' or 'assistant'.", i + 1]);
+            }
+        }
 
         var name = model.Name ?? string.Empty;
 
@@ -90,6 +112,16 @@ internal sealed class McpPromptDisplayDriver : DisplayDriver<McpPrompt>
             Required = a.Required,
         }).ToList();
 
+        entry.Messages = validMessages.Select(m => new McpPromptMessage
+        {
+            Role = string.IsNullOrWhiteSpace(m.Role) ? "user" : m.Role.Trim().ToLowerInvariant(),
+            Content = m.Content,
+        }).ToList();
+
         return Edit(entry, context);
     }
+
+    private static bool IsValidRole(string role)
+        => string.Equals(role, "user", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Handlers/McpPromptHandler.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Handlers/McpPromptHandler.cs
@@ -73,6 +73,20 @@ internal sealed class McpPromptHandler : CatalogEntryHandlerBase<McpPrompt>
             }
         }
 
+        if (context.Model.Messages != null)
+        {
+            for (var i = 0; i < context.Model.Messages.Count; i++)
+            {
+                var role = context.Model.Messages[i].Role;
+                if (!string.IsNullOrWhiteSpace(role)
+                    && !string.Equals(role, "user", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Result.Fail(new ValidationResult(S["Message {0} must have a role of 'user' or 'assistant'.", i + 1], [$"Messages[{i}].Role"]));
+                }
+            }
+        }
+
         return Task.CompletedTask;
     }
 
@@ -119,6 +133,26 @@ internal sealed class McpPromptHandler : CatalogEntryHandlerBase<McpPrompt>
             {
                 entry.Prompt.Description = description;
             }
+        }
+
+        // Populate the messages from data if provided (recipe/programmatic creation).
+        var messagesData = data?[nameof(McpPrompt.Messages)]?.AsArray();
+
+        if (messagesData is not null)
+        {
+            entry.Messages = messagesData
+                .Where(m => m is not null)
+                .Select(m =>
+                {
+                    var obj = m.AsObject();
+                    return new McpPromptMessage
+                    {
+                        Role = obj[nameof(McpPromptMessage.Role)]?.ToString(),
+                        Content = obj[nameof(McpPromptMessage.Content)]?.ToString(),
+                    };
+                })
+                .Where(m => !string.IsNullOrWhiteSpace(m.Content))
+                .ToList();
         }
 
         return Task.CompletedTask;

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Recipes/McpPromptStep.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Recipes/McpPromptStep.cs
@@ -130,6 +130,24 @@ internal sealed class McpPromptStep : NamedRecipeStepHandler
                     .ToList();
             }
         }
+
+        var messagesArray = token[nameof(McpPrompt.Messages)]?.AsArray();
+        if (messagesArray is not null)
+        {
+            entry.Messages = messagesArray
+                .Where(m => m is not null)
+                .Select(m =>
+                {
+                    var obj = m.AsObject();
+                    return new McpPromptMessage
+                    {
+                        Role = obj[nameof(McpPromptMessage.Role)]?.GetValue<string>(),
+                        Content = obj[nameof(McpPromptMessage.Content)]?.GetValue<string>(),
+                    };
+                })
+                .Where(m => !string.IsNullOrWhiteSpace(m.Content))
+                .ToList();
+        }
     }
 
     private sealed class McpPromptDeploymentStepModel

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/ViewModels/McpPromptFieldsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/ViewModels/McpPromptFieldsViewModel.cs
@@ -28,10 +28,31 @@ public class McpPromptFieldsViewModel
     public List<McpPromptArgumentViewModel> Arguments { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets the messages that make up the body of this prompt.
+    /// </summary>
+    public List<McpPromptMessageViewModel> Messages { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets a value indicating whether is new.
     /// </summary>
     [BindNever]
     public bool IsNew { get; set; }
+}
+
+/// <summary>
+/// Represents the view model for an mcp prompt message.
+/// </summary>
+public class McpPromptMessageViewModel
+{
+    /// <summary>
+    /// Gets or sets the role. Only "user" and "assistant" are supported.
+    /// </summary>
+    public string Role { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content. May contain <c>{{argName}}</c> placeholders.
+    /// </summary>
+    public string Content { get; set; }
 }
 
 /// <summary>

--- a/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpPromptFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Mcp/Views/McpPromptFields.Edit.cshtml
@@ -75,6 +75,45 @@
     </div>
 </fieldset>
 
+<fieldset class="ocat-wrapper">
+    <legend class="ocat-label">@T["Messages"]</legend>
+    <div class="ocat-end">
+        <div class="hint mb-2">@T["Define the messages returned when this prompt is requested. Use {{argName}} to reference an argument."]</div>
+
+        <div id="messages-container">
+            @for (int i = 0; i < Model.Messages.Count; i++)
+            {
+                <div class="card mb-2 message-item" data-index="@i">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-3">
+                                <label class="form-label">@T["Role"]</label>
+                                <select name="@Html.NameFor(m => m.Messages[i].Role)" class="form-select">
+                                    <option value="user" selected="@(string.Equals(Model.Messages[i].Role, "assistant", StringComparison.OrdinalIgnoreCase) ? null : "selected")">@T["User"]</option>
+                                    <option value="assistant" selected="@(string.Equals(Model.Messages[i].Role, "assistant", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">@T["Assistant"]</option>
+                                </select>
+                            </div>
+                            <div class="col-md-8">
+                                <label class="form-label">@T["Content"]</label>
+                                <textarea name="@Html.NameFor(m => m.Messages[i].Content)" class="form-control" rows="3" placeholder="@T["Message content"]">@Model.Messages[i].Content</textarea>
+                            </div>
+                            <div class="col-md-1 d-flex align-items-end">
+                                <button type="button" class="btn btn-danger btn-sm remove-message" title="@T["Remove message"]">
+                                    <i class="fa-solid fa-times"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+
+        <button type="button" class="btn btn-secondary btn-sm" id="add-message">
+            <i class="fa-solid fa-plus"></i> @T["Add Message"]
+        </button>
+    </div>
+</fieldset>
+
 <script asp-name="technical-name-generator"></script>
 <script at="Foot" depends-on="technical-name-generator">
     window.initAutoGenerateTechnicalName('@Html.IdFor(x => x.Title)', '@Html.IdFor(x => x.Name)');
@@ -134,6 +173,57 @@
         argumentsContainer.addEventListener('click', function (e) {
             if (e.target.classList.contains('remove-argument') || e.target.closest('.remove-argument')) {
                 const item = e.target.closest('.argument-item');
+                if (item) {
+                    item.remove();
+                }
+            }
+        });
+
+        const messagesContainer = document.getElementById('messages-container');
+        const addMessageBtn = document.getElementById('add-message');
+
+        function getNextMessageIndex() {
+            const items = messagesContainer.querySelectorAll('.message-item');
+            return items.length;
+        }
+
+        function createMessageItem(index) {
+            const prefix = '@Html.NameFor(m => m.Messages)';
+            const html = `
+            <div class="card mb-2 message-item" data-index="${index}">
+            <div class="card-body">
+            <div class="row">
+            <div class="col-md-3">
+            <label class="form-label">@T["Role"]</label>
+            <select name="${prefix}[${index}].Role" class="form-select">
+            <option value="user" selected>@T["User"]</option>
+            <option value="assistant">@T["Assistant"]</option>
+            </select>
+            </div>
+            <div class="col-md-8">
+            <label class="form-label">@T["Content"]</label>
+            <textarea name="${prefix}[${index}].Content" class="form-control" rows="3" placeholder="@T["Message content"]"></textarea>
+            </div>
+            <div class="col-md-1 d-flex align-items-end">
+            <button type="button" class="btn btn-danger btn-sm remove-message" title="@T["Remove message"]">
+            <i class="fa-solid fa-times"></i>
+            </button>
+            </div>
+            </div>
+            </div>
+            </div>
+            `;
+            return html;
+        }
+
+        addMessageBtn.addEventListener('click', function () {
+            const index = getNextMessageIndex();
+            messagesContainer.insertAdjacentHTML('beforeend', createMessageItem(index));
+        });
+
+        messagesContainer.addEventListener('click', function (e) {
+            if (e.target.classList.contains('remove-message') || e.target.closest('.remove-message')) {
+                const item = e.target.closest('.message-item');
                 if (item) {
                     item.remove();
                 }


### PR DESCRIPTION
## Summary

Catalog (admin-authored) MCP prompts were listed to clients but returned **empty content** on `GetPrompt`, because the MCP prompt model had nowhere to store the prompt message body. This PR adds message authoring and persistence throughout the MCP module so admin/recipe/deployment-authored prompts serve real content.

This is the OrchardCore half of a two-repo change. The matching `CrestApps.Core` change adds `McpPrompt.Messages` (a `List<McpPromptMessage>` of `{ Role, Content }`) and makes `DefaultMcpServerPromptService.GetAsync` return those messages with `{{arg}}` substitution.

## Changes

- **ViewModels/McpPromptFieldsViewModel.cs** — add `McpPromptMessageViewModel { Role, Content }` and a `Messages` collection.
- **Drivers/McpPromptDisplayDriver.cs** — `Edit` hydrates messages from the entry; `UpdateAsync` filters empty rows, validates the role is `user`/`assistant`, defaults a blank role to `user`, and writes `Messages` back onto the entry.
- **Views/McpPromptFields.Edit.cshtml** — repeatable messages editor (role dropdown + multiline content, add/remove rows) mirroring the existing Arguments editor.
- **Handlers/McpPromptHandler.cs** — read `Messages` from incoming JSON in `PopulateAsync` (recipe/programmatic creation); validate roles in `ValidatingAsync`.
- **Recipes/McpPromptStep.cs** — read/write the `Messages` array so prompts round-trip through recipes.
- **Deployments/Sources/McpPromptDeploymentSource.cs** — export the `Messages` array with the entry.

## Dependency / build note

This branch **requires a `CrestApps.Core` package that includes `McpPrompt.Messages` and `McpPromptMessage`** (the Part A change). Until that Core preview is published and `CrestAppsCoreVersion` is bumped in `Directory.Packages.props`, the module will not compile — every current build error is exclusively the missing `Messages` property / `McpPromptMessage` type from the older package, not a defect in this diff.

## Follow-up

- Add driver round-trip and recipe-import unit tests once the module builds against the updated Core package.

## Scope

Skill prompts and CrestApps.AgentSkills are untouched; only admin/recipe/deployment catalog prompts are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
