### PR TITLE
Remove incompatible OllamaSharp source generator to fix build error

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,10 @@
 <Project>
+  <Target Name="RemoveIncompatibleOllamaSharpSourceGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Filename)' == 'OllamaSharp.SourceGenerators'" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="SetComputedPackageTags" BeforeTargets="GenerateNuspec">
     <ItemGroup>
       <_ComputedPackageTag Include="CrestApps" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="NLog.Web.AspNetCore" Version="6.1.3" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="NuGet.Versioning" Version="7.6.0" />
+    <PackageVersion Include="OllamaSharp" Version="5.4.30" />
     <PackageVersion Include="ZString" Version="2.6.0" />
     <PackageVersion Include="YesSql.Abstractions" Version="5.4.7" />
     <PackageVersion Include="YesSql.Core" Version="5.4.7" />

--- a/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
@@ -41,10 +41,12 @@
   </ItemGroup>
 
   <!--
-    Ship the source-generator removal to downstream consumers. Transitive source generators
-    flow into consuming projects regardless of ExcludeAssets, so a buildTransitive target is
-    the only reliable way to keep OllamaSharp's incompatible generator from breaking consumer
-    builds on earlier .NET 10 SDKs. See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
+    Ship a buildTransitive target to downstream consumers. Transitive source generators flow
+    into consuming projects regardless of ExcludeAssets, so this is the only reliable way to
+    keep OllamaSharp's generator from breaking consumer builds on earlier .NET 10 SDKs. It
+    suppresses the CS9057 warning (non-breaking) rather than removing the analyzer, so the
+    generator keeps working on SDKs where it is compatible.
+    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
   -->
   <ItemGroup>
     <None Include="buildTransitive\CrestApps.OrchardCore.Ollama.targets" Pack="true" PackagePath="buildTransitive\CrestApps.OrchardCore.Ollama.targets" />

--- a/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
@@ -31,12 +31,23 @@
 
   <ItemGroup>
     <PackageReference Include="CrestApps.Core.AI.Ollama" />
+    <PackageReference Include="OllamaSharp" ExcludeAssets="analyzers" />
     <ProjectReference Include="../../Abstractions/CrestApps.OrchardCore.Abstractions/CrestApps.OrchardCore.Abstractions.csproj" />
     <ProjectReference Include="../../Core/CrestApps.OrchardCore.AI.Core/CrestApps.OrchardCore.AI.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- 
+    <Analyzer Remove="$(NuGetPackageRoot)ollamasharp/**/OllamaSharp.SourceGenerators.dll" />
+  </ItemGroup>
+
+  <Target Name="RemoveOllamaSharpSourceGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Filename)' == 'OllamaSharp.SourceGenerators'" />
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <!--
       Ensure this module directly depends on the required package so that when someone installs it, 
       they won't need to manually include the AI. 
       This guarantees the module functions correctly and resolves the feature dependency.

--- a/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
@@ -40,6 +40,16 @@
     <Analyzer Remove="$(NuGetPackageRoot)ollamasharp/**/OllamaSharp.SourceGenerators.dll" />
   </ItemGroup>
 
+  <!--
+    Ship the source-generator removal to downstream consumers. Transitive source generators
+    flow into consuming projects regardless of ExcludeAssets, so a buildTransitive target is
+    the only reliable way to keep OllamaSharp's incompatible generator from breaking consumer
+    builds on earlier .NET 10 SDKs. See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
+  -->
+  <ItemGroup>
+    <None Include="buildTransitive\CrestApps.OrchardCore.Ollama.targets" Pack="true" PackagePath="buildTransitive\CrestApps.OrchardCore.Ollama.targets" />
+  </ItemGroup>
+
   <Target Name="RemoveOllamaSharpSourceGenerator" BeforeTargets="CoreCompile">
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Filename)' == 'OllamaSharp.SourceGenerators'" />

