### PR TITLE
Fix ocat layout for the sitemap web-crawler editor

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/SitemapWebCrawler.Edit.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources.WebCrawlers/Views/SitemapWebCrawler.Edit.cshtml
@@ -10,65 +10,74 @@
     var crawlerDefaults = WebCrawlerOptions.Value;
 }
 
-<fieldset class="ocat-wrapper">
-    <legend class="ocat-label">@T["Sitemap Strategy"]</legend>
+<div class="ocat-wrapper">
+    <label asp-for="BaseUrl" class="ocat-label">@T["Base URL"]</label>
     <div class="ocat-end">
-        <div class="mb-3">
-            <label asp-for="BaseUrl" class="form-label">@T["Base URL"]</label>
-            <input asp-for="BaseUrl" class="form-control" placeholder="https://example.com" />
-            <span asp-validation-for="BaseUrl" class="text-danger"></span>
-            <span class="hint">@T["The site to scrape. The crawler discovers the sitemap from <code>robots.txt</code> and the conventional locations (for example <code>/sitemap.xml</code>). Provide this or an explicit sitemap URL below."]</span>
-        </div>
-
-        <div class="mb-3">
-            <label asp-for="SitemapUrl" class="form-label">@T["Sitemap URL (optional)"]</label>
-            <input asp-for="SitemapUrl" class="form-control" placeholder="https://example.com/sitemap.xml" />
-            <span asp-validation-for="SitemapUrl" class="text-danger"></span>
-            <span class="hint">@T["An explicit sitemap or sitemap-index URL. When set, discovery starts here instead of probing the base URL. Supports nested sitemap indexes, gzip, plain-text, and RSS/Atom feeds."]</span>
-        </div>
-
-        <div class="row">
-            <div class="col-md-4 mb-3">
-                <label asp-for="MaxPages" class="form-label">@T["Max pages"]</label>
-                <input asp-for="MaxPages" class="form-control" type="number" min="1" />
-                <span asp-validation-for="MaxPages" class="text-danger"></span>
-                <span class="hint">@T["The most pages to scrape per crawl. Leave empty to use the default ({0}).", crawlerDefaults.DefaultMaxPages]</span>
-            </div>
-
-            <div class="col-md-4 mb-3">
-                <label asp-for="MaxConcurrentRequests" class="form-label">@T["Max concurrent requests"]</label>
-                <input asp-for="MaxConcurrentRequests" class="form-control" type="number" min="1" />
-                <span asp-validation-for="MaxConcurrentRequests" class="text-danger"></span>
-                <span class="hint">@T["How many pages are fetched in parallel. Leave empty to use the default ({0}). Keep this low to be polite to the target site.", crawlerDefaults.DefaultMaxConcurrentRequests]</span>
-            </div>
-
-            <div class="col-md-4 mb-3">
-                <label asp-for="RequestTimeoutSeconds" class="form-label">@T["Request timeout (seconds)"]</label>
-                <input asp-for="RequestTimeoutSeconds" class="form-control" type="number" min="1" />
-                <span asp-validation-for="RequestTimeoutSeconds" class="text-danger"></span>
-                <span class="hint">@T["Per-request fetch timeout. Leave empty to use the default ({0} seconds).", crawlerDefaults.DefaultRequestTimeoutSeconds]</span>
-            </div>
-        </div>
-
-        <div class="mb-3">
-            <label asp-for="IncludeUrlPatterns" class="form-label">@T["Include URL patterns"]</label>
-            <textarea asp-for="IncludeUrlPatterns" class="form-control" rows="3" placeholder="^https://example\.com/docs/"></textarea>
-            <span asp-validation-for="IncludeUrlPatterns" class="text-danger"></span>
-            <span class="hint">@T["One <strong>regular expression</strong> per line. A discovered page is scraped only when its full URL matches <strong>at least one</strong> of these patterns. Leave empty to allow every discovered page. Example: <code>^https://example\\.com/docs/</code> keeps only pages under <code>/docs/</code>."]</span>
-        </div>
-
-        <div class="mb-3">
-            <label asp-for="ExcludeUrlPatterns" class="form-label">@T["Exclude URL patterns"]</label>
-            <textarea asp-for="ExcludeUrlPatterns" class="form-control" rows="3" placeholder="/tag/|/author/|\.pdf$"></textarea>
-            <span asp-validation-for="ExcludeUrlPatterns" class="text-danger"></span>
-            <span class="hint">@T["One <strong>regular expression</strong> per line. A page is skipped when its URL matches <strong>any</strong> of these patterns. Exclusions are applied <strong>after</strong> the include patterns, so exclude wins. Example: <code>/tag/|/author/</code> drops taxonomy and author pages."]</span>
-        </div>
-
-        <div class="mb-0">
-            <label asp-for="UserAgent" class="form-label">@T["User-Agent (optional)"]</label>
-            <input asp-for="UserAgent" class="form-control" />
-            <span asp-validation-for="UserAgent" class="text-danger"></span>
-            <span class="hint">@T["The <code>User-Agent</code> header sent while crawling. Leave empty to use the default. Some sites require a recognizable agent to serve content."]</span>
-        </div>
+        <input asp-for="BaseUrl" class="form-control" placeholder="https://example.com" />
+        <span asp-validation-for="BaseUrl" class="text-danger"></span>
+        <span class="hint">@T["The site to scrape. The crawler discovers the sitemap from <code>robots.txt</code> and the conventional locations (for example <code>/sitemap.xml</code>). Provide this or an explicit sitemap URL below."]</span>
     </div>
-</fieldset>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="SitemapUrl" class="ocat-label">@T["Sitemap URL (optional)"]</label>
+    <div class="ocat-end">
+        <input asp-for="SitemapUrl" class="form-control" placeholder="https://example.com/sitemap.xml" />
+        <span asp-validation-for="SitemapUrl" class="text-danger"></span>
+        <span class="hint">@T["An explicit sitemap or sitemap-index URL. When set, discovery starts here instead of probing the base URL. Supports nested sitemap indexes, gzip, plain-text, and RSS/Atom feeds."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="MaxPages" class="ocat-label">@T["Max pages"]</label>
+    <div class="ocat-end">
+        <input asp-for="MaxPages" class="form-control" type="number" min="1" />
+        <span asp-validation-for="MaxPages" class="text-danger"></span>
+        <span class="hint">@T["The most pages to scrape per crawl. Leave empty to use the default ({0}).", crawlerDefaults.DefaultMaxPages]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="MaxConcurrentRequests" class="ocat-label">@T["Max concurrent requests"]</label>
+    <div class="ocat-end">
+        <input asp-for="MaxConcurrentRequests" class="form-control" type="number" min="1" />
+        <span asp-validation-for="MaxConcurrentRequests" class="text-danger"></span>
+        <span class="hint">@T["How many pages are fetched in parallel. Leave empty to use the default ({0}). Keep this low to be polite to the target site.", crawlerDefaults.DefaultMaxConcurrentRequests]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="RequestTimeoutSeconds" class="ocat-label">@T["Request timeout (seconds)"]</label>
+    <div class="ocat-end">
+        <input asp-for="RequestTimeoutSeconds" class="form-control" type="number" min="1" />
+        <span asp-validation-for="RequestTimeoutSeconds" class="text-danger"></span>
+        <span class="hint">@T["Per-request fetch timeout. Leave empty to use the default ({0} seconds).", crawlerDefaults.DefaultRequestTimeoutSeconds]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="IncludeUrlPatterns" class="ocat-label">@T["Include URL patterns"]</label>
+    <div class="ocat-end">
+        <textarea asp-for="IncludeUrlPatterns" class="form-control" rows="3" placeholder="^https://example\.com/docs/"></textarea>
+        <span asp-validation-for="IncludeUrlPatterns" class="text-danger"></span>
+        <span class="hint">@T["One <strong>regular expression</strong> per line. A discovered page is scraped only when its full URL matches <strong>at least one</strong> of these patterns. Leave empty to allow every discovered page. Example: <code>^https://example\\.com/docs/</code> keeps only pages under <code>/docs/</code>."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="ExcludeUrlPatterns" class="ocat-label">@T["Exclude URL patterns"]</label>
+    <div class="ocat-end">
+        <textarea asp-for="ExcludeUrlPatterns" class="form-control" rows="3" placeholder="/tag/|/author/|\.pdf$"></textarea>
+        <span asp-validation-for="ExcludeUrlPatterns" class="text-danger"></span>
+        <span class="hint">@T["One <strong>regular expression</strong> per line. A page is skipped when its URL matches <strong>any</strong> of these patterns. Exclusions are applied <strong>after</strong> the include patterns, so exclude wins. Example: <code>/tag/|/author/</code> drops taxonomy and author pages."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="UserAgent" class="ocat-label">@T["User-Agent (optional)"]</label>
+    <div class="ocat-end">
+        <input asp-for="UserAgent" class="form-control" />
+        <span asp-validation-for="UserAgent" class="text-danger"></span>
+        <span class="hint">@T["The <code>User-Agent</code> header sent while crawling. Leave empty to use the default. Some sites require a recognizable agent to serve content."]</span>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

Follow-up to the Web Crawlers module (#634) addressing review feedback on the crawler editor.

### Fix: ocat layout for the sitemap strategy fields
The sitemap strategy fields (**Base URL**, **Sitemap URL**, **Max pages**, **Max concurrent requests**, **Request timeout**, include/exclude patterns, **User-Agent**) were grouped inside a single `fieldset` / `ocat-end` using plain `form-label` markup (and a `row`/`col-md-4` grid for the numeric fields). That made them render differently from the rest of the crawler editor, whose fields use proper ocat two-column rows.

Each field is now its own `ocat-wrapper` / `ocat-label` / `ocat-end` row, matching `WebCrawlerFields.Edit.cshtml`, so the whole crawler editor is visually consistent. Defaults are still sourced from `WebCrawlerOptions` and passed as localized-string `{0}` parameters.

### Verified (no change): "Re-index interval (minutes)" is used
The review also questioned whether the re-index interval is actually used. It is — `WebCrawlerReindexService.IsDueAsync` (CrestApps.Core) calls `ResolveReindexInterval(crawler.ReindexIntervalMinutes)` to decide when a crawler is due, and the module's hourly `WebCrawlerReindexBackgroundTask` drives `ReindexDueAsync`. It controls how often the **site is re-crawled**, which is independent of an index profile's own indexing schedule, so the field is kept.

## Testing
- `dotnet build` succeeds.
- The new per-field ocat markup is identical in structure to `WebCrawlerFields.Edit.cshtml`, which renders correctly in the admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)