### PR TITLE
Update CrestApps.Core packages to 2.0.0-preview.265

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrchardCoreVersion>4.0.0-preview-19142</OrchardCoreVersion>
-    <CrestAppsCoreVersion>2.0.0-preview.264</CrestAppsCoreVersion>
+    <CrestAppsCoreVersion>2.0.0-preview.265</CrestAppsCoreVersion>
     <ModelContextProtocolVersion>2.2.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Bumps `CrestAppsCoreVersion` from `2.0.0-preview.264` to `2.0.0-preview.265`.

Every `CrestApps.Core.*` pin flows from that single property in `Directory.Packages.props`, so this one line moves them all — no other file references a `CrestApps.Core` version.

## Verification

- `2.0.0-preview.265` confirmed published on the `CrestAppsCorePreview` feed before bumping.
- `dotnet restore` pulls it from the feed (it was not previously in the local NuGet cache, so this is the real package, not a locally-packed dev build).
- Every `CrestApps.Core.*` entry in the restored assets resolves to `2.0.0-preview.265`, with none left on an older version.
- `dotnet build` of the full solution: **0 warnings, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