--- a/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
@@ -1,0 +1,23 @@
+<Project>
+
+  <!--
+    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators) that is
+    compiled against a newer version of the C# compiler than earlier .NET 10 SDKs provide.
+    Loading it on such an SDK produces CS9057, which breaks builds that treat warnings as
+    errors (for example: dotnet build ... --warnaserror -p:TreatWarningsAsErrors=True).
+
+    Transitive analyzers and source generators flow into consuming projects regardless of
+    ExcludeAssets/exclude metadata on the intermediate dependencies
+    (see https://github.com/NuGet/Home/issues/13813). Because this package brings OllamaSharp
+    into the dependency graph, that incompatible generator would otherwise run in downstream
+    projects. This target removes it so consuming builds are not broken.
+
+    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
+  -->
+  <Target Name="RemoveIncompatibleOllamaSharpSourceGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Filename)' == 'OllamaSharp.SourceGenerators'" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
@@ -1,23 +1,27 @@
 <Project>
 
   <!--
-    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators) that is
-    compiled against a newer version of the C# compiler than earlier .NET 10 SDKs provide.
-    Loading it on such an SDK produces CS9057, which breaks builds that treat warnings as
-    errors (for example: dotnet build ... --warnaserror -p:TreatWarningsAsErrors=True).
+    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators). When it is
+    compiled against a newer C# compiler than the consuming build provides (for example an
+    earlier .NET 10 SDK), the compiler reports CS9057 and simply does not run the generator.
+    CS9057 is a warning by default, but builds that treat warnings as errors
+    (dotnet build ... --warnaserror -p:TreatWarningsAsErrors=True) then fail.
 
-    Transitive analyzers and source generators flow into consuming projects regardless of
-    ExcludeAssets/exclude metadata on the intermediate dependencies
+    Transitive analyzers and source generators flow into consuming projects regardless of the
+    ExcludeAssets/exclude metadata on intermediate dependencies
     (see https://github.com/NuGet/Home/issues/13813). Because this package brings OllamaSharp
-    into the dependency graph, that incompatible generator would otherwise run in downstream
-    projects. This target removes it so consuming builds are not broken.
+    into the dependency graph, that generator runs in downstream projects too.
+
+    Suppressing CS9057 (rather than removing the analyzer) keeps this change non-breaking:
+      * On an older SDK the generator could not load anyway, so nothing is lost - the build
+        just no longer fails.
+      * On a newer SDK the generator is compatible, no CS9057 is emitted, and this suppression
+        is a no-op - OllamaSharp's [OllamaTool] source generation keeps working.
 
     See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
   -->
-  <Target Name="RemoveIncompatibleOllamaSharpSourceGenerator" BeforeTargets="CoreCompile">
-    <ItemGroup>
-      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Filename)' == 'OllamaSharp.SourceGenerators'" />
-    </ItemGroup>
-  </Target>
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CS9057</NoWarn>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->

Fixes #640

## Problem

`OllamaSharp` 5.4.30 ships a Roslyn source generator (`OllamaSharp.SourceGenerators`) compiled against a newer C# compiler than earlier .NET 10 SDKs provide. On such an SDK (e.g. `10.0.102`) the compiler reports `CS9057` and does not run the generator. `CS9057` is a **warning** by default, but builds that treat warnings as errors fail:

```
CSC : error CS9057: Analyzer assembly '.../ollamasharp/5.4.30/analyzers/dotnet/cs/OllamaSharp.SourceGenerators.dll'
cannot be used because it references version '5.6.0.0' of the compiler, which is newer than the currently running version '5.0.0.0'.
```

Regression on the 2.1.x line (2.0.0 was fine).

## Fix

Two layers, solving two different builds — **both non-breaking**, safe for the 2.1.3 patch:

**1. This repository's own build** (backport of the OllamaSharp fix from #607):
- `Directory.Build.targets` — global target that removes the generator before `CoreCompile`.
- `Directory.Packages.props` — pins `OllamaSharp` to `5.4.30` (the version already resolved transitively — no downgrade).
- `CrestApps.OrchardCore.Ollama.csproj` — references `OllamaSharp` with `ExcludeAssets="analyzers"` and removes the generator locally.

**2. Downstream consumer builds** (the part that fixes the reported scenario):
- `buildTransitive/CrestApps.OrchardCore.Ollama.targets` shipped in the package, which appends `CS9057` to `NoWarn` in any project that (transitively) references it.

Transitive analyzers/source generators flow into consuming projects **regardless** of `ExcludeAssets`/`exclude` on intermediate dependencies (see [NuGet/Home#13813](https://github.com/NuGet/Home/issues/13813)). `CrestApps.Core.AI.Ollama` already declares OllamaSharp with `exclude="Analyzers"`, yet consumers still hit `CS9057` — so a `buildTransitive` target (the supported mechanism for flowing build logic to consumers) is required.

## Why suppress instead of remove — non-breaking guarantee

An earlier revision *removed* the generator downstream, which would silently disable OllamaSharp's `[OllamaTool]` source generation for consumers on a newer SDK where it works. Suppressing `CS9057` instead is a no-op where it matters:

- **Older SDK:** the generator could not load anyway → nothing lost, the build simply no longer fails under `--warnaserror`.
- **Newer SDK:** the generator is compatible, no `CS9057` is emitted → the suppression does nothing → `[OllamaTool]` keeps working.

No code/behavior changes; only MSBuild configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULPPAXpropJmpHhwa7mqav