### PR TITLE
Add 2.2.0 release notes and set version to 2.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <InformationalVersion></InformationalVersion>

--- a/src/CrestApps.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/2.0.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.0.0 Release Notes
-sidebar_position: 4
+sidebar_position: 5
 title: "Version 2.0.0 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.0.0, including the platform upgrade, major new features, and upgrade guidance.
 ---

--- a/src/CrestApps.Docs/docs/changelog/2.1.0.md
+++ b/src/CrestApps.Docs/docs/changelog/2.1.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.1.0 Release Notes
-sidebar_position: 3
+sidebar_position: 4
 title: "Version 2.1.0 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.1.0, including MCP Server breaking changes, recipe schema expansion, Omnichannel fixes, and module improvements.
 ---

--- a/src/CrestApps.Docs/docs/changelog/2.1.1.md
+++ b/src/CrestApps.Docs/docs/changelog/2.1.1.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.1.1 Release Notes
-sidebar_position: 2
+sidebar_position: 3
 title: "Version 2.1.1 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.1.1, including AI tool instance import and export support and a documentation search (sitemap) tool instance editor fix.
 ---

--- a/src/CrestApps.Docs/docs/changelog/2.1.2.md
+++ b/src/CrestApps.Docs/docs/changelog/2.1.2.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.1.2 Release Notes
-sidebar_position: 1
+sidebar_position: 2
 title: "Version 2.1.2 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.1.2, including agent skills that are now published with MCP Server sites and a fix for the AI email tool that used the logged-in user as the sender.
 ---

--- a/src/CrestApps.Docs/docs/changelog/2.2.0.md
+++ b/src/CrestApps.Docs/docs/changelog/2.2.0.md
@@ -1,0 +1,57 @@
+---
+sidebar_label: 2.2.0 Release Notes
+sidebar_position: 1
+title: "Version 2.2.0 Release Notes"
+description: Release notes for CrestApps.OrchardCore 2.2.0, including the reworked Content Transfer import and export pipeline, exporting Omnichannel contacts with their last activity, and a fix for the OllamaSharp source generator build error.
+---
+
+# Version 2.2.0 Release Notes
+
+**Release date:** September 6, 2026
+
+Version `2.2.0` is a minor release for the .NET 10 and Orchard Core 3.0 line. It keeps the Orchard Core package range at `>= 3.0.0` and `< 3.1.0` and the CrestApps.Core package line at stable `1.2.0`. The headline of this release is a reworked **Content Transfer** import and export pipeline, a new export-option extension point that lets other modules enrich an export, and an Omnichannel feature that exports each contact together with their last completed activity. It also fixes a build error caused by the OllamaSharp source generator on earlier .NET 10 SDKs.
+
+## At a glance
+
+| Area | 2.2.0 focus |
+| --- | --- |
+| Content Transfer | Queued imports now use the same background-job pattern as the Local DNC importer, with inline status, and **Pause**/**Resume** that continues from the last saved batch. |
+| Content Transfer | Bulk export gains version, date, and owner filters, queued background processing with an in-app notification when ready, and an extension point so other modules can contribute export options. |
+| Omnichannel | Exporting a contact content type can append each contact's most recent completed activity (**CRM last activity**), including the subject's fields. |
+| Build | Fixes the `OllamaSharp.SourceGenerators` `CS9057` build error on earlier .NET 10 SDKs. |
+
+## New features and improvements
+
+### Reworked Content Transfer import and export
+
+The **Content Transfer** import and export pipeline was reworked for reliability on large data sets:
+
+- Queued imports now follow the same background-job pattern used by the Local DNC list importer. The admin list updates each entry's status inline as work starts and stops, so an import moves cleanly through **Pending**, **Processing**, **Paused**, **Deleting**, **Completed**, **Completed with errors**, and **Failed** without briefly showing stale values.
+- A running import can be paused with **Pause import**. Paused, failed, pending, and stalled imports show **Resume import**, and the background job continues from the last saved batch instead of starting over.
+- Imports now default to saving drafts only. Enable **Publish imported content** to publish items immediately after create or update. When a row includes an existing `ContentItemId`, the import writes a new latest version and either keeps it as a draft or publishes it based on that choice. Imports now ignore `ContentItemVersionId` entirely, while exports still include it for reference on versionable types.
+- Bulk export supports published, latest, or all versions, created and modified date filters, and owner filtering, with an immediate download for smaller exports and queued background processing for larger ones. When notifications are enabled, users receive an in-app notification when a queued export is ready.
+- Modules can now contribute their own options to the export form for specific content types through a new export-option extension point. See [Contributing export options](../modules/content-transfer#contributing-export-options).
+
+### Export Omnichannel contacts with their last activity
+
+When you export a contact content type through **Content** -> **Export**, the form now shows a **CRM last activity** section. Enabling it appends each contact's most recent **completed** activity of a selected subject to the export, so a single file combines contact details with the latest interaction and its subject data. Added columns include `LastActivityNote`, `LastActivityCompletedUtc`, `LastActivityCompletedBy`, `LastActivityDisposition`, `LastActivitySubject`, and one column per exportable field of the selected subject content type. You can optionally limit the file to contacts that have a matching activity. This export always runs through the background queue and builds on the Content Transfer export-option extension point. See [Omnichannel management](../omnichannel/management#export-contacts-with-their-last-activity).
+
+### Stronger Omnichannel contact import
+
+Contact imports gained several safeguards for phone-based data:
+
+- Duplicate-phone filtering is enabled by default. Duplicate detection checks both the current import batch and the phone numbers already stored in Orchard before the batch commits, and skipped duplicate rows are recorded in the error export with the reason. When a row includes an existing `ContentItemId`, a matching phone number on that same content item is treated as an update instead of a conflict. The lookup also falls back to older stored phone values that predate the normalized-phone index columns, so re-importing the same list is still rejected while older tenants finish reindexing.
+- For content types that attach `OmnichannelContactPart`, selecting the file's lead country is now required so non-E.164 numbers are normalized before duplicate checks, DNC registry lookups, and contact-method storage. The picker shows the same `Country (+calling code)` labels used by the Local DNC import UI.
+- The `DoNotCall`, `DoNotSms`, `DoNotEmail`, and `DoNotChat` columns now advertise `true` and `false` as their expected values in the import metadata, so spreadsheet templates make the required boolean values clear.
+
+## Bug fixes
+
+### OllamaSharp source generator build error (CS9057)
+
+Building a project that references the Ollama module (or the packages that depend on it) with an earlier .NET 10 SDK failed with `CS9057`, because the `OllamaSharp.SourceGenerators` analyzer shipped by OllamaSharp references a newer C# compiler than those SDKs provide. `CS9057` is a warning by default, but builds that treat warnings as errors failed.
+
+This release removes the incompatible generator from this repository's own build and ships a `buildTransitive` MSBuild target with the Ollama package that suppresses `CS9057` in consuming projects. The suppression is a no-op on SDKs where the generator is compatible, so OllamaSharp's `[OllamaTool]` source generation keeps working there.
+
+### Open XML export no longer fails with a JSON node cycle
+
+The export pipeline now initializes missing parts on the parent content item before part handlers run, so Open XML (`.xlsx`) exports no longer fail with a JSON node cycle when a type includes a part that is not yet materialized on a specific content item.

--- a/src/CrestApps.Docs/docs/changelog/index.md
+++ b/src/CrestApps.Docs/docs/changelog/index.md
@@ -11,6 +11,7 @@ This section contains release notes and version highlights for **CrestApps.Orcha
 
 | Version | Highlights |
 | --- | --- |
+| [2.2.0](2.2.0) | Reworked Content Transfer import and export with pause/resume and an export-option extension point, exporting Omnichannel contacts with their last activity, and a fix for the OllamaSharp source generator build error |
 | [2.1.2](2.1.2) | Agent skills are now published with MCP Server sites, and the AI email tool no longer uses the logged-in user as the sender |
 | [2.1.1](2.1.1) | Import and export for AI tool instances with credential-stripping export handlers, and a documentation search (sitemap) tool instance editor fix |
 | [2.1.0](2.1.0) | Stable CrestApps.Core 1.2.0 package line, opt-in MCP Server tool exposure, MCP Server admin settings, and documentation search tool instances |


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->

Prepares `release/2.2` for the **v2.2.0** release (to ship alongside v2.1.3).

## What's in this PR

- **`src/CrestApps.Docs/docs/changelog/2.2.0.md`** — new release notes (`sidebar_position: 1`).
- **Existing changelog entries** — `sidebar_position` shifted down by one (2.1.2→2, 2.1.1→3, 2.1.0→4, 2.0.0→5), matching the convention used for every prior release.
- **`src/CrestApps.Docs/docs/changelog/index.md`** — new 2.2.0 row at the top of the highlights table.
- **`Directory.Build.props`** — `VersionPrefix` bumped `2.0.0` → `2.2.0` (suffix kept as `preview`). The released package version still comes from the git tag at release time via `release_ci.yml`; this only corrects the version reported by non-tagged builds on this branch.

## Release notes coverage

`release/2.2` is `2.1.2` plus two changes, and the notes cover both:

1. **Reworked Content Transfer import/export (#627)** — background-job imports with inline status and pause/resume, richer bulk export (version/date/owner filters, queued processing, in-app notification), a new export-option extension point, the Omnichannel "export contacts with their last activity" feature, stronger contact-import duplicate/phone handling, and the Open XML node-cycle export fix.
2. **OllamaSharp source generator build error (CS9057) (#640)** — listed under Bug fixes.

## Sequencing note

The notes list the OllamaSharp fix as part of 2.2.0, which assumes **#643 (the 2.2 backport of the #640 fix) is merged before the `v2.2.0` tag is created**. If 2.2.0 ships without #643, drop that bug-fix section.

The **release date** in the notes is set to September 6, 2026 — please adjust it to the actual tag date if it differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULPPAXpropJmpHhwa7mqav

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULPPAXpropJmpHhwa7mqav)_