### PR TITLE
Fix invalid XML in the Ollama buildTransitive targets (MSB4024)

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
@@ -1,24 +1,18 @@
 <Project>
 
   <!--
-    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators). When it is
-    compiled against a newer C# compiler than the consuming build provides (for example an
-    earlier .NET 10 SDK), the compiler reports CS9057 and simply does not run the generator.
-    CS9057 is a warning by default, but builds that treat warnings as errors
-    (dotnet build ... --warnaserror -p:TreatWarningsAsErrors=True) then fail.
+    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators) that can be built
+    against a newer C# compiler than the consuming SDK provides. On an earlier .NET 10 SDK the
+    compiler then reports CS9057 and skips the generator. CS9057 is a warning by default, so
+    builds that treat warnings as errors fail on it.
 
-    Transitive analyzers and source generators flow into consuming projects regardless of the
-    ExcludeAssets/exclude metadata on intermediate dependencies
-    (see https://github.com/NuGet/Home/issues/13813). Because this package brings OllamaSharp
-    into the dependency graph, that generator runs in downstream projects too.
+    Transitive analyzers and source generators reach consuming projects even when intermediate
+    dependencies exclude analyzer assets (see NuGet/Home issue 13813), and this package brings
+    OllamaSharp into the graph. Suppressing CS9057 keeps the change non breaking: on an older SDK
+    the generator could not load anyway, and on a newer SDK no CS9057 is emitted so the
+    suppression does nothing and OllamaSharp tool generation keeps working.
 
-    Suppressing CS9057 (rather than removing the analyzer) keeps this change non-breaking:
-      * On an older SDK the generator could not load anyway, so nothing is lost - the build
-        just no longer fails.
-      * On a newer SDK the generator is compatible, no CS9057 is emitted, and this suppression
-        is a no-op - OllamaSharp's [OllamaTool] source generation keeps working.
-
-    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
+    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640
   -->
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS9057</NoWarn>


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->

Fixes #640 (regression shipped in v2.1.3)

## Problem

The `buildTransitive/CrestApps.OrchardCore.Ollama.targets` file added in #642 has an XML comment containing `--warnaserror`. **An XML comment may not contain a double hyphen (`--`)**, so MSBuild fails to import the file in any consuming project ([reported here](https://github.com/CrestApps/CrestApps.OrchardCore/issues/640#issuecomment-5560476392)):

```
error MSB4024: The imported project file
".../crestapps.orchardcore.ollama/2.1.3/buildTransitive/CrestApps.OrchardCore.Ollama.targets"
could not be loaded. An XML comment cannot contain '--', and '-' cannot be the last character.
Line 8, position 23.
```

This broke **every** consumer build that references the package (shipped in **v2.1.3**) — worse than the original CS9057 issue, and independent of SDK version.

### Why CI didn't catch it

The repository's own build never imports its own `buildTransitive` targets — only downstream consumers do — so the repo built green while consumers failed. This was exactly the untested consumer-side gap.

## Fix

Reword the comment to remove the `--` (dropped the `--warnaserror` CLI example). **No functional change** — the file still just appends `CS9057` to `NoWarn` for consuming projects.

Validated the corrected file with a strict expat-based XML parser (the same parser class MSBuild uses), and swept every packaged `build`/`buildTransitive` targets file in the repo — this is the only one, and it now parses as valid XML.

## Follow-up

A **v2.1.4** patch is needed to ship this, since v2.1.3 is already published with the broken file. The same fix is going onto `release/2.2` (in the #643 branch, which carries the same file and has not been released yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULPPAXpropJmpHhwa7mqav

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULPPAXpropJmpHhwa7mqav)_