### PR TITLE
Release 2.1.4: fix Ollama buildTransitive XML (MSB4024) + release notes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.4</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <InformationalVersion></InformationalVersion>

--- a/src/CrestApps.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Docs/docs/changelog/2.0.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.0.0 Release Notes
-sidebar_position: 4
+sidebar_position: 5
 title: "Version 2.0.0 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.0.0, including the platform upgrade, major new features, and upgrade guidance.
 ---

--- a/src/CrestApps.Docs/docs/changelog/2.1.0.md
+++ b/src/CrestApps.Docs/docs/changelog/2.1.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.1.0 Release Notes
-sidebar_position: 3
+sidebar_position: 4
 title: "Version 2.1.0 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.1.0, including MCP Server breaking changes, recipe schema expansion, Omnichannel fixes, and module improvements.
 ---

--- a/src/CrestApps.Docs/docs/changelog/2.1.1.md
+++ b/src/CrestApps.Docs/docs/changelog/2.1.1.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.1.1 Release Notes
-sidebar_position: 2
+sidebar_position: 3
 title: "Version 2.1.1 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.1.1, including AI tool instance import and export support and a documentation search (sitemap) tool instance editor fix.
 ---

--- a/src/CrestApps.Docs/docs/changelog/2.1.2.md
+++ b/src/CrestApps.Docs/docs/changelog/2.1.2.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 2.1.2 Release Notes
-sidebar_position: 1
+sidebar_position: 2
 title: "Version 2.1.2 Release Notes"
 description: Release notes for CrestApps.OrchardCore 2.1.2, including agent skills that are now published with MCP Server sites and a fix for the AI email tool that used the logged-in user as the sender.
 ---

--- a/src/CrestApps.Docs/docs/changelog/2.1.4.md
+++ b/src/CrestApps.Docs/docs/changelog/2.1.4.md
@@ -1,0 +1,24 @@
+---
+sidebar_label: 2.1.4 Release Notes
+sidebar_position: 1
+title: "Version 2.1.4 Release Notes"
+description: Release notes for CrestApps.OrchardCore 2.1.4, completing the fix for the OllamaSharp source generator build error by correcting the buildTransitive targets file that failed to import in 2.1.3.
+---
+
+# Version 2.1.4 Release Notes
+
+**Release date:** September 6, 2026
+
+Version `2.1.4` is a patch release for the .NET 10 and Orchard Core 3.0 line. It keeps the Orchard Core package range at `>= 3.0.0` and `< 3.1.0` and the CrestApps.Core package line at stable `1.2.0`. This release completes the fix for the OllamaSharp source generator build error that `2.1.3` addressed but shipped incorrectly.
+
+## Bug fixes
+
+### OllamaSharp source generator build error (CS9057)
+
+`OllamaSharp` `5.4.30` ships a Roslyn source generator (`OllamaSharp.SourceGenerators`) that is built against a newer C# compiler than earlier .NET 10 SDKs provide. On such an SDK the compiler reports `CS9057` and skips the generator. `CS9057` is a warning by default, but builds that treat warnings as errors fail on it. Because transitive analyzers and source generators reach consuming projects even when intermediate dependencies exclude analyzer assets, the failure surfaced in projects that reference the Ollama module.
+
+The Ollama package now ships a `buildTransitive` MSBuild targets file that adds `CS9057` to `NoWarn` in consuming projects. The suppression is a no-op on SDKs where the generator is compatible, so OllamaSharp tool generation keeps working there.
+
+### Invalid XML in the 2.1.3 buildTransitive targets file
+
+`2.1.3` shipped the `buildTransitive` targets file with an XML comment that contained a double hyphen, which is not allowed in XML. MSBuild failed to import the file in consuming projects with `MSB4024` ("An XML comment cannot contain '--'"), which broke every build that referenced the package, regardless of SDK version. The comment has been corrected, and the file now imports normally. If you are on `2.1.3`, update to `2.1.4`.

--- a/src/CrestApps.Docs/docs/changelog/index.md
+++ b/src/CrestApps.Docs/docs/changelog/index.md
@@ -11,6 +11,7 @@ This section contains release notes and version highlights for **CrestApps.Orcha
 
 | Version | Highlights |
 | --- | --- |
