### PR TITLE
Use ITempDirectoryProvider for temporary file storage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <OrchardCoreVersion>4.0.0-preview-19124</OrchardCoreVersion>
+    <OrchardCoreVersion>4.0.0-preview-19133</OrchardCoreVersion>
     <CrestAppsCoreVersion>2.0.0-preview.239</CrestAppsCoreVersion>
     <ModelContextProtocolVersion>2.2.0</ModelContextProtocolVersion>
   </PropertyGroup>

--- a/src/Core/CrestApps.OrchardCore.ContentTransfer.Core/CrestApps.OrchardCore.ContentTransfer.Core.csproj
+++ b/src/Core/CrestApps.OrchardCore.ContentTransfer.Core/CrestApps.OrchardCore.ContentTransfer.Core.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="OrchardCore.Autoroute.Core" />
     <PackageReference Include="OrchardCore.ContentFields" />
     <PackageReference Include="OrchardCore.Html" />
+    <PackageReference Include="OrchardCore.Infrastructure.Abstractions" />
     <PackageReference Include="OrchardCore.Liquid" />
     <PackageReference Include="OrchardCore.Markdown" />
     <PackageReference Include="OrchardCore.Media.Core" />

--- a/src/Core/CrestApps.OrchardCore.ContentTransfer.Core/Services/ContentTransferChunkFileUploadService.cs
+++ b/src/Core/CrestApps.OrchardCore.ContentTransfer.Core/Services/ContentTransferChunkFileUploadService.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
+using OrchardCore.FileStorage;
 using OrchardCore.Modules;
 
 namespace CrestApps.OrchardCore.ContentTransfer.Services;
@@ -19,17 +20,20 @@ public sealed class ContentTransferChunkFileUploadService : IContentTransferChun
     private readonly IClock _clock;
     private readonly ILogger _logger;
     private readonly IOptions<ContentImportOptions> _options;
+    private readonly ITempDirectoryProvider _tempDirectoryProvider;
     private readonly string _tempFileNamePrefix;
 
     public ContentTransferChunkFileUploadService(
         ShellSettings shellSettings,
         IClock clock,
         ILogger<ContentTransferChunkFileUploadService> logger,
-        IOptions<ContentImportOptions> options)
+        IOptions<ContentImportOptions> options,
+        ITempDirectoryProvider tempDirectoryProvider)
     {
         _clock = clock;
         _logger = logger;
         _options = options;
+        _tempDirectoryProvider = tempDirectoryProvider;
         _tempFileNamePrefix = shellSettings.Name + "_";
     }
 
@@ -169,8 +173,8 @@ public sealed class ContentTransferChunkFileUploadService : IContentTransferChun
             FileName = formFile.FileName,
         };
 
-    private static string GetTempFolderPath()
-        => Path.Combine(Path.GetTempPath(), TempFolderName);
+    private string GetTempFolderPath()
+        => Path.Combine(_tempDirectoryProvider.GetRootDirectory(), TempFolderName);
 
     private string GetTempFilePath(Guid uploadId, IFormFile formFile)
         => Path.Combine(GetTempFolderPath(), _tempFileNamePrefix + CalculateHash(uploadId.ToString("N"), formFile.FileName, formFile.Name));

--- a/src/Core/CrestApps.OrchardCore.Recipes.Core/CrestApps.OrchardCore.Recipes.Core.csproj
+++ b/src/Core/CrestApps.OrchardCore.Recipes.Core/CrestApps.OrchardCore.Recipes.Core.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="OrchardCore.ContentTypes.Abstractions" />
     <PackageReference Include="OrchardCore.Deployment.Abstractions" />
     <PackageReference Include="OrchardCore.Indexing.Abstractions" />
+    <PackageReference Include="OrchardCore.Infrastructure.Abstractions" />
     <PackageReference Include="OrchardCore.Roles.Abstractions" />
     <PackageReference Include="OrchardCore.Workflows.Abstractions" />
   </ItemGroup>

--- a/src/Core/CrestApps.OrchardCore.Recipes.Core/Services/RecipeExecutionService.cs
+++ b/src/Core/CrestApps.OrchardCore.Recipes.Core/Services/RecipeExecutionService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Deployment;
+using OrchardCore.FileStorage;
 using OrchardCore.Json;
 
 namespace CrestApps.OrchardCore.Recipes.Core.Services;
@@ -16,6 +17,7 @@ public sealed class RecipeExecutionService
 {
     private readonly IEnumerable<IDeploymentTargetHandler> _deploymentTargetHandlers;
     private readonly DocumentJsonSerializerOptions _options;
+    private readonly ITempDirectoryProvider _tempDirectoryProvider;
     private readonly ILogger _logger;
 
     /// <summary>
@@ -23,14 +25,17 @@ public sealed class RecipeExecutionService
     /// </summary>
     /// <param name="deploymentTargetHandlers">The deployment target handlers that process recipe files.</param>
     /// <param name="options">The document JSON serializer options.</param>
+    /// <param name="tempDirectoryProvider">The provider used to resolve tenant-scoped temporary file locations.</param>
     /// <param name="logger">The logger instance.</param>
     public RecipeExecutionService(
         IEnumerable<IDeploymentTargetHandler> deploymentTargetHandlers,
         IOptions<DocumentJsonSerializerOptions> options,
+        ITempDirectoryProvider tempDirectoryProvider,
         ILogger<RecipeExecutionService> logger)
     {
         _deploymentTargetHandlers = deploymentTargetHandlers;
         _options = options.Value;
+        _tempDirectoryProvider = tempDirectoryProvider;
         _logger = logger;
     }
 
@@ -43,8 +48,8 @@ public sealed class RecipeExecutionService
     {
         ArgumentNullException.ThrowIfNull(data);
 
-        var tempArchiveName = $"{PathExtensions.GetTempFileName()}.json";
-        var tempArchiveFolder = PathExtensions.GetTempFileName();
+        var tempArchiveName = _tempDirectoryProvider.GetTempFileName(".json");
+        var tempArchiveFolder = _tempDirectoryProvider.GetTempFileName();
 
         try
         {

--- a/src/Modules/CrestApps.OrchardCore.ContentTransfer/BackgroundTasks/ExportFilesBackgroundTask.cs
+++ b/src/Modules/CrestApps.OrchardCore.ContentTransfer/BackgroundTasks/ExportFilesBackgroundTask.cs
@@ -10,6 +10,7 @@ using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.Entities;
+using OrchardCore.FileStorage;
 using OrchardCore.Locking.Distributed;
 using OrchardCore.Modules;
 using YesSql;
@@ -39,6 +40,7 @@ public sealed class ExportFilesBackgroundTask : IBackgroundTask
         var fileStore = serviceProvider.GetRequiredService<IContentTransferFileStore>();
         var contentDefinitionManager = serviceProvider.GetRequiredService<IContentDefinitionManager>();
         var contentImportManager = serviceProvider.GetRequiredService<IContentImportManager>();
+        var tempDirectoryProvider = serviceProvider.GetRequiredService<ITempDirectoryProvider>();
 
         var entries = await session.Query<ContentTransferEntry, ContentTransferEntryIndex>(x =>
             (x.Status == ContentTransferEntryStatus.New || x.Status == ContentTransferEntryStatus.Processing)
@@ -125,7 +127,7 @@ public sealed class ExportFilesBackgroundTask : IBackgroundTask
                 }
 
                 var fileName = entry.StoredFileName;
-                var tempFilePath = Path.GetTempFileName();
+                var tempFilePath = tempDirectoryProvider.GetTempFileName();
 
                 using var tempStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, bufferSize: 4096, FileOptions.DeleteOnClose);
                 var columnNames = exportColumns.Select(c => c.Name).ToList();

--- a/src/Modules/CrestApps.OrchardCore.ContentTransfer/Controllers/AdminController.cs
+++ b/src/Modules/CrestApps.OrchardCore.ContentTransfer/Controllers/AdminController.cs
@@ -25,6 +25,7 @@ using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Notify;
 using OrchardCore.Entities;
 using OrchardCore.Environment.Shell.Scope;
+using OrchardCore.FileStorage;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Routing;
@@ -60,6 +61,7 @@ public sealed class AdminController : Controller, IUpdateModel
     private readonly IDisplayManager<ExportRequest> _exportRequestDisplayManager;
     private readonly IContentTransferEntryAdminListFilterParser _entriesAdminListFilterParser;
     private readonly ContentImportOptions _contentImportOptions;
+    private readonly ITempDirectoryProvider _tempDirectoryProvider;
 
     internal readonly IStringLocalizer S;
     internal readonly IHtmlLocalizer H;
@@ -88,6 +90,7 @@ public sealed class AdminController : Controller, IUpdateModel
         IDisplayManager<ExportRequest> exportRequestDisplayManager,
         IContentTransferEntryAdminListFilterParser entriesAdminListFilterParser,
         IOptions<ContentImportOptions> contentImportOptions,
+        ITempDirectoryProvider tempDirectoryProvider,
         IClock clock)
     {
         _authorizationService = authorizationService;
@@ -113,6 +116,7 @@ public sealed class AdminController : Controller, IUpdateModel
         _exportRequestDisplayManager = exportRequestDisplayManager;
         _entriesAdminListFilterParser = entriesAdminListFilterParser;
         _contentImportOptions = contentImportOptions.Value;
+        _tempDirectoryProvider = tempDirectoryProvider;
         _shapeFactory = shapeFactory;
         _pagerOptions = pagerOptions.Value;
         _clock = clock;
@@ -570,7 +574,7 @@ public sealed class AdminController : Controller, IUpdateModel
         var batchSize = _contentImportOptions.ExportBatchSize < 1 ? 200 : _contentImportOptions.ExportBatchSize;
         var columnNames = exportColumns.Select(c => c.Name).ToList();
 
-        var tempFilePath = Path.GetTempFileName();
+        var tempFilePath = _tempDirectoryProvider.GetTempFileName();
         try
         {
             using (var fileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))

--- a/tests/CrestApps.OrchardCore.Tests/Agent/Recipes/ImportRecipeBaseToolTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Agent/Recipes/ImportRecipeBaseToolTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using OrchardCore.FileStorage;
 using OrchardCore.Json;
 
 namespace CrestApps.OrchardCore.Tests.Agent.Recipes;
@@ -97,9 +98,15 @@ public sealed class ImportRecipeBaseToolTests
             [],
             recipeSteps,
             new MemoryCache(new MemoryCacheOptions()));
+        var tempDirectoryProvider = new Mock<ITempDirectoryProvider>();
+        tempDirectoryProvider
+            .Setup(provider => provider.GetTempFileName(It.IsAny<string>()))
+            .Returns((string extension) => Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + (extension ?? string.Empty)));
+
         var recipeExecutionService = new RecipeExecutionService(
             [],
             Options.Create(new DocumentJsonSerializerOptions()),
+            tempDirectoryProvider.Object,
             NullLogger<RecipeExecutionService>.Instance);
 
         return new ServiceCollection()

