### PR TITLE
Fix OllamaSharp source generator build error (CS9057) — 2.2 backport

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,10 @@
 <Project>
+  <Target Name="RemoveIncompatibleOllamaSharpSourceGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Filename)' == 'OllamaSharp.SourceGenerators'" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="SetComputedPackageTags" BeforeTargets="GenerateNuspec">
     <ItemGroup>
       <_ComputedPackageTag Include="CrestApps" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="NLog.Web.AspNetCore" Version="6.1.3" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="NuGet.Versioning" Version="7.6.0" />
+    <PackageVersion Include="OllamaSharp" Version="5.4.30" />
     <PackageVersion Include="ZString" Version="2.6.0" />
     <PackageVersion Include="YesSql.Abstractions" Version="5.4.7" />
     <PackageVersion Include="YesSql.Core" Version="5.4.7" />

--- a/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/CrestApps.OrchardCore.Ollama.csproj
@@ -31,12 +31,35 @@
 
   <ItemGroup>
     <PackageReference Include="CrestApps.Core.AI.Ollama" />
+    <PackageReference Include="OllamaSharp" ExcludeAssets="analyzers" />
     <ProjectReference Include="../../Abstractions/CrestApps.OrchardCore.Abstractions/CrestApps.OrchardCore.Abstractions.csproj" />
     <ProjectReference Include="../../Core/CrestApps.OrchardCore.AI.Core/CrestApps.OrchardCore.AI.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- 
+    <Analyzer Remove="$(NuGetPackageRoot)ollamasharp/**/OllamaSharp.SourceGenerators.dll" />
+  </ItemGroup>
+
+  <!--
+    Ship a buildTransitive target to downstream consumers. Transitive source generators flow
+    into consuming projects regardless of ExcludeAssets, so this is the only reliable way to
+    keep OllamaSharp's generator from breaking consumer builds on earlier .NET 10 SDKs. It
+    suppresses the CS9057 warning (non-breaking) rather than removing the analyzer, so the
+    generator keeps working on SDKs where it is compatible.
+    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
+  -->
+  <ItemGroup>
+    <None Include="buildTransitive\CrestApps.OrchardCore.Ollama.targets" Pack="true" PackagePath="buildTransitive\CrestApps.OrchardCore.Ollama.targets" />
+  </ItemGroup>
+
+  <Target Name="RemoveOllamaSharpSourceGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Filename)' == 'OllamaSharp.SourceGenerators'" />
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <!--
       Ensure this module directly depends on the required package so that when someone installs it, 
       they won't need to manually include the AI. 
       This guarantees the module functions correctly and resolves the feature dependency.

--- a/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
@@ -1,0 +1,27 @@
+<Project>
+
+  <!--
+    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators). When it is
+    compiled against a newer C# compiler than the consuming build provides (for example an
+    earlier .NET 10 SDK), the compiler reports CS9057 and simply does not run the generator.
+    CS9057 is a warning by default, but builds that treat warnings as errors
+    (dotnet build ... --warnaserror -p:TreatWarningsAsErrors=True) then fail.
+
+    Transitive analyzers and source generators flow into consuming projects regardless of the
+    ExcludeAssets/exclude metadata on intermediate dependencies
+    (see https://github.com/NuGet/Home/issues/13813). Because this package brings OllamaSharp
+    into the dependency graph, that generator runs in downstream projects too.
+
+    Suppressing CS9057 (rather than removing the analyzer) keeps this change non-breaking:
+      * On an older SDK the generator could not load anyway, so nothing is lost - the build
+        just no longer fails.
+      * On a newer SDK the generator is compatible, no CS9057 is emitted, and this suppression
+        is a no-op - OllamaSharp's [OllamaTool] source generation keeps working.
+
+    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
+  -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CS9057</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
@@ -1,24 +1,18 @@
 <Project>
 
   <!--
-    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators). When it is
-    compiled against a newer C# compiler than the consuming build provides (for example an
-    earlier .NET 10 SDK), the compiler reports CS9057 and simply does not run the generator.
-    CS9057 is a warning by default, but builds that treat warnings as errors
-    (dotnet build ... --warnaserror -p:TreatWarningsAsErrors=True) then fail.
+    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators) that can be built
+    against a newer C# compiler than the consuming SDK provides. On an earlier .NET 10 SDK the
+    compiler then reports CS9057 and skips the generator. CS9057 is a warning by default, so
+    builds that treat warnings as errors fail on it.
 
