### PR TITLE
Hide text input on ai profile chat if user uses real time gpt model

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/AIChatSessionChat.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/AIChatSessionChat.cshtml
@@ -163,7 +163,7 @@
                 <div id="@documentBarHtmlId" class="d-none"></div>
             }
 
-            <textarea class="form-control bg-transparent border-0 chat-user-prompt-input px-4" id="@userPromptHtmlId" data-session-id="@(Model.IsNew ? string.Empty : Model.Session.SessionId)" data-profile-id="@(Model.Profile?.ItemId ?? Model.Session.ProfileId)" placeholder="@T["Message AI Chat"] ..." aria-label="@T["Message AI Chat"]" aria-describedby="@buttonHtmlId"></textarea>
+            <textarea class="form-control bg-transparent border-0 chat-user-prompt-input px-4" id="@userPromptHtmlId" data-session-id="@(Model.IsNew ? string.Empty : Model.Session.SessionId)" data-profile-id="@(Model.Profile?.ItemId ?? Model.Session.ProfileId)" placeholder="@T["Message AI Chat"] ..." aria-label="@T["Message AI Chat"]" aria-describedby="@buttonHtmlId" hidden="@realtimeEnabled"></textarea>
 
             @* Single flex row so the realtime "Start speaking" button (flex-grow-1) can span the full input
                width when the client hides the text controls (audio-only). The shared realtime-audio
@@ -211,7 +211,7 @@
                         </button>
                     }
 
-                    <button class="btn btn-dark rounded" type="button" id="@buttonHtmlId" disabled data-start-icon="<i class='fa-solid fa-arrow-up'></i>" data-stop-icon="<i class='fa-solid fa-stop'></i>">
+                    <button class="btn btn-dark rounded" type="button" id="@buttonHtmlId" disabled hidden="@realtimeEnabled" data-start-icon="<i class='fa-solid fa-arrow-up'></i>" data-stop-icon="<i class='fa-solid fa-stop'></i>">
                         <i class="fa-solid fa-arrow-up"></i>
                     </button>
                 </div>


### PR DESCRIPTION
This pull request makes targeted UI changes to the AI chat session view to improve the user experience when realtime audio input is enabled. Specifically, it hides the text input and send button when realtime mode is active, ensuring the interface adapts appropriately for audio-only interactions.

UI adjustments for realtime audio mode:

* [`AIChatSessionChat.cshtml`](diffhunk://#diff-8db357db487bfc03c4877eb6b076723d14902e29027c2f8d60804a08f52eec22L166-R166): The chat text input `<textarea>` is now hidden when realtime audio input is enabled by setting the `hidden` attribute based on the `realtimeEnabled` flag.
* [`AIChatSessionChat.cshtml`](diffhunk://#diff-8db357db487bfc03c4877eb6b076723d14902e29027c2f8d60804a08f52eec22L214-R214): The send button is also hidden when realtime audio input is enabled by adding the `hidden` attribute, ensuring users are not presented with controls that are not relevant in audio-only mode.