--- a/tests/CrestApps.OrchardCore.Tests/Modules/CrestApps.OrchardCore.ContentTransfer/ContentTransferChunkFileUploadServiceTests.cs
+++ b/tests/CrestApps.OrchardCore.Tests/Modules/CrestApps.OrchardCore.ContentTransfer/ContentTransferChunkFileUploadServiceTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using OrchardCore.Environment.Shell;
+using OrchardCore.FileStorage;
 using OrchardCore.Modules;
 
 namespace CrestApps.OrchardCore.Tests.Modules.ContentTransfer;
@@ -276,7 +277,8 @@ public sealed class ContentTransferChunkFileUploadServiceTests
             new ShellSettings { Name = "Default" },
             Mock.Of<IClock>(),
             NullLogger<ContentTransferChunkFileUploadService>.Instance,
-            Options.Create(options));
+            Options.Create(options),
+            Mock.Of<ITempDirectoryProvider>(provider => provider.GetRootDirectory() == Path.GetTempPath()));
 
     private static DefaultHttpContext CreateContext(string contentRange, Guid? uploadId, params IFormFile[] files)
     {


### PR DESCRIPTION
## Summary

Upgrades the Orchard Core preview to **4.0.0-preview-19133** and routes all runtime temporary file/directory usage through the new `ITempDirectoryProvider` introduced in [OrchardCMS/OrchardCore#19789](https://github.com/OrchardCMS/OrchardCore/pull/19789).

`ITempDirectoryProvider` hands out **tenant-scoped** temp locations under an operator-configurable root (`OrchardCore:TempDirectory:Path`), so temporary files (chunked uploads, export files, recipe archives) can be relocated onto a larger/shared volume instead of overwhelming the system `TEMP` folder — which can otherwise fill up and crash the app.

## Changes

- **`ContentTransferChunkFileUploadService`** — the chunked-upload temp folder is now rooted at `ITempDirectoryProvider.GetRootDirectory()` instead of `Path.GetTempPath()` (mirrors OrchardCore's own `ChunkFileUploadService` change).
- **`ContentTransfer` `AdminController`** (immediate export) and **`ExportFilesBackgroundTask`** (queued export) — export temp files are allocated via `ITempDirectoryProvider.GetTempFileName()`.
- **`RecipeExecutionService`** — the recipe archive file/folder are allocated via the provider instead of `PathExtensions.GetTempFileName()`.
- Added `OrchardCore.Infrastructure.Abstractions` package references to the two Core projects that now use the type, and updated the affected unit tests.

Test-only temp usages (SQLite DB files and probe directories that run without a tenant/DI context) are intentionally left as-is.

## Verification

- `dotnet build CrestApps.OrchardCore.slnx -warnaserror` → **0 warnings, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)