### PR TITLE
Let a tenant configure its own realtime transport

### DIFF
--- a/src/Core/CrestApps.OrchardCore.AI.Core/ServiceCollectionExtensions.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using CrestApps.Core.AI.Tooling;
 using CrestApps.Core.Infrastructure.Indexing;
 using CrestApps.Core.Services;
 using CrestApps.OrchardCore.AI.Core.Handlers;
+using CrestApps.Core.AI.Realtime;
 using CrestApps.OrchardCore.AI.Core.Services;
 using Fluid;
 using Microsoft.AspNetCore.Authorization;
@@ -125,6 +126,11 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<IOptions<AIOptions>>(),
                 sp.GetRequiredService<IOptions<AIDeploymentCatalogOptions>>(),
                 sp.GetRequiredService<ILogger<ConfigurationAIDeploymentSource>>()));
+
+        // Options, unlike the catalog sources below, cannot be replaced: the core registration has already
+        // bound the host configuration by the time this runs. Post-configure instead, which applies after every
+        // Configure regardless of the order the modules registered in.
+        services.AddTransient<IPostConfigureOptions<RealtimeTransportOptions>, RealtimeTransportOptionsConfiguration>();
 
         ReplaceService<INamedSourceCatalogSource<AIProviderConnection>, ConfigurationAIProviderConnectionSource>(
             services,

--- a/src/Core/CrestApps.OrchardCore.AI.Core/Services/RealtimeTransportOptionsConfiguration.cs
+++ b/src/Core/CrestApps.OrchardCore.AI.Core/Services/RealtimeTransportOptionsConfiguration.cs
@@ -1,0 +1,56 @@
+using CrestApps.Core.AI.Realtime;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using OrchardCore.Environment.Shell.Configuration;
+
+namespace CrestApps.OrchardCore.AI.Core.Services;
+
+/// <summary>
+/// Re-binds <see cref="RealtimeTransportOptions"/> from the tenant's shell configuration.
+/// </summary>
+/// <remarks>
+/// CrestApps.Core binds these options from <see cref="IConfiguration"/>, which under Orchard Core resolves to
+/// the host configuration alone. That left the realtime transport — the STUN and TURN servers above all —
+/// settable only at the host, so every tenant shared one set of relay credentials and none could be given its
+/// own. Running as a post-configure step, this reapplies the same section from <see cref="IShellConfiguration"/>
+/// after the core registration whatever order the modules load in, so a value set for a tenant wins and one it
+/// leaves alone keeps whatever the host provided.
+/// </remarks>
+internal sealed class RealtimeTransportOptionsConfiguration : IPostConfigureOptions<RealtimeTransportOptions>
+{
+    public const string ConfigurationSection = "CrestApps:AI:RealtimeTransport";
+
+    private readonly IShellConfiguration _shellConfiguration;
+
+    public RealtimeTransportOptionsConfiguration(IShellConfiguration shellConfiguration)
+    {
+        _shellConfiguration = shellConfiguration;
+    }
+
+    public void PostConfigure(string name, RealtimeTransportOptions options)
+    {
+        var section = _shellConfiguration.GetSection(ConfigurationSection);
+
+        if (!section.Exists())
+        {
+            return;
+        }
+
+        // The configuration binder appends to an array property rather than replacing it, so binding this
+        // section over values the host already supplied would leave every STUN and TURN URL listed twice. A
+        // duplicated TURN URL is not harmless: it makes the peer allocate a second relay on the same server,
+        // which is billed and needlessly slows gathering. Clear an array only when this section actually
+        // declares it, so a tenant that overrides the URLs replaces them and one that does not keeps the host's.
+        if (section.GetSection(nameof(RealtimeTransportOptions.StunUrls)).Exists())
+        {
+            options.StunUrls = [];
+        }
+
+        if (section.GetSection(nameof(RealtimeTransportOptions.TurnUrls)).Exists())
+        {
+            options.TurnUrls = [];
+        }
+
+        section.Bind(options);
+    }
+}


### PR DESCRIPTION
`RealtimeTransportOptions` is bound in CrestApps.Core with `BindConfiguration("CrestApps:AI:RealtimeTransport")`, which resolves `IConfiguration` — under Orchard Core, the host configuration alone. So the realtime transport could only be configured host-wide: every tenant shared one set of TURN credentials, no tenant could be given its own, and a value placed in a tenant's `App_Data/appsettings.json` was read by nothing at all.

`ReplaceConfigurationServices()` already documents and corrects exactly this problem for `ConfigurationAIDeploymentSource` and `ConfigurationAIProviderConnectionSource`. The transport options were simply missed.

This was found while diagnosing a WebRTC failure: TURN settings written to a tenant's `App_Data/appsettings.json` had no effect, and the server kept handing browsers the built-in default STUN server.

## Two details worth calling out

**It post-configures rather than configures.** The catalog sources can use `ReplaceService` because they are plain services; options cannot. The core registration has already bound the host configuration by the time this runs, and `IConfigureOptions` executes in registration order — which depends on whether `AddAIServices` or `AddWebRtcRealtimeTransport` registered first. `PostConfigure` runs after every `Configure` whatever that order turns out to be.

**It clears an array only when the section declares it.** The configuration binder appends to array properties rather than replacing them, so binding this section over values the host already supplied would leave every STUN and TURN URL listed twice. That is not cosmetic — a duplicated TURN URL makes the peer allocate a second relay on the same server, which is billed and slows gathering. It is the same defect fixed in CrestApps.Core#170. So:

```csharp
if (section.GetSection(nameof(RealtimeTransportOptions.StunUrls)).Exists())
{
    options.StunUrls = [];
}
```

A tenant that overrides the URLs replaces them; a tenant that does not keeps the host's.

## Audit

I swept CrestApps.Core for every library-level `CrestApps:` configuration binding and checked each against this repository. `src/Startup/*` is excluded — those are standalone hosts where host configuration is correct.

| Section | Bound by | Status |
|---|---|---|
| `CrestApps:AI:RealtimeTransport` | `WebRtcRealtimeServiceCollectionExtensions` | **fixed here** |
| `CrestApps:AI:Deployments` | `ConfigurationAIDeploymentSource` | already replaced |
| `CrestApps:AI:Connections`, `CrestApps:AI:Providers` | `ConfigurationAIProviderConnectionSource` | already replaced |
| `CrestApps:AI:AzureClient` | `AzureClientOptionsConfiguration` | already post-configured from `IShellConfiguration` |
| `CrestApps:AI:Documents:BasePath` | `DocumentFileSystemFileStoreOptionsConfiguration` | already overridden per tenant from `ShellSettings` |

`AzureClientOptions` has no collection properties, so its double-bind is not exposed to the append behaviour described above.

This was the only gap.

## Verified

Confirmed live, not inferred: with this change a tenant's `App_Data/appsettings.json` TURN configuration reaches the peer — the browser received the configured Cloudflare TURN servers instead of the default STUN fallback, and a realtime WebRTC session then connected over a pure relay path.
