### PR TITLE
Update CrestApps.AgentSkills.Mcp.OrchardCore to 1.2.0 — 2.2 backport

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Miscellaneous Packages -->
-    <PackageVersion Include="CrestApps.AgentSkills.Mcp.OrchardCore" Version="1.1.1" />
+    <PackageVersion Include="CrestApps.AgentSkills.Mcp.OrchardCore" Version="1.2.0" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.19.23" />
     <PackageVersion Include="Fluid.Core" Version="2.31.0" />


### PR DESCRIPTION
Bumps the central pin for `CrestApps.AgentSkills.Mcp.OrchardCore` from **1.1.1** to **1.2.0** on the 2.2 release branch. 1.2.0 is the latest version published on nuget.org.

This backports the package half of #630, which made the same bump on `main`.

### Scope

One line, in `Directory.Packages.props`. The package is consumed by a single project, `CrestApps.OrchardCore.AI.Mcp`, and needs no source changes here: #630 also switched `AddOrchardCoreAgentSkillServices()` to the `(_ => { })` overload, but the parameterless overload still resolves against 1.2.0, so that edit is cosmetic and is deliberately left out to keep the backport minimal.

### Verification

`dotnet build CrestApps.OrchardCore.slnx -c Release -warnaserror` — build succeeded, 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