+| [2.1.4](2.1.4) | Completes the fix for the OllamaSharp source generator build error by correcting the buildTransitive targets file that failed to import in 2.1.3 |
 | [2.1.2](2.1.2) | Agent skills are now published with MCP Server sites, and the AI email tool no longer uses the logged-in user as the sender |
 | [2.1.1](2.1.1) | Import and export for AI tool instances with credential-stripping export handlers, and a documentation search (sitemap) tool instance editor fix |
 | [2.1.0](2.1.0) | Stable CrestApps.Core 1.2.0 package line, opt-in MCP Server tool exposure, MCP Server admin settings, and documentation search tool instances |

--- a/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
+++ b/src/Modules/CrestApps.OrchardCore.Ollama/buildTransitive/CrestApps.OrchardCore.Ollama.targets
@@ -1,24 +1,18 @@
 <Project>
 
   <!--
-    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators). When it is
-    compiled against a newer C# compiler than the consuming build provides (for example an
-    earlier .NET 10 SDK), the compiler reports CS9057 and simply does not run the generator.
-    CS9057 is a warning by default, but builds that treat warnings as errors
-    (dotnet build ... --warnaserror -p:TreatWarningsAsErrors=True) then fail.
+    OllamaSharp ships a Roslyn source generator (OllamaSharp.SourceGenerators) that can be built
+    against a newer C# compiler than the consuming SDK provides. On an earlier .NET 10 SDK the
+    compiler then reports CS9057 and skips the generator. CS9057 is a warning by default, so
+    builds that treat warnings as errors fail on it.
 
-    Transitive analyzers and source generators flow into consuming projects regardless of the
-    ExcludeAssets/exclude metadata on intermediate dependencies
-    (see https://github.com/NuGet/Home/issues/13813). Because this package brings OllamaSharp
-    into the dependency graph, that generator runs in downstream projects too.
+    Transitive analyzers and source generators reach consuming projects even when intermediate
+    dependencies exclude analyzer assets (see NuGet/Home issue 13813), and this package brings
+    OllamaSharp into the graph. Suppressing CS9057 keeps the change non breaking: on an older SDK
+    the generator could not load anyway, and on a newer SDK no CS9057 is emitted so the
+    suppression does nothing and OllamaSharp tool generation keeps working.
 
-    Suppressing CS9057 (rather than removing the analyzer) keeps this change non-breaking:
-      * On an older SDK the generator could not load anyway, so nothing is lost - the build
-        just no longer fails.
-      * On a newer SDK the generator is compatible, no CS9057 is emitted, and this suppression
-        is a no-op - OllamaSharp's [OllamaTool] source generation keeps working.
-
-    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640.
+    See https://github.com/CrestApps/CrestApps.OrchardCore/issues/640
   -->
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS9057</NoWarn>


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->

Fixes #640 (regression shipped in v2.1.3)

Prepares **v2.1.4** for `release/2.1`. A single PR to merge and tag: the fix, the version bump, and the release notes.

## The fix

`v2.1.3` shipped `buildTransitive/CrestApps.OrchardCore.Ollama.targets` with an XML comment containing `--warnaserror`. **An XML comment may not contain `--`**, so MSBuild fails to import the file in any consuming project ([reported here](https://github.com/CrestApps/CrestApps.OrchardCore/issues/640#issuecomment-5560476392)):

```
error MSB4024: The imported project file
".../crestapps.orchardcore.ollama/2.1.3/buildTransitive/CrestApps.OrchardCore.Ollama.targets"
could not be loaded. An XML comment cannot contain '--', and '-' cannot be the last character.
```

This broke **every** consumer build that referenced the package (independent of SDK version). The repository's own build never imports its own `buildTransitive` targets, so CI stayed green while consumers failed.

The comment is reworded to remove the `--`. **No functional change** — the file still appends `CS9057` to `NoWarn` for consuming projects. Verified with a strict expat-based XML parser.

## Also in this PR

- **`Directory.Build.props`** — `VersionPrefix` bumped `2.0.0` → `2.1.4` (suffix kept as `preview`; the released version still comes from the git tag via `release_ci.yml`).
- **`src/CrestApps.Docs/docs/changelog/2.1.4.md`** — new release notes, with the existing changelog `sidebar_position` values shifted down by one and a 2.1.4 row added to `index.md`.

## Relationship to other PRs

- **Supersedes #646** (the standalone XML fix) — this PR includes that change plus the version bump and notes, so #646 can be closed. I'll close it once you confirm you want the consolidated PR.
- The same XML fix is already on `release/2.2` (in #643), which has not been released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULPPAXpropJmpHhwa7mqav

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULPPAXpropJmpHhwa7mqav)_