### PR TITLE
Quiet the per-packet RTP warning from a relayed realtime call

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrchardCoreVersion>4.0.0-preview-19142</OrchardCoreVersion>
-    <CrestAppsCoreVersion>2.0.0-preview.263</CrestAppsCoreVersion>
+    <CrestAppsCoreVersion>2.0.0-preview.264</CrestAppsCoreVersion>
     <ModelContextProtocolVersion>2.2.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Modules/CrestApps.OrchardCore.AI.DataSources/Drivers/DataSourceSearchToolInstanceDisplayDriver.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.DataSources/Drivers/DataSourceSearchToolInstanceDisplayDriver.cs
@@ -73,7 +73,6 @@ internal sealed class DataSourceSearchToolInstanceDisplayDriver : DisplayDriver<
         }
 
         var model = new DataSourceSearchToolInstanceViewModel();
-        var existing = instance.GetOrCreate<DataSourceSearchToolSettings>();
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
@@ -114,13 +113,6 @@ internal sealed class DataSourceSearchToolInstanceDisplayDriver : DisplayDriver<
             TopNDocuments = model.TopNDocuments,
             Strictness = model.Strictness,
             Filter = string.IsNullOrWhiteSpace(model.Filter) ? null : model.Filter.Trim(),
-
-            // Carried over rather than edited. There is no editor control for it because nothing here can
-            // honor it: at tool level it only changes the wording of the "nothing found" string the model
-            // reads, and the model is free to answer from general knowledge regardless. Scope is enforceable
-            // on a profile, where retrieval runs before the turn and shapes the prompt, not on a function the
-            // model chose to call. Preserved so an instance imported with a value keeps it.
-            IsInScope = existing.IsInScope,
         });
 
         return Edit(instance, context);

--- a/src/Startup/CrestApps.OrchardCore.Cms.Web/NLog.config
+++ b/src/Startup/CrestApps.OrchardCore.Cms.Web/NLog.config
@@ -26,6 +26,7 @@
     <variable name="hostingLifetimeLevel" value="${configsetting:item=Logging.LogLevel.Microsoft\\.Hosting\\.Lifetime:whenEmpty=Information}" />
     <variable name="yessqlLevel" value="${configsetting:item=Logging.LogLevel.YesSql:whenEmpty=Information}" />
     <variable name="crestApps" value="${configsetting:item=Logging.LogLevel.CrestApps:whenEmpty=Error}" />
+    <variable name="sipSorceryMediaStreamLevel" value="${configsetting:item=Logging.LogLevel.SIPSorcery\\.Net\\.MediaStream:whenEmpty=Error}" />
 
     <rules>
         <!-- Capture trace-level logs from CrestApps for STT diagnostics -->
@@ -36,6 +37,19 @@
 
         <!-- The hosting lifetime events go to the console and file targets -->
         <logger name="Microsoft.Hosting.Lifetime" minlevel="${var:hostingLifetimeLevel}" writeTo="file, console" finalMinLevel="Off" />
+
+        <!--
+            A realtime caller whose browser relays through TURN sends media from the relay's address, which is
+            not the address SIPSorcery recorded when ICE nominated the pair. It warns on the mismatch and, since
+            the warning path leaves the remote track's SSRC unset and an unset SSRC is what guards the check,
+            warns again for the next packet: fifty warnings a second for the length of the call, while the audio
+            itself is unaffected. The fix belongs in the peer and is being made there, but a log this loud fills
+            a disk long before that reaches a released package.
+
+            This does cost the stream's other warnings, an unknown RTP payload type among them, so raise it back
+            with Logging:LogLevel:SIPSorcery.Net.MediaStream when diagnosing a call rather than editing here.
+        -->
+        <logger name="SIPSorcery.Net.MediaStream" minlevel="${var:sipSorceryMediaStreamLevel}" writeTo="file" finalMinLevel="Off" />
 
         <!-- All default and above go to the file target -->
         <logger name="*" minlevel="${var:defaultLevel}" writeTo="file" />


### PR DESCRIPTION
A realtime WebRTC call whose browser relays through TURN fills the log with one warning per RTP packet:

```
SIPSorcery.Net.MediaStream|WARN|RTP packet with SSRC 2277538103 received from unrecognised end point <relay address>.
```

Fifty a second, for the length of the call.

## Why it repeats

SIPSorcery only re-points a media stream's destination on a mismatch when the address it expected was private — the NAT case. A browser relaying through TURN sends from the relay's public address, so the mismatch falls through to the warning instead. That path leaves the remote track's SSRC unset, and an unset SSRC is the condition guarding the check, so the next packet takes the same branch. It never latches.

The audio is unaffected — the packet is processed either way, and the same session logged inbound audio flowing and a clean close — so this is log volume, not a broken call.

## What this changes

The real fix belongs in the peer and is being made there (CrestApps/CrestApps.Core#180), but a log this loud fills a disk long before that reaches a released package. This holds `SIPSorcery.Net.MediaStream` at `Error` in `NLog.config` in the meantime.

It does cost the stream's other warnings, an unknown RTP payload type among them, so the level is read from configuration like the neighboring rules — set `Logging:LogLevel:SIPSorcery.Net.MediaStream` to `Warning` to get them back for a call that needs diagnosing, rather than editing the file.

Once the Core fix ships and this host picks up the package, the rule can be dropped.

## Testing

`NLog.config` validated as well-formed and the rules parsed in order. `finalMinLevel="Off"` blocks every matched event from the later catch-all rule, matching how the neighboring `CrestApps.Core.*`, `YesSql` and `Microsoft.Hosting.Lifetime` rules are already written. Not yet observed against a live relayed call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)