### PR TITLE
Advertise WebRTC as a server capability, not as a page mode

### DIFF
--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Views/ChatInteractionChat.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Views/ChatInteractionChat.cshtml
@@ -51,7 +51,10 @@
     var effectiveChatMode = realtimeEnabled
         ? ChatMode.TextInput
         : chatMode;
-    var realtimeWebRtcEnabled = realtimeEnabled && RealtimeTransportSettings.IsWebRtcEnabled(Context.RequestServices);
+    // Whether the server can offer WebRTC is a capability of the host, not of this page's current mode. The
+    // client turns realtime on by itself when a realtime-capable deployment is picked after the page loaded, and
+    // gating this on realtimeEnabled left those sessions permanently on the WebSocket transport.
+    var realtimeWebRtcEnabled = RealtimeTransportSettings.IsWebRtcEnabled(Context.RequestServices);
 
     var speechToTextEnabled = !realtimeEnabled
         && (effectiveChatMode == ChatMode.AudioInput || effectiveChatMode == ChatMode.Conversation)

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/AIChatAdminWidget.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/AIChatAdminWidget.cshtml
@@ -95,7 +95,10 @@
             _ => ChatMode.TextInput,
         };
 
-    var realtimeWebRtcEnabled = realtimeEnabled && RealtimeTransportSettings.IsWebRtcEnabled(Context.RequestServices);
+    // Whether the server can offer WebRTC is a capability of the host, not of this page's current mode. The
+    // client turns realtime on by itself when a realtime-capable deployment is picked after the page loaded, and
+    // gating this on realtimeEnabled left those sessions permanently on the WebSocket transport.
+    var realtimeWebRtcEnabled = RealtimeTransportSettings.IsWebRtcEnabled(Context.RequestServices);
     var realtimeVoiceName = chatModeSettings?.VoiceName;
 
     // The conversation button doubles as the realtime "Start speaking" toggle, so render it for both modes.

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/AIChatSessionChat.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/AIChatSessionChat.cshtml
@@ -100,7 +100,10 @@
             _ => ChatMode.TextInput,
         };
 
-    var realtimeWebRtcEnabled = realtimeEnabled && RealtimeTransportSettings.IsWebRtcEnabled(Context.RequestServices);
+    // Whether the server can offer WebRTC is a capability of the host, not of this page's current mode. The
+    // client turns realtime on by itself when a realtime-capable deployment is picked after the page loaded, and
+    // gating this on realtimeEnabled left those sessions permanently on the WebSocket transport.
+    var realtimeWebRtcEnabled = RealtimeTransportSettings.IsWebRtcEnabled(Context.RequestServices);
     var realtimeVoiceName = chatModeSettings?.VoiceName;
 
     // The conversation button doubles as the realtime "Start speaking" toggle, so render it for both modes.

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/Widget-AIChat.cshtml
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/Views/Widget-AIChat.cshtml
@@ -118,7 +118,10 @@
             _ => ChatMode.TextInput,
         };
 
-    var realtimeWebRtcEnabled = realtimeEnabled && RealtimeTransportSettings.IsWebRtcEnabled(Context.RequestServices);
+    // Whether the server can offer WebRTC is a capability of the host, not of this page's current mode. The
+    // client turns realtime on by itself when a realtime-capable deployment is picked after the page loaded, and
+    // gating this on realtimeEnabled left those sessions permanently on the WebSocket transport.
+    var realtimeWebRtcEnabled = RealtimeTransportSettings.IsWebRtcEnabled(Context.RequestServices);
     var realtimeVoiceName = chatModeSettings?.VoiceName;
 
     // The conversation button doubles as the realtime "Start speaking" toggle, so render it for both modes.


### PR DESCRIPTION
## The bug

Every chat view computed:

```csharp
var realtimeWebRtcEnabled = realtimeEnabled && RealtimeTransportSettings.IsWebRtcEnabled(Context.RequestServices);
```

`realtimeEnabled &&` is wrong. Whether the server can offer WebRTC is a **host capability** — the peer factory is registered and the transport isn't switched off. It has nothing to do with whether the page was in realtime mode at render time.

All four of these views let the client enter realtime *after* load: they watch the deployment picker and switch the moment a realtime-capable deployment is selected. By then `realtimeWebRtcEnabled` is already serialized as `false`, so the session runs on WebSocket and the browser reports "the server did not advertise the WebRTC transport" — on a host where WebRTC is fully configured and working.

## Evidence

On a staging deployment, opening a chat interaction whose saved deployment was not realtime and then selecting `GptRealtime`:

```
18:04:56  GET /Realtime/Voices?deploymentName=GptRealtime
18:04:56  SaveSettings ... "deploymentName":"GptRealtime"
```

A realtime session started and never attempted WebRTC. The same host, reached through a profile that *already* had a realtime deployment, did attempt it — and got as far as exchanging Cloudflare TURN relay candidates. That difference is the entire asymmetry between the two chat surfaces.

`CrestApps.Core`'s own MVC view has never had this gate, which is why it was unaffected.

## The change

Compute the flag from the host capability alone, in all four views. The client already refuses to start a peer unless realtime is actually running (`webRtcEnabled` is only consulted inside `startRealtimeConversation`), so nothing starts prematurely.

Both module projects build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)