-    Transitive analyzers and source generators flow into consuming projects regardless of the
-    ExcludeAssets/exclude metadata on intermediate dependencies
-    (see https://github.com/NuGet/Home/issues/13813). Because this package brings OllamaSharp
-    into the dependency graph, that generator runs in downstream projects too.
+    Transitive analyzers and source generators reach consuming projects even when intermediate
+    dependencies exclude analyzer assets (see NuGet/Home issue 13813), and this package brings
+    OllamaSharp into the graph. Suppressing CS9057 keeps the change non breaking: on an older SDK
+    the generator could not load anyway, and on a newer SDK no CS9057 is emitted so the
+    suppression does nothing and OllamaSharp tool generation keeps working.
 
-    Suppressing CS9057 (rather than removing the analyzer) keeps this change non-breaking:
-      * On an older SDK the generator could not load anyway, so nothing is lost - the build
-        just no longer fails.
-      * On a newer SDK the generator is compatible, no CS9057 is emitted, and this suppression
-        is a no-op - OllamaSharp's [OllamaTool] source generation keeps working.
-
-    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
+    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640
   -->
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS9057</NoWarn>


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->

Fixes #640

Backport of the `release/2.1` fix (#642) to `release/2.2` — this branch had the identical problem (no fix present, `CrestApps.Core.AI.Ollama` 1.2.0 → `OllamaSharp` 5.4.30 transitively).

## Problem

`OllamaSharp` 5.4.30 ships a Roslyn source generator (`OllamaSharp.SourceGenerators`) compiled against a newer C# compiler than earlier .NET 10 SDKs provide. On such an SDK (e.g. `10.0.102`) the compiler reports `CS9057` and does not run the generator. `CS9057` is a **warning** by default, but builds that treat warnings as errors fail:

```
CSC : error CS9057: Analyzer assembly '.../ollamasharp/5.4.30/analyzers/dotnet/cs/OllamaSharp.SourceGenerators.dll'
cannot be used because it references version '5.6.0.0' of the compiler, which is newer than the currently running version '5.0.0.0'.
```

## Fix

Two layers, both **non-breaking**:

**1. This repository's own build:**
- `Directory.Build.targets` — global target that removes the generator before `CoreCompile`.
- `Directory.Packages.props` — pins `OllamaSharp` to `5.4.30` (the version already resolved transitively — no downgrade).
- `CrestApps.OrchardCore.Ollama.csproj` — references `OllamaSharp` with `ExcludeAssets="analyzers"` and removes the generator locally.

**2. Downstream consumer builds:**
- `buildTransitive/CrestApps.OrchardCore.Ollama.targets` shipped in the package, which appends `CS9057` to `NoWarn` in any project that (transitively) references it.

Transitive analyzers/source generators flow into consuming projects **regardless** of `ExcludeAssets`/`exclude` on intermediate dependencies (see [NuGet/Home#13813](https://github.com/NuGet/Home/issues/13813)), so a `buildTransitive` target is required to reach consumers.

## Why suppress instead of remove — non-breaking guarantee

Suppressing `CS9057` is a no-op where the generator works, so nothing is disabled for anyone:

- **Older SDK:** the generator could not load anyway → nothing lost; the build simply no longer fails under `--warnaserror`.
- **Newer SDK:** the generator is compatible, no `CS9057` is emitted → the suppression does nothing → `[OllamaTool]` keeps working.

No code/behavior changes; only MSBuild configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULPPAXpropJmpHhwa7mqav

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULPPAXpropJmpHhwa7mqav)_