### PR TITLE
Add Web Crawlers AI data source module

### DIFF
--- a/CrestApps.OrchardCore.slnx
+++ b/CrestApps.OrchardCore.slnx
@@ -49,6 +49,7 @@
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.DataSources.AzureAI/CrestApps.OrchardCore.AI.DataSources.AzureAI.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.DataSources.Elasticsearch/CrestApps.OrchardCore.AI.DataSources.Elasticsearch.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.DataSources.PostgreSQL/CrestApps.OrchardCore.AI.DataSources.PostgreSQL.csproj" />
+    <Project Path="src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/CrestApps.OrchardCore.AI.DataSources.WebCrawlers.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.DataSources/CrestApps.OrchardCore.AI.DataSources.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.Documents.Azure/CrestApps.OrchardCore.AI.Documents.Azure.csproj" />
     <Project Path="src/Modules/CrestApps.OrchardCore.AI.Documents.AzureAI/CrestApps.OrchardCore.AI.Documents.AzureAI.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrchardCoreVersion>4.0.0-preview-19124</OrchardCoreVersion>
-    <CrestAppsCoreVersion>2.0.0-preview.237</CrestAppsCoreVersion>
+    <CrestAppsCoreVersion>2.0.0-preview.239</CrestAppsCoreVersion>
     <ModelContextProtocolVersion>2.2.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -112,6 +112,7 @@
     <PackageVersion Include="CrestApps.Core" Version="$(CrestAppsCoreVersion)" />
     <PackageVersion Include="CrestApps.Core.AI" Version="$(CrestAppsCoreVersion)" />
     <PackageVersion Include="CrestApps.Core.AI.Abstractions" Version="$(CrestAppsCoreVersion)" />
+    <PackageVersion Include="CrestApps.Core.AI.WebCrawlers" Version="$(CrestAppsCoreVersion)" />
     <PackageVersion Include="CrestApps.Core.AI.A2A" Version="$(CrestAppsCoreVersion)" />
     <PackageVersion Include="CrestApps.Core.AI.AzureAIInference" Version="$(CrestAppsCoreVersion)" />
     <PackageVersion Include="CrestApps.Core.AI.Chat" Version="$(CrestAppsCoreVersion)" />
@@ -176,7 +177,7 @@
     <!-- Transitive Packages -->
     <PackageVersion Include="System.Memory.Data" Version="10.0.11" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.11" />
-    <PackageVersion Include="AngleSharp" Version="1.7.0" />
+    <PackageVersion Include="AngleSharp" Version="1.7.1" />
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.4" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>

--- a/src/CrestApps.Docs/docs/ai/data-sources/index.md
+++ b/src/CrestApps.Docs/docs/ai/data-sources/index.md
@@ -50,6 +50,7 @@ The data source list now follows the deployments-style creation flow. **Add Data
 - **Elasticsearch** — read directly from an external Elasticsearch index
 - **Azure AI Search** — read directly from an external Azure AI Search index
 - **PostgreSQL** — read directly from a PostgreSQL table
+- **Web** — populated by [web crawlers](web-crawlers.md) that scrape public websites
 
 After you choose a source type from the modal, the create screen keeps that source type fixed for the new data source instead of showing it as another editable field. When **Search Index Profile** is selected, the editor shows the Orchard-managed source index picker and excludes internal AI-managed index types such as **AI Documents**, **AI Memory**, and other **Data Source** knowledge-base indexes so only valid source indexes appear in the selector.
 
@@ -173,6 +174,8 @@ Enable one of the following provider modules to get started:
 - `CrestApps.OrchardCore.AI.DataSources.Elasticsearch`
 - `CrestApps.OrchardCore.AI.DataSources.AzureAI`
 - `CrestApps.OrchardCore.AI.DataSources.PostgreSQL`
+
+Or enable the **[Web Crawlers](web-crawlers.md)** module (`CrestApps.OrchardCore.AI.DataSources.WebCrawlers`) to scrape public websites into a **Web** data source.
 
 ## Keeping the AI KB index in sync
 

--- a/src/CrestApps.Docs/docs/ai/data-sources/web-crawlers.md
+++ b/src/CrestApps.Docs/docs/ai/data-sources/web-crawlers.md
@@ -1,0 +1,86 @@
+---
+sidebar_label: Web Crawlers
+sidebar_position: 5
+title: AI Data Sources - Web Crawlers
+description: A Web AI data source populated by strategy-based web crawlers that scrape public websites and index each page into the AI Knowledge Base for RAG.
+---
+
+| | |
+| --- | --- |
+| **Feature Name** | AI Data Sources - Web Crawlers |
+| **Feature ID** | `CrestApps.OrchardCore.AI.DataSources.WebCrawlers` |
+
+Adds a **Web** AI data source that is populated by strategy-based web crawlers. Crawlers scrape public websites (starting with sitemap discovery), clean each page to text, and index it into the AI Knowledge Base for Retrieval-Augmented Generation (RAG).
+
+## Overview
+
+Unlike the other data sources, which read from an index or database you already maintain, the **Web** source builds its knowledge base by scraping live websites. A **Web** data source is a target bucket, and one or more **web crawlers** point at it. Each crawler owns a site and a crawl **strategy**:
+
+- **Web data source** — A knowledge-base target with no connection settings of its own. It aggregates every enabled crawler that targets it.
+- **Web crawler** — A configured site to scrape: a strategy (for example **Sitemap**), the strategy's settings, and the target Web data source. Many crawlers can point at one data source.
+- **Crawl strategy** — Defines how a site is discovered and how a page is fetched and cleaned. The built-in strategy is **Sitemap**; the model is extensible, so future strategies (for example depth-limited link following) plug in without changing the data source or the UI.
+
+Each scraped page becomes one knowledge-base document keyed by its URL, and the URL is kept for citations.
+
+## Getting Started
+
+1. **Enable the feature** — Enable **AI Data Sources - Web Crawlers** in the Orchard Core admin dashboard. This also enables the **AI Data Sources** feature it depends on.
+2. **Create a Knowledge Base Index** — In **Search > Indexing**, add an **AI Knowledge Base Index** (Elasticsearch or Azure AI Search) with an embedding connection configured. See the [AI Data Sources overview](index.md) for the embedding requirements.
+3. **Add a Web data source** — Under **Artificial Intelligence > Data Sources**, click **Add Data Source**, choose **Web**, then configure the destination knowledge-base index and field mappings. The Web source itself has no connection settings.
+4. **Add a web crawler** — Under **Artificial Intelligence > Web Crawlers**, click **Add Web Crawler**, choose the **Sitemap** strategy, and configure the site to scrape and its target Web data source.
+5. **Synchronize** — Use the **Synchronize now** action on a crawler to scrape immediately, or wait for the hourly background task to re-index crawlers that are due.
+
+## Managing Web Crawlers
+
+The **Web Crawlers** admin screen mirrors the other source-based catalogs (AI Templates, Data Sources): a searchable list, an **Add Web Crawler** button that opens a modal of available strategies, and an **Actions** menu per crawler.
+
+### Shared fields
+
+| Field | Description |
+| --- | --- |
+| **Name** | A human-readable name that identifies the crawler in the list. |
+| **Target Web data source** | The Web AI data source whose knowledge base receives the scraped pages. Multiple crawlers can target the same data source. |
+| **Enabled** | Disabled crawlers are skipped by the hourly re-index task and are not read during a full data source synchronization. |
+| **Re-index interval (minutes)** | How often the background task re-crawls this site. Leave empty to use the global default (24 hours). The task evaluates crawlers hourly, so intervals are honored to the nearest hour. |
+
+### Sitemap strategy settings
+
+| Field | Description |
+| --- | --- |
+| **Base URL** | The site to scrape. The crawler discovers the sitemap from `robots.txt` and the conventional locations (for example `/sitemap.xml`). Provide this or an explicit sitemap URL. |
+| **Sitemap URL** | An explicit sitemap or sitemap-index URL. When set, discovery starts here. Supports nested sitemap indexes, gzip, plain-text, and RSS/Atom feeds. |
+| **Max pages** | The most pages to scrape per crawl. Default: 500. |
+| **Max concurrent requests** | How many pages are fetched in parallel. Default: 4. Keep this low to be polite to the target site. |
+| **Request timeout (seconds)** | Per-request fetch timeout. Default: 30. |
+| **Include URL patterns** | One regular expression per line. A discovered page is scraped only when its full URL matches **at least one** pattern. Empty allows every discovered page. |
+| **Exclude URL patterns** | One regular expression per line. A page is skipped when its URL matches **any** pattern. Applied **after** the include patterns, so exclude wins. |
+| **User-Agent** | The `User-Agent` header sent while crawling. Leave empty to use the default. |
+
+### Include and exclude patterns
+
+Both boxes take one **regular expression** per line and are matched against the full page URL.
+
+- **Include** acts as an allow-list. When empty, every discovered page is eligible. When set, a page must match at least one include pattern to be scraped. For example, `^https://example\.com/docs/` keeps only pages under `/docs/`.
+- **Exclude** acts as a deny-list and runs after include, so exclusions win. For example, `/tag/|/author/` drops taxonomy and author pages, and `\.pdf$` drops PDF links.
+
+Invalid regular expressions are rejected in the editor, and a crawler must define a base URL or an explicit sitemap URL before it can be saved.
+
+## Synchronization
+
+- **Manual** — The **Synchronize now** action on a crawler re-crawls just that site: it discovers the current pages, diffs them against the recorded crawl state, and queues only the new, changed, and removed pages for indexing into the target data source. Unchanged pages are skipped.
+- **Scheduled** — An hourly Orchard background task (`WebCrawlerReindexBackgroundTask`) evaluates every enabled crawler and re-indexes the ones whose re-index interval is due. Disabled crawlers are skipped.
+- **On save** — Creating, updating, or deleting a crawler queues a full synchronization of its target Web data source so the knowledge base stays aligned.
+
+Because a crawler tracks per-page crawl state (last-modified, change-frequency, and a content hash), re-indexing is incremental: only pages that actually changed are re-fetched and re-embedded, and a transient block that returns no pages leaves the existing knowledge base untouched rather than wiping it.
+
+## Citations
+
+Scraped pages are indexed with their URL kept as the knowledge-base reference id, and the feature registers a link resolver for the **Web** reference type so citations link back to the original page. See [AI Data Sources — Citation & Reference Tracking](index.md#citation--reference-tracking) for how `[doc:N]` markers are produced.
+
+## Storage
+
+The feature persists crawlers and per-page crawl state in the AI YesSql collection through the shared `CrestApps.Core` stores (`IWebCrawlerStore` and `IWebCrawlStateStore`). Migrations create the `WebCrawlerIndex` and `WebCrawlStateIndex` tables via the Core schema builders (`CreateWebCrawlerIndexSchemaAsync` and `CreateWebCrawlStateIndexSchemaAsync`).
+
+## Permissions
+
+The feature adds the **Manage web crawlers** (`ManageWebCrawlers`) permission, granted to the Administrator role by default. It controls access to the entire Web Crawlers admin area, including the synchronize action.

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/BackgroundTasks/WebCrawlerReindexBackgroundTask.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/BackgroundTasks/WebCrawlerReindexBackgroundTask.cs
@@ -1,0 +1,45 @@
+using CrestApps.Core.AI.WebCrawlers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OrchardCore.BackgroundTasks;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.BackgroundTasks;
+
+/// <summary>
+/// Hourly Orchard background task that re-crawls every enabled web crawler that is due per its
+/// configured re-index interval, indexing only the pages that were added, changed, or removed.
+/// </summary>
+[BackgroundTask(
+    Title = "Web Crawler Re-index",
+    Schedule = "0 * * * *",
+    Description = "Hourly evaluation of web crawlers; re-crawls and re-indexes each crawler that is due.",
+    LockTimeout = 5_000,
+    LockExpiration = 600_000)]
+public sealed class WebCrawlerReindexBackgroundTask : IBackgroundTask
+{
+    /// <summary>
+    /// Evaluates the configured web crawlers and re-indexes the ones that are due.
+    /// </summary>
+    /// <param name="serviceProvider">The tenant service provider.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async Task DoWorkAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var reindexService = serviceProvider.GetService<IWebCrawlerReindexService>();
+
+        if (reindexService is null)
+        {
+            return;
+        }
+
+        var logger = serviceProvider.GetRequiredService<ILogger<WebCrawlerReindexBackgroundTask>>();
+
+        try
+        {
+            await reindexService.ReindexDueAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An error occurred while re-indexing due web crawlers.");
+        }
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Controllers/WebCrawlersController.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Controllers/WebCrawlersController.cs
@@ -1,0 +1,430 @@
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.WebCrawlers;
+using CrestApps.Core.AI.WebCrawlers.Strategies;
+using CrestApps.Core.Services;
+using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Services;
+using CrestApps.OrchardCore.Core.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Navigation;
+using OrchardCore.Routing;
+using QueryContext = CrestApps.Core.Models.QueryContext;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Controllers;
+
+/// <summary>
+/// Manages web crawlers in the admin area. Each crawl strategy (for example <c>Sitemap</c>) is a source,
+/// so the create flow mirrors the other source-based catalog editors (AI Templates, Data Sources).
+/// </summary>
+public sealed class WebCrawlersController : Controller
+{
+    private const string _optionsSearch = "Options.Search";
+
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IUpdateModelAccessor _updateModelAccessor;
+    private readonly ISourceCatalogManager<WebCrawler> _manager;
+    private readonly IDisplayManager<WebCrawler> _displayManager;
+    private readonly IWebCrawlerReindexPlanner _reindexPlanner;
+    private readonly IReadOnlyList<WebCrawlerStrategyDescriptor> _strategies;
+    private readonly INotifier _notifier;
+
+    internal readonly IHtmlLocalizer H;
+    internal readonly IStringLocalizer S;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlersController"/> class.
+    /// </summary>
+    public WebCrawlersController(
+        IAuthorizationService authorizationService,
+        IUpdateModelAccessor updateModelAccessor,
+        ISourceCatalogManager<WebCrawler> manager,
+        IDisplayManager<WebCrawler> displayManager,
+        IWebCrawlerReindexPlanner reindexPlanner,
+        IOptions<WebCrawlerStrategyOptions> strategyOptions,
+        INotifier notifier,
+        IHtmlLocalizer<WebCrawlersController> htmlLocalizer,
+        IStringLocalizer<WebCrawlersController> stringLocalizer)
+    {
+        _authorizationService = authorizationService;
+        _updateModelAccessor = updateModelAccessor;
+        _manager = manager;
+        _displayManager = displayManager;
+        _reindexPlanner = reindexPlanner;
+        _strategies = strategyOptions.Value.Strategies
+            .OrderBy(strategy => strategy.DisplayName.Value, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        _notifier = notifier;
+        H = htmlLocalizer;
+        S = stringLocalizer;
+    }
+
+    /// <summary>
+    /// Displays a paginated list of web crawlers.
+    /// </summary>
+    [Admin("ai/web-crawlers", "WebCrawlersIndex")]
+    public async Task<IActionResult> Index(
+        CatalogEntryOptions options,
+        PagerParameters pagerParameters,
+        [FromServices] IOptions<PagerOptions> pagerOptions,
+        [FromServices] IShapeFactory shapeFactory)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, WebCrawlerPermissions.ManageWebCrawlers))
+        {
+            return Forbid();
+        }
+
+        var pager = new Pager(pagerParameters, pagerOptions.Value.GetPageSize());
+
+        var result = await _manager.PageAsync(pager.Page, pager.PageSize, new QueryContext
+        {
+            Sorted = true,
+            Name = options.Search,
+        });
+
+        var routeData = new RouteData();
+
+        if (!string.IsNullOrEmpty(options.Search))
+        {
+            routeData.Values.TryAdd(_optionsSearch, options.Search);
+        }
+
+        var viewModel = new ListSourceModelViewModel<WebCrawlerStrategyDescriptor, CatalogEntryViewModel<WebCrawler>>
+        {
+            Models = [],
+            Options = options,
+            Pager = await shapeFactory.PagerAsync(pager, result.Count, routeData),
+            Sources = _strategies,
+        };
+
+        foreach (var model in result.Entries)
+        {
+            viewModel.Models.Add(new CatalogEntryViewModel<WebCrawler>
+            {
+                Model = model,
+                Shape = await _displayManager.BuildDisplayAsync(model, _updateModelAccessor.ModelUpdater, "SummaryAdmin"),
+            });
+        }
+
+        viewModel.Options.BulkActions =
+        [
+            new SelectListItem(S["Delete"], nameof(CatalogEntryAction.Remove)),
+        ];
+
+        return View(viewModel);
+    }
+
+    /// <summary>
+    /// Handles the filter form submission for the web crawlers index page.
+    /// </summary>
+    [HttpPost]
+    [ActionName(nameof(Index))]
+    [FormValueRequired("submit.Filter")]
+    [Admin("ai/web-crawlers", "WebCrawlersIndex")]
+    public async Task<ActionResult> IndexFilterPost(ListCatalogEntryViewModel model)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, WebCrawlerPermissions.ManageWebCrawlers))
+        {
+            return Forbid();
+        }
+
+        return RedirectToAction(nameof(Index), new RouteValueDictionary
+        {
+            { _optionsSearch, model.Options?.Search },
+        });
+    }
+
+    /// <summary>
+    /// Displays the form for creating a new web crawler for the given strategy.
+    /// </summary>
+    /// <param name="source">The crawl strategy identifier.</param>
+    [Admin("ai/web-crawler/create/{source}", "WebCrawlersCreate")]
+    public async Task<ActionResult> Create(string source)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, WebCrawlerPermissions.ManageWebCrawlers))
+        {
+            return Forbid();
+        }
+
+        if (!TryGetStrategy(source, out var strategy))
+        {
+            await _notifier.ErrorAsync(H["Unable to find a crawl strategy with the name '{0}'.", source]);
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        var crawler = await _manager.NewAsync(strategy.Strategy);
+
+        if (crawler == null)
+        {
+            await _notifier.ErrorAsync(H["Unable to create a new web crawler."]);
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        var model = new EditCatalogEntryViewModel
+        {
+            DisplayName = strategy.DisplayName.Value,
+            Editor = await _displayManager.BuildEditorAsync(crawler, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Handles the form submission for creating a new web crawler.
+    /// </summary>
+    /// <param name="source">The crawl strategy identifier.</param>
+    [HttpPost]
+    [ActionName(nameof(Create))]
+    [Admin("ai/web-crawler/create/{source}", "WebCrawlersCreate")]
+    public async Task<ActionResult> CreatePost(string source)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, WebCrawlerPermissions.ManageWebCrawlers))
+        {
+            return Forbid();
+        }
+
+        if (!TryGetStrategy(source, out var strategy))
+        {
+            await _notifier.ErrorAsync(H["Unable to find a crawl strategy with the name '{0}'.", source]);
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        var crawler = await _manager.NewAsync(strategy.Strategy);
+
+        if (crawler == null)
+        {
+            await _notifier.ErrorAsync(H["Unable to create a new web crawler."]);
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        var model = new EditCatalogEntryViewModel
+        {
+            DisplayName = strategy.DisplayName.Value,
+            Editor = await _displayManager.UpdateEditorAsync(crawler, _updateModelAccessor.ModelUpdater, isNew: true),
+        };
+
+        if (ModelState.IsValid)
+        {
+            await _manager.CreateAsync(crawler);
+
+            await _notifier.SuccessAsync(H["Web crawler has been created successfully. Initial synchronization has been queued."]);
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Displays the form for editing an existing web crawler.
+    /// </summary>
+    /// <param name="id">The unique identifier of the crawler to edit.</param>
+    [Admin("ai/web-crawler/edit/{id}", "WebCrawlersEdit")]
+    public async Task<ActionResult> Edit(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, WebCrawlerPermissions.ManageWebCrawlers))
+        {
+            return Forbid();
+        }
+
+        var crawler = await _manager.FindByIdAsync(id);
+
+        if (crawler == null)
+        {
+            return NotFound();
+        }
+
+        var model = new EditCatalogEntryViewModel
+        {
+            DisplayName = crawler.DisplayText,
+            Editor = await _displayManager.BuildEditorAsync(crawler, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Handles the form submission for editing an existing web crawler.
+    /// </summary>
+    /// <param name="id">The unique identifier of the crawler to update.</param>
+    [HttpPost]
+    [ActionName(nameof(Edit))]
+    [Admin("ai/web-crawler/edit/{id}", "WebCrawlersEdit")]
+    public async Task<ActionResult> EditPost(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, WebCrawlerPermissions.ManageWebCrawlers))
+        {
+            return Forbid();
+        }
+
+        var crawler = await _manager.FindByIdAsync(id);
+
+        if (crawler == null)
+        {
+            return NotFound();
+        }
+
+        var model = new EditCatalogEntryViewModel
+        {
+            DisplayName = crawler.DisplayText,
+            Editor = await _displayManager.UpdateEditorAsync(crawler, _updateModelAccessor.ModelUpdater, isNew: false),
+        };
+
+        if (ModelState.IsValid)
+        {
+            await _manager.UpdateAsync(crawler);
+
+            await _notifier.SuccessAsync(H["Web crawler has been updated successfully. Synchronization has been queued."]);
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Deletes a web crawler by its identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the crawler to delete.</param>
+    [HttpPost]
+    [Admin("ai/web-crawler/delete/{id}", "WebCrawlersDelete")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, WebCrawlerPermissions.ManageWebCrawlers))
+        {
+            return Forbid();
+        }
+
+        var crawler = await _manager.FindByIdAsync(id);
+
+        if (crawler == null)
+        {
+            return NotFound();
+        }
+
+        if (await _manager.DeleteAsync(crawler))
+        {
+            await _notifier.SuccessAsync(H["Web crawler has been deleted successfully. Knowledge-base cleanup has been queued."]);
+        }
+        else
+        {
+            await _notifier.ErrorAsync(H["Unable to remove the web crawler."]);
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    /// <summary>
+    /// Re-crawls just this site and queues the new, changed, and removed pages for indexing.
+    /// </summary>
+    /// <param name="id">The unique identifier of the crawler to synchronize.</param>
+    [HttpPost]
+    [Admin("ai/web-crawler/sync/{id}", "WebCrawlersSync")]
+    public async Task<IActionResult> Sync(string id)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, WebCrawlerPermissions.ManageWebCrawlers))
+        {
+            return Forbid();
+        }
+
+        var crawler = await _manager.FindByIdAsync(id);
+
+        if (crawler == null)
+        {
+            return NotFound();
+        }
+
+        var result = await _reindexPlanner.PlanAndEnqueueAsync(crawler, HttpContext.RequestAborted);
+
+        if (result.Status is WebCrawlerReindexStatus.DiscoveryFailed or WebCrawlerReindexStatus.NoPagesDiscovered)
+        {
+            await _notifier.ErrorAsync(H["{0}", result.Message]);
+        }
+        else
+        {
+            await _notifier.SuccessAsync(H["Web crawler synchronization queued: {0} new, {1} changed, {2} removed.", result.NewCount, result.ChangedCount, result.RemovedCount]);
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    /// <summary>
+    /// Handles bulk actions on selected web crawlers.
+    /// </summary>
+    [HttpPost]
+    [ActionName(nameof(Index))]
+    [FormValueRequired("submit.BulkAction")]
+    [Admin("ai/web-crawlers", "WebCrawlersIndex")]
+    public async Task<ActionResult> IndexPost(CatalogEntryOptions options, IEnumerable<string> itemIds)
+    {
+        if (!await _authorizationService.AuthorizeAsync(User, WebCrawlerPermissions.ManageWebCrawlers))
+        {
+            return Forbid();
+        }
+
+        if (itemIds?.Count() > 0)
+        {
+            switch (options.BulkAction)
+            {
+                case CatalogEntryAction.None:
+                    break;
+                case CatalogEntryAction.Remove:
+                    var counter = 0;
+                    foreach (var id in itemIds)
+                    {
+                        var crawler = await _manager.FindByIdAsync(id);
+
+                        if (crawler == null)
+                        {
+                            continue;
+                        }
+
+                        if (await _manager.DeleteAsync(crawler))
+                        {
+                            counter++;
+                        }
+                    }
+                    if (counter == 0)
+                    {
+                        await _notifier.WarningAsync(H["No web crawlers were removed."]);
+                    }
+                    else
+                    {
+                        await _notifier.SuccessAsync(H.Plural(counter, "1 web crawler has been removed successfully.", "{0} web crawlers have been removed successfully."));
+                    }
+                    break;
+                default:
+                    return BadRequest();
+            }
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    private bool TryGetStrategy(string source, out WebCrawlerStrategyDescriptor strategy)
+    {
+        strategy = null;
+
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return false;
+        }
+
+        strategy = _strategies.FirstOrDefault(entry =>
+            string.Equals(entry.Strategy, source, StringComparison.OrdinalIgnoreCase));
+
+        return strategy != null;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/CrestApps.OrchardCore.AI.DataSources.WebCrawlers.csproj
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/CrestApps.OrchardCore.AI.DataSources.WebCrawlers.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <RootNamespace>$(MSBuildProjectName)</RootNamespace>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+    <Title>CrestApps OrchardCore AI Data Sources - Web Crawlers</Title>
+    <Description>
+      $(CrestAppsDescription)
+
+      Adds a Web AI data source that is populated by strategy-based web crawlers (starting with sitemap discovery). Crawlers scrape public websites, index each page into the AI Knowledge Base for RAG, and are re-crawled on a schedule.
+    </Description>
+    <PackageTags>$(PackageTags) OrchardCoreCMS AI DataSources RAG WebCrawler Sitemap</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OrchardCore.Module.Targets" />
+    <PackageReference Include="OrchardCore.DisplayManagement" />
+    <PackageReference Include="OrchardCore.Navigation.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CrestApps.Core.AI.WebCrawlers" />
+    <PackageReference Include="CrestApps.Core.Data.YesSql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Ensure this module directly depends on the AI Data Sources module so that enabling it also enables
+      the Data Sources feature this module extends, without any manual step.
+    -->
+    <ProjectReference Include="../CrestApps.OrchardCore.AI.DataSources/CrestApps.OrchardCore.AI.DataSources.csproj" PrivateAssets="none" />
+  </ItemGroup>
+
+</Project>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Drivers/SitemapWebCrawlerDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Drivers/SitemapWebCrawlerDisplayDriver.cs
@@ -1,0 +1,135 @@
+using System.Text.RegularExpressions;
+using CrestApps.Core;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.WebCrawlers;
+using CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
+using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels;
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Mvc.ModelBinding;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Drivers;
+
+/// <summary>
+/// Display driver for the sitemap crawl-strategy settings. Only renders for crawlers whose strategy is
+/// <see cref="WebCrawlerConstants.Strategies.Sitemap"/>.
+/// </summary>
+internal sealed class SitemapWebCrawlerDisplayDriver : DisplayDriver<WebCrawler>
+{
+    internal readonly IStringLocalizer S;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SitemapWebCrawlerDisplayDriver"/> class.
+    /// </summary>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public SitemapWebCrawlerDisplayDriver(IStringLocalizer<SitemapWebCrawlerDisplayDriver> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    public override IDisplayResult Edit(WebCrawler crawler, BuildEditorContext context)
+    {
+        if (!IsSitemap(crawler))
+        {
+            return null;
+        }
+
+        return Initialize<SitemapWebCrawlerViewModel>("SitemapWebCrawler_Edit", model =>
+        {
+            if (crawler.TryGet<SitemapWebCrawlerMetadata>(out var metadata))
+            {
+                model.BaseUrl = metadata.BaseUrl;
+                model.SitemapUrl = metadata.SitemapUrl;
+                model.MaxPages = metadata.MaxPages;
+                model.MaxConcurrentRequests = metadata.MaxConcurrentRequests;
+                model.RequestTimeoutSeconds = metadata.RequestTimeoutSeconds;
+                model.UserAgent = metadata.UserAgent;
+                model.IncludeUrlPatterns = JoinPatterns(metadata.IncludeUrlPatterns);
+                model.ExcludeUrlPatterns = JoinPatterns(metadata.ExcludeUrlPatterns);
+            }
+        }).Location("Content:5");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(WebCrawler crawler, UpdateEditorContext context)
+    {
+        if (!IsSitemap(crawler))
+        {
+            return null;
+        }
+
+        var model = new SitemapWebCrawlerViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (string.IsNullOrWhiteSpace(model.BaseUrl) && string.IsNullOrWhiteSpace(model.SitemapUrl))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.BaseUrl), S["Provide a base URL or an explicit sitemap URL."]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(model.BaseUrl) && !Uri.TryCreate(model.BaseUrl.Trim(), UriKind.Absolute, out _))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.BaseUrl), S["The base URL must be an absolute URL, for example https://example.com."]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(model.SitemapUrl) && !Uri.TryCreate(model.SitemapUrl.Trim(), UriKind.Absolute, out _))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.SitemapUrl), S["The sitemap URL must be an absolute URL, for example https://example.com/sitemap.xml."]);
+        }
+
+        ValidatePatterns(context, nameof(model.IncludeUrlPatterns), model.IncludeUrlPatterns);
+        ValidatePatterns(context, nameof(model.ExcludeUrlPatterns), model.ExcludeUrlPatterns);
+
+        crawler.Put(new SitemapWebCrawlerMetadata
+        {
+            BaseUrl = model.BaseUrl?.Trim(),
+            SitemapUrl = model.SitemapUrl?.Trim(),
+            MaxPages = model.MaxPages,
+            MaxConcurrentRequests = model.MaxConcurrentRequests,
+            RequestTimeoutSeconds = model.RequestTimeoutSeconds,
+            UserAgent = string.IsNullOrWhiteSpace(model.UserAgent) ? null : model.UserAgent.Trim(),
+            IncludeUrlPatterns = SplitPatterns(model.IncludeUrlPatterns),
+            ExcludeUrlPatterns = SplitPatterns(model.ExcludeUrlPatterns),
+        });
+
+        return Edit(crawler, context);
+    }
+
+    private void ValidatePatterns(UpdateEditorContext context, string field, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        foreach (var pattern in SplitPatterns(value))
+        {
+            try
+            {
+                _ = Regex.Match(string.Empty, pattern);
+            }
+            catch (ArgumentException)
+            {
+                context.Updater.ModelState.AddModelError(Prefix, field, S["'{0}' is not a valid regular expression.", pattern]);
+            }
+        }
+    }
+
+    private static bool IsSitemap(WebCrawler crawler)
+        => string.Equals(crawler.Source, WebCrawlerConstants.Strategies.Sitemap, StringComparison.OrdinalIgnoreCase);
+
+    private static string JoinPatterns(IEnumerable<string> patterns)
+        => patterns is null ? null : string.Join('\n', patterns);
+
+    private static List<string> SplitPatterns(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return [];
+        }
+
+        return value
+            .Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Drivers/WebAIDataSourceDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Drivers/WebAIDataSourceDisplayDriver.cs
@@ -1,0 +1,23 @@
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Drivers;
+
+/// <summary>
+/// Adds an informational section to the Web AI data source editor explaining that the sites to scrape are
+/// managed as separate web crawlers. The Web source itself has no connection settings.
+/// </summary>
+internal sealed class WebAIDataSourceDisplayDriver : DisplayDriver<AIDataSource>
+{
+    public override IDisplayResult Edit(AIDataSource dataSource, BuildEditorContext context)
+    {
+        if (!string.Equals(dataSource.Source, AIDataSourceSourceTypes.Web, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return View("WebAIDataSource_Edit", dataSource).Location("Content:1");
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Drivers/WebCrawlerDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Drivers/WebCrawlerDisplayDriver.cs
@@ -1,0 +1,93 @@
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Mvc.ModelBinding;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Drivers;
+
+/// <summary>
+/// Display driver for the fields shared by every web-crawler strategy: display name, target Web data
+/// source, enabled flag, and re-index interval.
+/// </summary>
+internal sealed class WebCrawlerDisplayDriver : DisplayDriver<WebCrawler>
+{
+    private readonly IAIDataSourceStore _dataSourceStore;
+
+    internal readonly IStringLocalizer S;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlerDisplayDriver"/> class.
+    /// </summary>
+    /// <param name="dataSourceStore">The AI data source store.</param>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public WebCrawlerDisplayDriver(
+        IAIDataSourceStore dataSourceStore,
+        IStringLocalizer<WebCrawlerDisplayDriver> stringLocalizer)
+    {
+        _dataSourceStore = dataSourceStore;
+        S = stringLocalizer;
+    }
+
+    public override Task<IDisplayResult> DisplayAsync(WebCrawler crawler, BuildDisplayContext context)
+    {
+        return CombineAsync(
+            View("WebCrawler_Fields_SummaryAdmin", crawler).Location("Content:1"),
+            View("WebCrawler_Buttons_SummaryAdmin", crawler).Location("Actions:5"),
+            View("WebCrawler_DefaultMeta_SummaryAdmin", crawler).Location("Meta:5"),
+            View("WebCrawler_ActionsMenu_SummaryAdmin", crawler).Location("ActionsMenu:10")
+        );
+    }
+
+    public override IDisplayResult Edit(WebCrawler crawler, BuildEditorContext context)
+    {
+        return Initialize<WebCrawlerFieldsViewModel>("WebCrawlerFields_Edit", async model =>
+        {
+            model.DisplayText = crawler.DisplayText;
+            model.AIDataSourceId = crawler.AIDataSourceId;
+            model.Enabled = crawler.Enabled;
+            model.ReindexIntervalMinutes = crawler.ReindexIntervalMinutes;
+
+            var dataSources = await _dataSourceStore.GetAsync(AIDataSourceSourceTypes.Web);
+
+            model.DataSources = dataSources
+                .OrderBy(dataSource => dataSource.DisplayText, StringComparer.OrdinalIgnoreCase)
+                .Select(dataSource => new SelectListItem(dataSource.DisplayText, dataSource.ItemId))
+                .ToArray();
+
+            model.HasDataSources = model.DataSources.Any();
+        }).Location("Content:1");
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(WebCrawler crawler, UpdateEditorContext context)
+    {
+        var model = new WebCrawlerFieldsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (string.IsNullOrWhiteSpace(model.DisplayText))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.DisplayText), S["The name is required."]);
+        }
+
+        if (string.IsNullOrWhiteSpace(model.AIDataSourceId))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.AIDataSourceId), S["A target Web data source is required."]);
+        }
+
+        if (model.ReindexIntervalMinutes is < 1)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.ReindexIntervalMinutes), S["The re-index interval must be a positive number of minutes."]);
+        }
+
+        crawler.DisplayText = model.DisplayText?.Trim();
+        crawler.AIDataSourceId = model.AIDataSourceId?.Trim();
+        crawler.Enabled = model.Enabled;
+        crawler.ReindexIntervalMinutes = model.ReindexIntervalMinutes;
+
+        return Edit(crawler, context);
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Manifest.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Manifest.cs
@@ -1,0 +1,16 @@
+using CrestApps.OrchardCore;
+using CrestApps.OrchardCore.AI.Core;
+using OrchardCore.Modules.Manifest;
+
+[assembly: Module(
+    Name = "AI Data Sources - Web Crawlers",
+    Description = "Adds a Web AI data source populated by strategy-based web crawlers that scrape public websites (starting with sitemap discovery) and index each page into the AI Knowledge Base for RAG.",
+    Author = CrestAppsManifestConstants.Author,
+    Website = CrestAppsManifestConstants.Website,
+    Version = CrestAppsManifestConstants.Version,
+    Category = "Artificial Intelligence - Knowledgebase",
+    Dependencies =
+    [
+        AIConstants.Feature.DataSources,
+    ]
+)]

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Migrations/WebCrawlerIndexMigrations.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Migrations/WebCrawlerIndexMigrations.cs
@@ -1,0 +1,34 @@
+using CrestApps.Core.Data.YesSql;
+using CrestApps.Core.Data.YesSql.Indexes.WebCrawlers;
+using Microsoft.Extensions.Options;
+using OrchardCore.Data.Migration;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Migrations;
+
+/// <summary>
+/// Creates the YesSql index tables backing the web-crawler stores.
+/// </summary>
+internal sealed class WebCrawlerIndexMigrations : DataMigration
+{
+    private readonly YesSqlStoreOptions _option;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlerIndexMigrations"/> class.
+    /// </summary>
+    /// <param name="option">The YesSql store options.</param>
+    public WebCrawlerIndexMigrations(IOptions<YesSqlStoreOptions> option)
+    {
+        _option = option.Value;
+    }
+
+    /// <summary>
+    /// Creates the web crawler and web crawl-state index schemas.
+    /// </summary>
+    public async Task<int> CreateAsync()
+    {
+        await SchemaBuilder.CreateWebCrawlerIndexSchemaAsync(_option);
+        await SchemaBuilder.CreateWebCrawlStateIndexSchemaAsync(_option);
+
+        return 1;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Services/WebCrawlerAdminMenu.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Services/WebCrawlerAdminMenu.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Localization;
+using OrchardCore.Navigation;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Services;
+
+/// <summary>
+/// Adds the Web Crawlers entry to the Artificial Intelligence admin menu.
+/// </summary>
+public sealed class WebCrawlerAdminMenu : AdminNavigationProvider
+{
+    internal readonly IStringLocalizer S;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlerAdminMenu"/> class.
+    /// </summary>
+    /// <param name="stringLocalizer">The string localizer.</param>
+    public WebCrawlerAdminMenu(IStringLocalizer<WebCrawlerAdminMenu> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    protected override ValueTask BuildAsync(NavigationBuilder builder)
+    {
+        builder
+            .Add(S["Artificial Intelligence"], ai => ai
+                .Add(S["Web Crawlers"], S["Web Crawlers"].PrefixPosition(), webCrawlers => webCrawlers
+                    .AddClass("ai-web-crawlers")
+                    .Id("aiWebCrawlers")
+                    .Action("Index", "WebCrawlers", "CrestApps.OrchardCore.AI.DataSources.WebCrawlers")
+                    .Permission(WebCrawlerPermissions.ManageWebCrawlers)
+                    .LocalNav()
+                )
+            );
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Services/WebCrawlerPermissionProvider.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Services/WebCrawlerPermissionProvider.cs
@@ -1,0 +1,30 @@
+using OrchardCore;
+using OrchardCore.Security.Permissions;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Services;
+
+internal sealed class WebCrawlerPermissionProvider : IPermissionProvider
+{
+    private readonly IEnumerable<Permission> _allPermissions =
+    [
+        WebCrawlerPermissions.ManageWebCrawlers,
+    ];
+
+    /// <summary>
+    /// Retrieves the permissions async.
+    /// </summary>
+    public Task<IEnumerable<Permission>> GetPermissionsAsync()
+        => Task.FromResult(_allPermissions);
+
+    /// <summary>
+    /// Retrieves the default stereotypes.
+    /// </summary>
+    public IEnumerable<PermissionStereotype> GetDefaultStereotypes() =>
+    [
+        new PermissionStereotype
+        {
+            Name = OrchardCoreConstants.Roles.Administrator,
+            Permissions = _allPermissions,
+        },
+    ];
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Startup.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Startup.cs
@@ -1,0 +1,44 @@
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.WebCrawlers;
+using CrestApps.Core.Data.YesSql;
+using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.BackgroundTasks;
+using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Drivers;
+using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Migrations;
+using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.Services;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.BackgroundTasks;
+using OrchardCore.Data.Migration;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.Modules;
+using OrchardCore.Navigation;
+using OrchardCore.Security.Permissions;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers;
+
+/// <summary>
+/// Registers services and configuration for the Web Crawlers feature.
+/// </summary>
+public sealed class Startup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        // Registers the Web AI data source source handler, the crawl strategies (sitemap), the re-index
+        // planner and service, the crawler catalog handler, and the shared crawling primitives.
+        services.AddCoreWebCrawlers();
+
+        // Registers the YesSql-backed IWebCrawlerStore and IWebCrawlStateStore plus their index providers.
+        // The crawler indexes live in the AI collection, which the AI feature (a dependency) initializes.
+        services.AddCoreWebCrawlerStoresYesSql();
+
+        services.AddDataMigration<WebCrawlerIndexMigrations>();
+
+        services.AddDisplayDriver<WebCrawler, WebCrawlerDisplayDriver>();
+        services.AddDisplayDriver<WebCrawler, SitemapWebCrawlerDisplayDriver>();
+        services.AddDisplayDriver<AIDataSource, WebAIDataSourceDisplayDriver>();
+
+        services.AddPermissionProvider<WebCrawlerPermissionProvider>();
+        services.AddNavigationProvider<WebCrawlerAdminMenu>();
+
+        services.AddSingleton<IBackgroundTask, WebCrawlerReindexBackgroundTask>();
+    }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/ViewModels/SitemapWebCrawlerViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/ViewModels/SitemapWebCrawlerViewModel.cs
@@ -1,0 +1,48 @@
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels;
+
+/// <summary>
+/// View model for the sitemap crawl-strategy settings. Include/exclude patterns are edited as one
+/// newline-separated value per box and are stored as a list of regular-expression patterns.
+/// </summary>
+public sealed class SitemapWebCrawlerViewModel
+{
+    /// <summary>
+    /// Gets or sets the base URL of the site to scrape.
+    /// </summary>
+    public string BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets an explicit sitemap or sitemap-index URL.
+    /// </summary>
+    public string SitemapUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of pages to scrape.
+    /// </summary>
+    public int? MaxPages { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent page requests.
+    /// </summary>
+    public int? MaxConcurrentRequests { get; set; }
+
+    /// <summary>
+    /// Gets or sets the per-request fetch timeout, in seconds.
+    /// </summary>
+    public int? RequestTimeoutSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the User-Agent header presented while crawling.
+    /// </summary>
+    public string UserAgent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the newline-separated include URL regular-expression patterns.
+    /// </summary>
+    public string IncludeUrlPatterns { get; set; }
+
+    /// <summary>
+    /// Gets or sets the newline-separated exclude URL regular-expression patterns.
+    /// </summary>
+    public string ExcludeUrlPatterns { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/ViewModels/SitemapWebCrawlerViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/ViewModels/SitemapWebCrawlerViewModel.cs
@@ -4,7 +4,7 @@ namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels;
 /// View model for the sitemap crawl-strategy settings. Include/exclude patterns are edited as one
 /// newline-separated value per box and are stored as a list of regular-expression patterns.
 /// </summary>
-public sealed class SitemapWebCrawlerViewModel
+public class SitemapWebCrawlerViewModel
 {
     /// <summary>
     /// Gets or sets the base URL of the site to scrape.

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/ViewModels/WebCrawlerFieldsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/ViewModels/WebCrawlerFieldsViewModel.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels;
+
+/// <summary>
+/// View model for the fields shared by every web-crawler strategy.
+/// </summary>
+public sealed class WebCrawlerFieldsViewModel
+{
+    /// <summary>
+    /// Gets or sets the human-readable display name of the crawler.
+    /// </summary>
+    public string DisplayText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the target Web AI data source that receives the scraped pages.
+    /// </summary>
+    public string AIDataSourceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this crawler is active.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets how often, in minutes, the background task re-crawls this site. Empty uses the default.
+    /// </summary>
+    public int? ReindexIntervalMinutes { get; set; }
+
+    [BindNever]
+    public IEnumerable<SelectListItem> DataSources { get; set; } = [];
+
+    [BindNever]
+    public bool HasDataSources { get; set; }
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/ViewModels/WebCrawlerFieldsViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/ViewModels/WebCrawlerFieldsViewModel.cs
@@ -6,7 +6,7 @@ namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels;
 /// <summary>
 /// View model for the fields shared by every web-crawler strategy.
 /// </summary>
-public sealed class WebCrawlerFieldsViewModel
+public class WebCrawlerFieldsViewModel
 {
     /// <summary>
     /// Gets or sets the human-readable display name of the crawler.

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/Items/WebCrawler.ActionsMenu.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/Items/WebCrawler.ActionsMenu.SummaryAdmin.cshtml
@@ -1,0 +1,30 @@
+@using CrestApps.Core.AI.Models
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<WebCrawler>
+
+<li>
+    <a asp-action="Sync"
+       asp-controller="WebCrawlers"
+       asp-area="CrestApps.OrchardCore.AI.DataSources.WebCrawlers"
+       asp-route-id="@Model.Value.ItemId"
+       class="dropdown-item"
+       data-url-af="UnsafeUrl"
+       data-title="@T["Synchronize"]"
+       data-message="@T["Are you sure you want to re-crawl this site and queue its changed pages for indexing?"]"
+       data-ok-text="@T["Yes"]"
+       data-cancel-text="@T["Cancel"]">@T["Synchronize now"]</a>
+</li>
+
+<li>
+    <a asp-action="Delete"
+       asp-controller="WebCrawlers"
+       asp-area="CrestApps.OrchardCore.AI.DataSources.WebCrawlers"
+       asp-route-id="@Model.Value.ItemId"
+       class="dropdown-item text-danger"
+       data-url-af="RemoveUrl UnsafeUrl"
+       data-title="@T["Delete"]"
+       data-message="@T["Are you sure you want to delete this web crawler?"]"
+       data-ok-text="@T["Yes"]"
+       data-cancel-text="@T["Cancel"]">@T["Delete"]</a>
+</li>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/Items/WebCrawler.Buttons.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/Items/WebCrawler.Buttons.SummaryAdmin.cshtml
@@ -1,0 +1,10 @@
+@using CrestApps.Core.AI.Models
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<WebCrawler>
+
+<a asp-action="Edit"
+   asp-controller="WebCrawlers"
+   asp-area="CrestApps.OrchardCore.AI.DataSources.WebCrawlers"
+   asp-route-id="@Model.Value.ItemId"
+   class="btn btn-primary btn-sm">@T["Edit"]</a>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/Items/WebCrawler.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/Items/WebCrawler.DefaultMeta.SummaryAdmin.cshtml
@@ -1,0 +1,19 @@
+@using System.Globalization
+@using CrestApps.Core.AI.Models
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<WebCrawler>
+
+@{
+    var modifiedAt = Model.Value.ModifiedUtc ?? Model.Value.CreatedUtc;
+}
+
+<span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: modifiedAt, Format: "g"))">
+    <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i>
+    <time datetime="@modifiedAt.ToString(DateTimeFormatConstants.HtmlDateTimeOffset, CultureInfo.InvariantCulture)">@await DisplayAsync(await New.Timespan(Utc: modifiedAt))</time>
+</span>
+
+@if (!string.IsNullOrEmpty(Model.Value.Author))
+{
+    <user-display-name user-name="@(Model.Value.Author)" display-type="SummaryAdmin" cache-id="user-display-name-author" />
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/Items/WebCrawler.Fields.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/Items/WebCrawler.Fields.SummaryAdmin.cshtml
@@ -1,0 +1,15 @@
+@using CrestApps.Core.AI.Models
+@using OrchardCore.DisplayManagement.Views
+
+@model ShapeViewModel<WebCrawler>
+
+<h5>
+    @(Model.Value.DisplayText)
+    @if (!Model.Value.Enabled)
+    {
+        <span class="badge bg-secondary align-middle">@T["Disabled"]</span>
+    }
+</h5>
+<div class="text-muted small">
+    <span class="badge bg-light text-dark">@Model.Value.Source</span>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/SitemapWebCrawler.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/SitemapWebCrawler.Edit.cshtml
@@ -1,6 +1,14 @@
 @using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels
+@using CrestApps.Core.AI.WebCrawlers
+@using Microsoft.Extensions.Options
+
+@inject IOptions<WebCrawlerOptions> WebCrawlerOptions
 
 @model SitemapWebCrawlerViewModel
+
+@{
+    var crawlerDefaults = WebCrawlerOptions.Value;
+}
 
 <fieldset class="ocat-wrapper">
     <legend class="ocat-label">@T["Sitemap Strategy"]</legend>
@@ -24,21 +32,21 @@
                 <label asp-for="MaxPages" class="form-label">@T["Max pages"]</label>
                 <input asp-for="MaxPages" class="form-control" type="number" min="1" />
                 <span asp-validation-for="MaxPages" class="text-danger"></span>
-                <span class="hint">@T["The most pages to scrape per crawl. Leave empty to use the default (500)."]</span>
+                <span class="hint">@T["The most pages to scrape per crawl. Leave empty to use the default ({0}).", crawlerDefaults.DefaultMaxPages]</span>
             </div>
 
             <div class="col-md-4 mb-3">
                 <label asp-for="MaxConcurrentRequests" class="form-label">@T["Max concurrent requests"]</label>
                 <input asp-for="MaxConcurrentRequests" class="form-control" type="number" min="1" />
                 <span asp-validation-for="MaxConcurrentRequests" class="text-danger"></span>
-                <span class="hint">@T["How many pages are fetched in parallel. Leave empty to use the default (4). Keep this low to be polite to the target site."]</span>
+                <span class="hint">@T["How many pages are fetched in parallel. Leave empty to use the default ({0}). Keep this low to be polite to the target site.", crawlerDefaults.DefaultMaxConcurrentRequests]</span>
             </div>
 
             <div class="col-md-4 mb-3">
                 <label asp-for="RequestTimeoutSeconds" class="form-label">@T["Request timeout (seconds)"]</label>
                 <input asp-for="RequestTimeoutSeconds" class="form-control" type="number" min="1" />
                 <span asp-validation-for="RequestTimeoutSeconds" class="text-danger"></span>
-                <span class="hint">@T["Per-request fetch timeout. Leave empty to use the default (30 seconds)."]</span>
+                <span class="hint">@T["Per-request fetch timeout. Leave empty to use the default ({0} seconds).", crawlerDefaults.DefaultRequestTimeoutSeconds]</span>
             </div>
         </div>
 

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/SitemapWebCrawler.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/SitemapWebCrawler.Edit.cshtml
@@ -1,0 +1,65 @@
+@using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels
+
+@model SitemapWebCrawlerViewModel
+
+<fieldset class="border rounded p-3 mb-3">
+    <legend class="float-none w-auto px-2 fs-6 text-muted">@T["Sitemap Strategy"]</legend>
+
+    <div class="mb-3" asp-validation-class-for="BaseUrl">
+        <label asp-for="BaseUrl" class="form-label">@T["Base URL"]</label>
+        <input asp-for="BaseUrl" class="form-control" placeholder="https://example.com" />
+        <span asp-validation-for="BaseUrl"></span>
+        <span class="hint">@T["The site to scrape. The crawler discovers the sitemap from <code>robots.txt</code> and the conventional locations (for example <code>/sitemap.xml</code>). Provide this or an explicit sitemap URL below."]</span>
+    </div>
+
+    <div class="mb-3" asp-validation-class-for="SitemapUrl">
+        <label asp-for="SitemapUrl" class="form-label">@T["Sitemap URL (optional)"]</label>
+        <input asp-for="SitemapUrl" class="form-control" placeholder="https://example.com/sitemap.xml" />
+        <span asp-validation-for="SitemapUrl"></span>
+        <span class="hint">@T["An explicit sitemap or sitemap-index URL. When set, discovery starts here instead of probing the base URL. Supports nested sitemap indexes, gzip, plain-text, and RSS/Atom feeds."]</span>
+    </div>
+
+    <div class="row">
+        <div class="col-md-4 mb-3" asp-validation-class-for="MaxPages">
+            <label asp-for="MaxPages" class="form-label">@T["Max pages"]</label>
+            <input asp-for="MaxPages" class="form-control" type="number" min="1" />
+            <span asp-validation-for="MaxPages"></span>
+            <span class="hint">@T["The most pages to scrape per crawl. Leave empty to use the default (500)."]</span>
+        </div>
+
+        <div class="col-md-4 mb-3" asp-validation-class-for="MaxConcurrentRequests">
+            <label asp-for="MaxConcurrentRequests" class="form-label">@T["Max concurrent requests"]</label>
+            <input asp-for="MaxConcurrentRequests" class="form-control" type="number" min="1" />
+            <span asp-validation-for="MaxConcurrentRequests"></span>
+            <span class="hint">@T["How many pages are fetched in parallel. Leave empty to use the default (4). Keep this low to be polite to the target site."]</span>
+        </div>
+
+        <div class="col-md-4 mb-3" asp-validation-class-for="RequestTimeoutSeconds">
+            <label asp-for="RequestTimeoutSeconds" class="form-label">@T["Request timeout (seconds)"]</label>
+            <input asp-for="RequestTimeoutSeconds" class="form-control" type="number" min="1" />
+            <span asp-validation-for="RequestTimeoutSeconds"></span>
+            <span class="hint">@T["Per-request fetch timeout. Leave empty to use the default (30 seconds)."]</span>
+        </div>
+    </div>
+
+    <div class="mb-3" asp-validation-class-for="IncludeUrlPatterns">
+        <label asp-for="IncludeUrlPatterns" class="form-label">@T["Include URL patterns"]</label>
+        <textarea asp-for="IncludeUrlPatterns" class="form-control" rows="3" placeholder="^https://example\.com/docs/"></textarea>
+        <span asp-validation-for="IncludeUrlPatterns"></span>
+        <span class="hint">@T["One <strong>regular expression</strong> per line. A discovered page is scraped only when its full URL matches <strong>at least one</strong> of these patterns. Leave empty to allow every discovered page. Example: <code>^https://example\\.com/docs/</code> keeps only pages under <code>/docs/</code>."]</span>
+    </div>
+
+    <div class="mb-3" asp-validation-class-for="ExcludeUrlPatterns">
+        <label asp-for="ExcludeUrlPatterns" class="form-label">@T["Exclude URL patterns"]</label>
+        <textarea asp-for="ExcludeUrlPatterns" class="form-control" rows="3" placeholder="/tag/|/author/|\.pdf$"></textarea>
+        <span asp-validation-for="ExcludeUrlPatterns"></span>
+        <span class="hint">@T["One <strong>regular expression</strong> per line. A page is skipped when its URL matches <strong>any</strong> of these patterns. Exclusions are applied <strong>after</strong> the include patterns, so exclude wins. Example: <code>/tag/|/author/</code> drops taxonomy and author pages."]</span>
+    </div>
+
+    <div class="mb-3" asp-validation-class-for="UserAgent">
+        <label asp-for="UserAgent" class="form-label">@T["User-Agent (optional)"]</label>
+        <input asp-for="UserAgent" class="form-control" />
+        <span asp-validation-for="UserAgent"></span>
+        <span class="hint">@T["The <code>User-Agent</code> header sent while crawling. Leave empty to use the default. Some sites require a recognizable agent to serve content."]</span>
+    </div>
+</fieldset>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/SitemapWebCrawler.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/SitemapWebCrawler.Edit.cshtml
@@ -2,64 +2,65 @@
 
 @model SitemapWebCrawlerViewModel
 
-<fieldset class="border rounded p-3 mb-3">
-    <legend class="float-none w-auto px-2 fs-6 text-muted">@T["Sitemap Strategy"]</legend>
-
-    <div class="mb-3" asp-validation-class-for="BaseUrl">
-        <label asp-for="BaseUrl" class="form-label">@T["Base URL"]</label>
-        <input asp-for="BaseUrl" class="form-control" placeholder="https://example.com" />
-        <span asp-validation-for="BaseUrl"></span>
-        <span class="hint">@T["The site to scrape. The crawler discovers the sitemap from <code>robots.txt</code> and the conventional locations (for example <code>/sitemap.xml</code>). Provide this or an explicit sitemap URL below."]</span>
-    </div>
-
-    <div class="mb-3" asp-validation-class-for="SitemapUrl">
-        <label asp-for="SitemapUrl" class="form-label">@T["Sitemap URL (optional)"]</label>
-        <input asp-for="SitemapUrl" class="form-control" placeholder="https://example.com/sitemap.xml" />
-        <span asp-validation-for="SitemapUrl"></span>
-        <span class="hint">@T["An explicit sitemap or sitemap-index URL. When set, discovery starts here instead of probing the base URL. Supports nested sitemap indexes, gzip, plain-text, and RSS/Atom feeds."]</span>
-    </div>
-
-    <div class="row">
-        <div class="col-md-4 mb-3" asp-validation-class-for="MaxPages">
-            <label asp-for="MaxPages" class="form-label">@T["Max pages"]</label>
-            <input asp-for="MaxPages" class="form-control" type="number" min="1" />
-            <span asp-validation-for="MaxPages"></span>
-            <span class="hint">@T["The most pages to scrape per crawl. Leave empty to use the default (500)."]</span>
+<fieldset class="ocat-wrapper">
+    <legend class="ocat-label">@T["Sitemap Strategy"]</legend>
+    <div class="ocat-end">
+        <div class="mb-3">
+            <label asp-for="BaseUrl" class="form-label">@T["Base URL"]</label>
+            <input asp-for="BaseUrl" class="form-control" placeholder="https://example.com" />
+            <span asp-validation-for="BaseUrl" class="text-danger"></span>
+            <span class="hint">@T["The site to scrape. The crawler discovers the sitemap from <code>robots.txt</code> and the conventional locations (for example <code>/sitemap.xml</code>). Provide this or an explicit sitemap URL below."]</span>
         </div>
 
-        <div class="col-md-4 mb-3" asp-validation-class-for="MaxConcurrentRequests">
-            <label asp-for="MaxConcurrentRequests" class="form-label">@T["Max concurrent requests"]</label>
-            <input asp-for="MaxConcurrentRequests" class="form-control" type="number" min="1" />
-            <span asp-validation-for="MaxConcurrentRequests"></span>
-            <span class="hint">@T["How many pages are fetched in parallel. Leave empty to use the default (4). Keep this low to be polite to the target site."]</span>
+        <div class="mb-3">
+            <label asp-for="SitemapUrl" class="form-label">@T["Sitemap URL (optional)"]</label>
+            <input asp-for="SitemapUrl" class="form-control" placeholder="https://example.com/sitemap.xml" />
+            <span asp-validation-for="SitemapUrl" class="text-danger"></span>
+            <span class="hint">@T["An explicit sitemap or sitemap-index URL. When set, discovery starts here instead of probing the base URL. Supports nested sitemap indexes, gzip, plain-text, and RSS/Atom feeds."]</span>
         </div>
 
-        <div class="col-md-4 mb-3" asp-validation-class-for="RequestTimeoutSeconds">
-            <label asp-for="RequestTimeoutSeconds" class="form-label">@T["Request timeout (seconds)"]</label>
-            <input asp-for="RequestTimeoutSeconds" class="form-control" type="number" min="1" />
-            <span asp-validation-for="RequestTimeoutSeconds"></span>
-            <span class="hint">@T["Per-request fetch timeout. Leave empty to use the default (30 seconds)."]</span>
+        <div class="row">
+            <div class="col-md-4 mb-3">
+                <label asp-for="MaxPages" class="form-label">@T["Max pages"]</label>
+                <input asp-for="MaxPages" class="form-control" type="number" min="1" />
+                <span asp-validation-for="MaxPages" class="text-danger"></span>
+                <span class="hint">@T["The most pages to scrape per crawl. Leave empty to use the default (500)."]</span>
+            </div>
+
+            <div class="col-md-4 mb-3">
+                <label asp-for="MaxConcurrentRequests" class="form-label">@T["Max concurrent requests"]</label>
+                <input asp-for="MaxConcurrentRequests" class="form-control" type="number" min="1" />
+                <span asp-validation-for="MaxConcurrentRequests" class="text-danger"></span>
+                <span class="hint">@T["How many pages are fetched in parallel. Leave empty to use the default (4). Keep this low to be polite to the target site."]</span>
+            </div>
+
+            <div class="col-md-4 mb-3">
+                <label asp-for="RequestTimeoutSeconds" class="form-label">@T["Request timeout (seconds)"]</label>
+                <input asp-for="RequestTimeoutSeconds" class="form-control" type="number" min="1" />
+                <span asp-validation-for="RequestTimeoutSeconds" class="text-danger"></span>
+                <span class="hint">@T["Per-request fetch timeout. Leave empty to use the default (30 seconds)."]</span>
+            </div>
         </div>
-    </div>
 
-    <div class="mb-3" asp-validation-class-for="IncludeUrlPatterns">
-        <label asp-for="IncludeUrlPatterns" class="form-label">@T["Include URL patterns"]</label>
-        <textarea asp-for="IncludeUrlPatterns" class="form-control" rows="3" placeholder="^https://example\.com/docs/"></textarea>
-        <span asp-validation-for="IncludeUrlPatterns"></span>
-        <span class="hint">@T["One <strong>regular expression</strong> per line. A discovered page is scraped only when its full URL matches <strong>at least one</strong> of these patterns. Leave empty to allow every discovered page. Example: <code>^https://example\\.com/docs/</code> keeps only pages under <code>/docs/</code>."]</span>
-    </div>
+        <div class="mb-3">
+            <label asp-for="IncludeUrlPatterns" class="form-label">@T["Include URL patterns"]</label>
+            <textarea asp-for="IncludeUrlPatterns" class="form-control" rows="3" placeholder="^https://example\.com/docs/"></textarea>
+            <span asp-validation-for="IncludeUrlPatterns" class="text-danger"></span>
+            <span class="hint">@T["One <strong>regular expression</strong> per line. A discovered page is scraped only when its full URL matches <strong>at least one</strong> of these patterns. Leave empty to allow every discovered page. Example: <code>^https://example\\.com/docs/</code> keeps only pages under <code>/docs/</code>."]</span>
+        </div>
 
-    <div class="mb-3" asp-validation-class-for="ExcludeUrlPatterns">
-        <label asp-for="ExcludeUrlPatterns" class="form-label">@T["Exclude URL patterns"]</label>
-        <textarea asp-for="ExcludeUrlPatterns" class="form-control" rows="3" placeholder="/tag/|/author/|\.pdf$"></textarea>
-        <span asp-validation-for="ExcludeUrlPatterns"></span>
-        <span class="hint">@T["One <strong>regular expression</strong> per line. A page is skipped when its URL matches <strong>any</strong> of these patterns. Exclusions are applied <strong>after</strong> the include patterns, so exclude wins. Example: <code>/tag/|/author/</code> drops taxonomy and author pages."]</span>
-    </div>
+        <div class="mb-3">
+            <label asp-for="ExcludeUrlPatterns" class="form-label">@T["Exclude URL patterns"]</label>
+            <textarea asp-for="ExcludeUrlPatterns" class="form-control" rows="3" placeholder="/tag/|/author/|\.pdf$"></textarea>
+            <span asp-validation-for="ExcludeUrlPatterns" class="text-danger"></span>
+            <span class="hint">@T["One <strong>regular expression</strong> per line. A page is skipped when its URL matches <strong>any</strong> of these patterns. Exclusions are applied <strong>after</strong> the include patterns, so exclude wins. Example: <code>/tag/|/author/</code> drops taxonomy and author pages."]</span>
+        </div>
 
-    <div class="mb-3" asp-validation-class-for="UserAgent">
-        <label asp-for="UserAgent" class="form-label">@T["User-Agent (optional)"]</label>
-        <input asp-for="UserAgent" class="form-control" />
-        <span asp-validation-for="UserAgent"></span>
-        <span class="hint">@T["The <code>User-Agent</code> header sent while crawling. Leave empty to use the default. Some sites require a recognizable agent to serve content."]</span>
+        <div class="mb-0">
+            <label asp-for="UserAgent" class="form-label">@T["User-Agent (optional)"]</label>
+            <input asp-for="UserAgent" class="form-control" />
+            <span asp-validation-for="UserAgent" class="text-danger"></span>
+            <span class="hint">@T["The <code>User-Agent</code> header sent while crawling. Leave empty to use the default. Some sites require a recognizable agent to serve content."]</span>
+        </div>
     </div>
 </fieldset>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebAIDataSource.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebAIDataSource.Edit.cshtml
@@ -1,11 +1,16 @@
 @using CrestApps.Core.AI.Models
+@using OrchardCore.DisplayManagement.Views
 
-@model AIDataSource
+@model ShapeViewModel<AIDataSource>
 
-<div class="alert alert-info" role="alert">
-    <h5 class="alert-heading">@T["Web data source"]</h5>
-    <p class="mb-1">@T["This data source has no connection settings of its own. It is a target bucket that aggregates every enabled web crawler pointing at it."]</p>
-    <p class="mb-0">
-        @T["After you save, configure the sites to scrape under <strong>Artificial Intelligence &gt; Web Crawlers</strong>. Each scraped page is indexed with its URL kept for citations."]
-    </p>
+<div class="ocat-wrapper">
+    <div class="ocat-end-offset">
+        <div class="alert alert-info mb-0" role="alert">
+            <h5 class="alert-heading">@T["Web data source"]</h5>
+            <p class="mb-1">@T["This data source has no connection settings of its own. It is a target bucket that aggregates every enabled web crawler pointing at it."]</p>
+            <p class="mb-0">
+                @T["After you save, configure the sites to scrape under <strong>Artificial Intelligence &gt; Web Crawlers</strong>. Each scraped page is indexed with its URL kept for citations."]
+            </p>
+        </div>
+    </div>
 </div>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebAIDataSource.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebAIDataSource.Edit.cshtml
@@ -1,0 +1,11 @@
+@using CrestApps.Core.AI.Models
+
+@model AIDataSource
+
+<div class="alert alert-info" role="alert">
+    <h5 class="alert-heading">@T["Web data source"]</h5>
+    <p class="mb-1">@T["This data source has no connection settings of its own. It is a target bucket that aggregates every enabled web crawler pointing at it."]</p>
+    <p class="mb-0">
+        @T["After you save, configure the sites to scrape under <strong>Artificial Intelligence &gt; Web Crawlers</strong>. Each scraped page is indexed with its URL kept for citations."]
+    </p>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawler.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawler.Edit.cshtml
@@ -1,0 +1,1 @@
+@await DisplayAsync(Model.Content)

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawler.SummaryAdmin.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawler.SummaryAdmin.cshtml
@@ -1,0 +1,43 @@
+<div class="row g-0">
+    <div class="col-lg col-12 title d-flex align-items-center">
+
+        <div class="summary">
+            <div class="d-flex flex-column flex-md-row">
+                <div class="me-2">
+                    @if (Model.Content != null)
+                    {
+                        @await DisplayAsync(Model.Content)
+                    }
+                </div>
+
+                @if (Model.Meta != null)
+                {
+                    <div class="metadata me-1">
+                        @await DisplayAsync(Model.Meta)
+                    </div>
+                }
+            </div>
+        </div>
+
+    </div>
+    <div class="col-lg-auto col-12 d-flex justify-content-end align-items-center">
+        <div class="actions">
+            @if (Model.Actions != null)
+            {
+                @await DisplayAsync(Model.Actions)
+            }
+
+            @if (Model.ActionsMenu != null && Model.ActionsMenu.HasItems)
+            {
+                <div class="btn-group" title="@T["Actions"]">
+                    <button type="button" class="btn btn-sm btn-secondary dropdown-toggle actions" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span>@T["Actions"]</span>
+                    </button>
+                    <ul class="actions-menu dropdown-menu dropdown-menu-end">
+                        @await DisplayAsync(Model.ActionsMenu)
+                    </ul>
+                </div>
+            }
+        </div>
+    </div>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlerFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlerFields.Edit.cshtml
@@ -2,40 +2,50 @@
 
 @model WebCrawlerFieldsViewModel
 
-<div class="mb-3" asp-validation-class-for="DisplayText">
-    <label asp-for="DisplayText" class="form-label">@T["Name"]</label>
-    <input asp-for="DisplayText" class="form-control" />
-    <span asp-validation-for="DisplayText"></span>
-    <span class="hint">@T["A human-readable name that identifies this crawler in the list."]</span>
+<div class="ocat-wrapper">
+    <label asp-for="DisplayText" class="ocat-label">@T["Name"]</label>
+    <div class="ocat-end">
+        <input asp-for="DisplayText" class="form-control" />
+        <span asp-validation-for="DisplayText" class="text-danger"></span>
+        <span class="hint">@T["A human-readable name that identifies this crawler in the list."]</span>
+    </div>
 </div>
 
-<div class="mb-3" asp-validation-class-for="AIDataSourceId">
-    <label asp-for="AIDataSourceId" class="form-label">@T["Target Web data source"]</label>
-    @if (Model.HasDataSources)
-    {
-        <select asp-for="AIDataSourceId" asp-items="Model.DataSources" class="form-select">
-            <option value="">@T["Select a Web data source..."]</option>
-        </select>
-        <span asp-validation-for="AIDataSourceId"></span>
-        <span class="hint">@T["The Web AI data source whose knowledge base receives the pages scraped by this crawler. Multiple crawlers can target the same data source."]</span>
-    }
-    else
-    {
-        <div class="alert alert-warning" role="alert">
-            @T["No Web data sources exist yet. Create a data source of type <strong>Web</strong> under <strong>Artificial Intelligence &gt; Data Sources</strong>, then return here to point a crawler at it."]
+<div class="ocat-wrapper">
+    <label asp-for="AIDataSourceId" class="ocat-label">@T["Target Web data source"]</label>
+    <div class="ocat-end">
+        @if (Model.HasDataSources)
+        {
+            <select asp-for="AIDataSourceId" asp-items="Model.DataSources" class="form-select">
+                <option value="">@T["Select a Web data source..."]</option>
+            </select>
+            <span asp-validation-for="AIDataSourceId" class="text-danger"></span>
+            <span class="hint">@T["The Web AI data source whose knowledge base receives the pages scraped by this crawler. Multiple crawlers can target the same data source."]</span>
+        }
+        else
+        {
+            <div class="alert alert-warning mb-0" role="alert">
+                @T["No Web data sources exist yet. Create a data source of type <strong>Web</strong> under <strong>Artificial Intelligence &gt; Data Sources</strong>, then return here to point a crawler at it."]
+            </div>
+        }
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <div class="ocat-end-offset">
+        <div class="form-check">
+            <input asp-for="Enabled" class="form-check-input" type="checkbox" />
+            <label asp-for="Enabled" class="form-check-label">@T["Enabled"]</label>
+            <span class="hint">@T["Disabled crawlers are skipped by the hourly re-index task and are not read during a full data source synchronization."]</span>
         </div>
-    }
+    </div>
 </div>
 
-<div class="mb-3 form-check">
-    <input asp-for="Enabled" class="form-check-input" />
-    <label asp-for="Enabled" class="form-check-label">@T["Enabled"]</label>
-    <span class="hint">@T["Disabled crawlers are skipped by the hourly re-index task and are not read during a full data source synchronization."]</span>
-</div>
-
-<div class="mb-3" asp-validation-class-for="ReindexIntervalMinutes">
-    <label asp-for="ReindexIntervalMinutes" class="form-label">@T["Re-index interval (minutes)"]</label>
-    <input asp-for="ReindexIntervalMinutes" class="form-control" type="number" min="1" />
-    <span asp-validation-for="ReindexIntervalMinutes"></span>
-    <span class="hint">@T["How often the background task re-crawls this site and re-indexes changed pages. Leave empty to use the global default (24 hours). The task evaluates crawlers hourly, so intervals are honored to the nearest hour."]</span>
+<div class="ocat-wrapper">
+    <label asp-for="ReindexIntervalMinutes" class="ocat-label">@T["Re-index interval (minutes)"]</label>
+    <div class="ocat-end">
+        <input asp-for="ReindexIntervalMinutes" class="form-control" type="number" min="1" />
+        <span asp-validation-for="ReindexIntervalMinutes" class="text-danger"></span>
+        <span class="hint">@T["How often the background task re-crawls this site and re-indexes changed pages. Leave empty to use the global default (24 hours). The task evaluates crawlers hourly, so intervals are honored to the nearest hour."]</span>
+    </div>
 </div>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlerFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlerFields.Edit.cshtml
@@ -1,6 +1,14 @@
 @using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels
+@using CrestApps.Core.AI.WebCrawlers
+@using Microsoft.Extensions.Options
+
+@inject IOptions<WebCrawlerOptions> WebCrawlerOptions
 
 @model WebCrawlerFieldsViewModel
+
+@{
+    var crawlerDefaults = WebCrawlerOptions.Value;
+}
 
 <div class="ocat-wrapper">
     <label asp-for="DisplayText" class="ocat-label">@T["Name"]</label>
@@ -46,6 +54,6 @@
     <div class="ocat-end">
         <input asp-for="ReindexIntervalMinutes" class="form-control" type="number" min="1" />
         <span asp-validation-for="ReindexIntervalMinutes" class="text-danger"></span>
-        <span class="hint">@T["How often the background task re-crawls this site and re-indexes changed pages. Leave empty to use the global default (24 hours). The task evaluates crawlers hourly, so intervals are honored to the nearest hour."]</span>
+        <span class="hint">@T["How often the background task re-crawls this site and re-indexes changed pages. Leave empty to use the global default ({0} minutes). The task evaluates crawlers hourly, so intervals are honored to the nearest hour.", crawlerDefaults.DefaultReindexIntervalMinutes]</span>
     </div>
 </div>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlerFields.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlerFields.Edit.cshtml
@@ -1,0 +1,41 @@
+@using CrestApps.OrchardCore.AI.DataSources.WebCrawlers.ViewModels
+
+@model WebCrawlerFieldsViewModel
+
+<div class="mb-3" asp-validation-class-for="DisplayText">
+    <label asp-for="DisplayText" class="form-label">@T["Name"]</label>
+    <input asp-for="DisplayText" class="form-control" />
+    <span asp-validation-for="DisplayText"></span>
+    <span class="hint">@T["A human-readable name that identifies this crawler in the list."]</span>
+</div>
+
+<div class="mb-3" asp-validation-class-for="AIDataSourceId">
+    <label asp-for="AIDataSourceId" class="form-label">@T["Target Web data source"]</label>
+    @if (Model.HasDataSources)
+    {
+        <select asp-for="AIDataSourceId" asp-items="Model.DataSources" class="form-select">
+            <option value="">@T["Select a Web data source..."]</option>
+        </select>
+        <span asp-validation-for="AIDataSourceId"></span>
+        <span class="hint">@T["The Web AI data source whose knowledge base receives the pages scraped by this crawler. Multiple crawlers can target the same data source."]</span>
+    }
+    else
+    {
+        <div class="alert alert-warning" role="alert">
+            @T["No Web data sources exist yet. Create a data source of type <strong>Web</strong> under <strong>Artificial Intelligence &gt; Data Sources</strong>, then return here to point a crawler at it."]
+        </div>
+    }
+</div>
+
+<div class="mb-3 form-check">
+    <input asp-for="Enabled" class="form-check-input" />
+    <label asp-for="Enabled" class="form-check-label">@T["Enabled"]</label>
+    <span class="hint">@T["Disabled crawlers are skipped by the hourly re-index task and are not read during a full data source synchronization."]</span>
+</div>
+
+<div class="mb-3" asp-validation-class-for="ReindexIntervalMinutes">
+    <label asp-for="ReindexIntervalMinutes" class="form-label">@T["Re-index interval (minutes)"]</label>
+    <input asp-for="ReindexIntervalMinutes" class="form-control" type="number" min="1" />
+    <span asp-validation-for="ReindexIntervalMinutes"></span>
+    <span class="hint">@T["How often the background task re-crawls this site and re-indexes changed pages. Leave empty to use the global default (24 hours). The task evaluates crawlers hourly, so intervals are honored to the nearest hour."]</span>
+</div>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlers/Create.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlers/Create.cshtml
@@ -1,0 +1,17 @@
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["New Web Crawler: {0}", Model.DisplayName])</h1>
+</zone>
+
+<form method="post" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <div class="ocat-wrapper">
+        <div class="ocat-end-offset">
+            <button class="btn btn-primary" type="submit">@T["Save"]</button>
+            <a class="btn btn-secondary cancel" role="button" asp-route-action="Index">@T["Cancel"]</a>
+        </div>
+    </div>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlers/Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlers/Edit.cshtml
@@ -1,0 +1,17 @@
+@model EditCatalogEntryViewModel
+
+<zone Name="Title">
+    <h1>@RenderTitleSegments(T["Edit Web Crawler: '{0}'", Model.DisplayName])</h1>
+</zone>
+
+<form method="post" asp-route-id="@ViewContext.HttpContext.Request.RouteValues["id"]" enctype="multipart/form-data" class="no-multisubmit">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Editor)
+
+    <div class="ocat-wrapper">
+        <div class="ocat-end-offset">
+            <button class="btn btn-primary" type="submit">@T["Save"]</button>
+            <a class="btn btn-secondary cancel" role="button" asp-route-action="Index">@T["Cancel"]</a>
+        </div>
+    </div>
+</form>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlers/Index.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/WebCrawlers/Index.cshtml
@@ -1,0 +1,150 @@
+@using CrestApps.Core.AI.Models
+@using CrestApps.Core.AI.WebCrawlers.Strategies
+@using CrestApps.OrchardCore.Core.Models
+
+@model ListSourceModelViewModel<WebCrawlerStrategyDescriptor, CatalogEntryViewModel<WebCrawler>>
+
+<zone Name="Title"><h1>@RenderTitleSegments(T["Web Crawlers"])</h1></zone>
+
+@* The form is necessary to generate an antiforgery token for the delete and bulk actions. *@
+<form asp-action="Index" method="post" class="no-multisubmit" data-list-management data-selected-label="@T["selected"]" data-client-side-search="true">
+    <input type="submit" name="submit.Filter" id="submitFilter" class="visually-hidden" />
+    <input asp-for="Options.BulkAction" type="hidden" />
+    <input type="submit" name="submit.BulkAction" class="visually-hidden" />
+
+    <div class="card text-bg-theme mb-3 position-sticky action-bar">
+        <div class="card-body">
+            <div class="row gx-1">
+                <div class="col">
+                    <div class="input-group">
+                        <div class="has-search flex-grow-1">
+                            <i class="fa-solid fa-search form-control-feedback" aria-hidden="true"></i>
+                            <input id="search-box" asp-for="Options.Search" class="form-control rounded-end-0" placeholder="@T["Search"]" type="search" autofocus autocomplete="off" />
+                        </div>
+                        <button type="submit" name="submit.Filter" class="btn btn-primary text-nowrap">
+                            <i class="fa-solid fa-search me-1" aria-hidden="true"></i>@T["Go"]
+                        </button>
+                    </div>
+                </div>
+                <div class="col-auto">
+                    <button type="button" class="btn btn-secondary create" role="button" data-bs-toggle="modal" data-bs-target="#modalAddWebCrawler">@T["Add Web Crawler"]</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <ul class="list-group with-checkbox">
+        @if (Model.Models.Count > 0)
+        {
+            var pager = (dynamic)Model.Pager;
+            int startIndex = (pager.Page - 1) * pager.PageSize + 1;
+            int endIndex = startIndex + Model.Models.Count - 1;
+
+            <li class="list-group-item text-bg-theme ignore-elements">
+                <div class="row gx-3">
+                    <div class="col">
+                        <div class="form-check my-1">
+                            <input type="checkbox" class="form-check-input" id="select-all">
+                            <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
+                            <label id="items" for="select-all">
+                                @T.Plural(Model.Models.Count, "1 item", "{0} items")
+                                <span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">
+                                    @T.Plural((int)pager.TotalItemCount, " / {0} item in total", " / {0} items in total")
+                                </span>
+                            </label>
+                            <label id="selected-items" class="text-muted" for="select-all"></label>
+                        </div>
+                    </div>
+                    <div class="col-auto">
+                        <div class="dropdown d-none" id="actions">
+                            <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                @T["Actions"]
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                                @foreach (var item in Model.Options.BulkActions)
+                                {
+                                    <li>
+                                        <a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a>
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </li>
+            @foreach (var entry in Model.Models)
+            {
+                <li class="list-group-item item d-flex justify-content-between align-items-center" data-filter-value="@entry.Model.DisplayText?.ToLowerInvariant()">
+                    <div class="d-flex flex-row">
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" value="@entry.Model.ItemId" name="itemIds" id="itemIds-@entry.Model.ItemId">
+                            <label class="form-check-label" for="itemIds-@entry.Model.ItemId">&nbsp;</label>
+                        </div>
+                    </div>
+
+                    <div class="flex-grow-1">
+                        @await DisplayAsync(entry.Shape)
+                    </div>
+                </li>
+            }
+        }
+        else
+        {
+            <li class="list-group-item list-group-item-info text-center ignore-elements">
+                @T["<strong>Nothing here!</strong> There are no web crawlers at the moment."]
+            </li>
+        }
+    </ul>
+
+    <div id="list-alert" class="alert alert-info my-3 d-none text-center" role="alert">
+        @T["Your search returned no results."]
+    </div>
+</form>
+
+<!-- Modal -->
+<div class="modal fade" id="modalAddWebCrawler" tabindex="-1" role="dialog" aria-labelledby="available-strategies-title" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="available-strategies-title">@T["Available Crawl Strategies"]</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                @if (!(Model.Sources?.Any() ?? false))
+                {
+                    <p class="p-3 mb-2 bg-warning text-white">@T["No crawl strategies are available at the moment."]</p>
+                }
+                else
+                {
+                    <div class="row row-cols-1 row-cols-md-3 g-2">
+                        @foreach (var source in Model.Sources)
+                        {
+                            <div class="col">
+                                <div class="card h-100">
+                                    <div class="card-body">
+                                        <h4>@source.DisplayName</h4>
+                                        <p class="hint">@source.Description</p>
+                                    </div>
+                                    <div class="card-footer text-muted text-sm-end">
+                                        <a class="btn btn-primary btn-sm"
+                                           asp-route-area="CrestApps.OrchardCore.AI.DataSources.WebCrawlers"
+                                           asp-route-controller="WebCrawlers"
+                                           asp-route-action="Create"
+                                           asp-route-source="@source.Strategy">@T["Add"]</a>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">@T["Cancel"]</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@await DisplayAsync(Model.Pager)
+
+<script asp-name="list-management-ui" at="Foot"></script>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/_ViewImports.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/_ViewImports.cshtml
@@ -1,0 +1,12 @@
+@inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>
+
+@using CrestApps.OrchardCore
+@using CrestApps.OrchardCore.Core.Models
+@using Microsoft.AspNetCore.Mvc.Localization
+@using OrchardCore.DisplayManagement
+@using OrchardCore.DisplayManagement.Views
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, OrchardCore.DisplayManagement
+@addTagHelper *, OrchardCore.ResourceManagement
+@addTagHelper *, OrchardCore.Contents.TagHelpers

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/WebCrawlerPermissions.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/WebCrawlerPermissions.cs
@@ -1,0 +1,14 @@
+using OrchardCore.Security.Permissions;
+
+namespace CrestApps.OrchardCore.AI.DataSources.WebCrawlers;
+
+/// <summary>
+/// Permissions provided by the Web Crawlers feature.
+/// </summary>
+public static class WebCrawlerPermissions
+{
+    /// <summary>
+    /// Permission that allows managing web crawlers (create, edit, delete, and synchronize).
+    /// </summary>
+    public static readonly Permission ManageWebCrawlers = new("ManageWebCrawlers", "Manage web crawlers");
+}

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources/Drivers/AIDataSourceDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources/Drivers/AIDataSourceDisplayDriver.cs
@@ -73,7 +73,9 @@ internal sealed class AIDataSourceDisplayDriver : DisplayDriver<AIDataSource>
             context.Updater.ModelState.AddModelError(Prefix, nameof(sharedModel.AIKnowledgeBaseIndexProfileName), S["The destination index is required."]);
         }
 
-        if (string.IsNullOrWhiteSpace(sharedModel.ContentFieldName))
+        var requiresFieldMapping = AIDataSourceDriverHelper.RequiresFieldMapping(AIDataSourceDriverHelper.GetSourceType(dataSource));
+
+        if (requiresFieldMapping && string.IsNullOrWhiteSpace(sharedModel.ContentFieldName))
         {
             context.Updater.ModelState.AddModelError(Prefix, nameof(sharedModel.ContentFieldName), S["The content field is required."]);
         }
@@ -158,6 +160,7 @@ internal sealed class AIDataSourceDisplayDriver : DisplayDriver<AIDataSource>
         model.TitleFieldName = dataSource.TitleFieldName;
         model.ContentFieldName = dataSource.ContentFieldName;
         model.IsConfigurationLocked = isConfigurationLocked;
+        model.ShowFieldMapping = AIDataSourceDriverHelper.RequiresFieldMapping(sourceType);
 
         var allIndexes = await _indexProfileStore.GetAllAsync();
         var knowledgeBaseIndexes = allIndexes

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources/Drivers/AIDataSourceDriverHelper.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources/Drivers/AIDataSourceDriverHelper.cs
@@ -13,6 +13,14 @@ internal static class AIDataSourceDriverHelper
             : dataSource.Source;
     }
 
+    /// <summary>
+    /// Returns whether the given source type needs the shared field mapping (content, title, key). Sources
+    /// that produce fully-formed documents themselves — such as the <see cref="AIDataSourceSourceTypes.Web"/>
+    /// source — supply the title, content, and reference key directly, so the mapping does not apply.
+    /// </summary>
+    public static bool RequiresFieldMapping(string sourceType)
+        => !string.Equals(sourceType, AIDataSourceSourceTypes.Web, StringComparison.OrdinalIgnoreCase);
+
     public static bool IsConfigurationLocked(AIDataSource dataSource)
     {
         ArgumentNullException.ThrowIfNull(dataSource);

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources/ViewModels/EditAIDataSourceSharedViewModel.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources/ViewModels/EditAIDataSourceSharedViewModel.cs
@@ -40,6 +40,13 @@ public class EditAIDataSourceSharedViewModel
     public bool IsConfigurationLocked { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the field mapping section is shown. Sources that supply
+    /// their own document title, content, and key (for example the <c>Web</c> source) hide it.
+    /// </summary>
+    [BindNever]
+    public bool ShowFieldMapping { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the AI knowledge base index profile names.
     /// </summary>
     [BindNever]

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources/Views/AIDataSourceShared.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources/Views/AIDataSourceShared.Edit.cshtml
@@ -28,6 +28,8 @@
     </div>
 </fieldset>
 
+@if (Model.ShowFieldMapping)
+{
 <fieldset class="ocat-wrapper">
     <legend class="ocat-label">@T["Field Mapping"]</legend>
     <div class="ocat-end">
@@ -116,3 +118,4 @@
         </div>
     </div>
 </fieldset>
+}

--- a/src/Targets/CrestApps.OrchardCore.Cms.Core.Targets/CrestApps.OrchardCore.Cms.Core.Targets.csproj
+++ b/src/Targets/CrestApps.OrchardCore.Cms.Core.Targets/CrestApps.OrchardCore.Cms.Core.Targets.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.AI.DataSources.AzureAI/CrestApps.OrchardCore.AI.DataSources.AzureAI.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.AI.DataSources.Elasticsearch/CrestApps.OrchardCore.AI.DataSources.Elasticsearch.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.AI.DataSources.PostgreSQL/CrestApps.OrchardCore.AI.DataSources.PostgreSQL.csproj" PrivateAssets="none" />
+    <ProjectReference Include="../../Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/CrestApps.OrchardCore.AI.DataSources.WebCrawlers.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.AI.Documents/CrestApps.OrchardCore.AI.Documents.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.AI.Documents.Azure/CrestApps.OrchardCore.AI.Documents.Azure.csproj" PrivateAssets="none" />
     <ProjectReference Include="../../Modules/CrestApps.OrchardCore.AI.Documents.AzureAI/CrestApps.OrchardCore.AI.Documents.AzureAI.csproj" PrivateAssets="none" />


### PR DESCRIPTION
## Summary

Adds `CrestApps.OrchardCore.AI.DataSources.WebCrawlers`, an optional module that surfaces the CrestApps.Core web-crawler feature ([Core #157](https://github.com/CrestApps/CrestApps.Core/pull/157)) in Orchard Core.

- **New `Web` AI data source** — a knowledge-base target with no connection settings of its own, populated by strategy-based web crawlers that point at it. Registered through Core's `AddCoreWebCrawlers()` plus the YesSql stores/index providers (`AddCoreWebCrawlerStoresYesSql()`).
- **Extensible, source-based admin UI** — modeled on `AITemplatesController` / `DataSourcesController` for consistency. Crawl **strategies** are the "sources" (only **Sitemap** today). Includes a searchable list, an **Add Web Crawler** strategy-picker modal, and per-crawler **Edit / Synchronize now / Delete** actions. Every field has an inline hint, including how the include/exclude URL regex patterns work.
- **Hourly background worker** — `WebCrawlerReindexBackgroundTask` (`IBackgroundTask`, schedule `0 * * * *`) evaluates every enabled crawler and re-indexes the ones due per their re-index interval, calling `IWebCrawlerReindexService.ReindexDueAsync`.
- **Migrations** — create the `WebCrawlerIndex` / `WebCrawlStateIndex` tables via `CreateWebCrawlerIndexSchemaAsync` / `CreateWebCrawlStateIndexSchemaAsync`.
- **Permission + navigation** — adds `ManageWebCrawlers` (Administrator by default) and a **Web Crawlers** entry under **Artificial Intelligence**.
- **Docs** — new `data-sources/web-crawlers.md` page plus overview cross-links.

## Design notes

- The strategy-specific editor (Sitemap) is a separate display driver gated on the crawler's `Source`, so new strategies plug in without touching the controller or shared fields. Validation lives in the drivers, matching the existing data-source/template pattern.
- The Core-registered `WebCrawlerReindexBackgroundService` (`IHostedService`) is inert inside an Orchard tenant container (Orchard never starts tenant `IHostedService`s), so scheduling is handled by the Orchard `IBackgroundTask` instead.
- Bumps the central **AngleSharp** pin `1.7.0` → `1.7.1`, required by `CrestApps.Core.AI.WebCrawlers`.

## Testing

- `dotnet build` of the full solution succeeds.
- Manual end-to-end verification in a running tenant is still recommended (create a Web data source, add a sitemap crawler, synchronize, confirm pages land in the KB index and cite back to their URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)