### PR TITLE
Update @crestapps/ai-chat-ui to 2.0.0-preview.175 and CrestApps.Core to 2.0.0-preview.266

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrchardCoreVersion>4.0.0-preview-19142</OrchardCoreVersion>
-    <CrestAppsCoreVersion>2.0.0-preview.265</CrestAppsCoreVersion>
+    <CrestAppsCoreVersion>2.0.0-preview.266</CrestAppsCoreVersion>
     <ModelContextProtocolVersion>2.2.0</ModelContextProtocolVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Services/ResourceManagementOptionsConfiguration.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/Services/ResourceManagementOptionsConfiguration.cs
@@ -15,8 +15,8 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
             .DefineScript("ChatInteractionApp")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat.Interactions/scripts/chat-interaction.min.js", "~/CrestApps.OrchardCore.AI.Chat.Interactions/scripts/chat-interaction.js")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/chat-interaction.min.js",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/chat-interaction.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/chat-interaction.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/chat-interaction.js")
             .SetCdnIntegrity(
                 "sha384-/atHPMoIkm6+WbJH1qDtYuNM83BT0H7sSREM61ZAj7OfIWoDEVZqchyl2xE36Ttr",
                 "sha384-XPyvrOLS39eDF4bzVEml7PXcr4wK9QZJtHQZJSyItcNgu6o7fDQbmrY9fBNdjwas")

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/package-lock.json
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@crestapps/ai-chat-ui": "2.0.0-preview.173"
+        "@crestapps/ai-chat-ui": "2.0.0-preview.175"
       },
       "devDependencies": {
         "eslint": "^10.5.0"
       }
     },
     "node_modules/@crestapps/ai-chat-ui": {
-      "version": "2.0.0-preview.173",
-      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-2.0.0-preview.173.tgz",
-      "integrity": "sha512-7ECRQzdodadd/5lCsRebp/oVqA4LhA4ec3fDGnabOnwfam2S7KSTT777GAznpKJ+EP3HuuUSnftrtAy4suYLVg==",
+      "version": "2.0.0-preview.175",
+      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-2.0.0-preview.175.tgz",
+      "integrity": "sha512-ApYfcXeBktioyq47EHG89CgWePfwXmlpNAd0pjh3B+83qZN2UK5uTsi2hkD+48fES6mTJ3aPshigq4triDxdPQ==",
       "license": "MIT",
       "peerDependencies": {
         "chart.js": ">=3.0.0"

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/package.json
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat.Interactions/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@crestapps/ai-chat-ui": "2.0.0-preview.173"
+    "@crestapps/ai-chat-ui": "2.0.0-preview.175"
   },
   "devDependencies": {
     "eslint": "^10.5.0"

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/Services/ResourceManagementOptionsConfiguration.cs
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/Services/ResourceManagementOptionsConfiguration.cs
@@ -15,8 +15,8 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
             .DefineScript("AIChatApp")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat/scripts/ai-chat.min.js", "~/CrestApps.OrchardCore.AI.Chat/scripts/ai-chat.js")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/ai-chat.min.js",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/ai-chat.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/ai-chat.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/ai-chat.js")
             .SetCdnIntegrity(
                 "sha384-0FGFP5eoQuXAuj5GXIwqr13ftU3LoBUMHl6cc0dxSyVVzoB0RkwxLKsWnNka9WPL",
                 "sha384-sW0z6hFJUnkgfj0iNPZYtFEbaMKObMFY24RyvP1sgnaRZVwzKcHsI8MELQf/10xc")
@@ -27,8 +27,8 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
             .DefineScript("AIChatWidgetApp")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat/scripts/ai-chat-widget.min.js", "~/CrestApps.OrchardCore.AI.Chat/scripts/ai-chat-widget.js")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/ai-chat-widget.min.js",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/ai-chat-widget.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/ai-chat-widget.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/ai-chat-widget.js")
             .SetCdnIntegrity(
                 "sha384-JpfYxsQXZwg0H6LfwDj26TrcwcFGPKazqsQA83FP70hy2vCLwQWreKQIQ7HMrKXK",
                 "sha384-+dvDdShn9ZUw9QDWQaDkyrV6sbNwVZcBLcjxD82nmOWYh5Q6YZ49OFKFz6glUycX")
@@ -39,8 +39,8 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
             .DefineStyle("AIChatApp")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat/css/ai-chat.min.css", "~/CrestApps.OrchardCore.AI.Chat/css/ai-chat.css")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/ai-chat.min.css",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/ai-chat.css")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/ai-chat.min.css",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/ai-chat.css")
             .SetCdnIntegrity(
                 "sha384-KKZ8hVlHa3DGMa6QV4PPzbSyMsxF76YT6+dRHsiI+cBJ3wt+m9cSBW07CQlKUq87",
                 "sha384-ItWpot1IYdNGFGwJxcWg+uJ42DWXOXkl/WeVy1Byf0LfcKgFjiV8kuKlSkcf/Z4Z")
@@ -50,8 +50,8 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
             .DefineStyle("AIChatWidget")
             .SetUrl("~/CrestApps.OrchardCore.AI.Chat/css/ai-chat-widget.min.css", "~/CrestApps.OrchardCore.AI.Chat/css/ai-chat-widget.css")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/chat-widget.min.css",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/chat-widget.css")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/chat-widget.min.css",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/chat-widget.css")
             .SetCdnIntegrity(
                 "sha384-ETUZFWfTXtm2hDzz71g3rPZQSSA9R0njFfXiYaBT6QTb2+bLMuZNQKChN52Q+pzU",
                 "sha384-8SMfXg8HrWLJjzqfwxowYAz0HVAsaN2o5Y1X46je0Fa3HrwobAKBTbPOrPI0gfz/")

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/package-lock.json
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@crestapps/ai-chat-ui": "2.0.0-preview.173"
+        "@crestapps/ai-chat-ui": "2.0.0-preview.175"
       }
     },
     "node_modules/@crestapps/ai-chat-ui": {
-      "version": "2.0.0-preview.173",
-      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-2.0.0-preview.173.tgz",
-      "integrity": "sha512-7ECRQzdodadd/5lCsRebp/oVqA4LhA4ec3fDGnabOnwfam2S7KSTT777GAznpKJ+EP3HuuUSnftrtAy4suYLVg==",
+      "version": "2.0.0-preview.175",
+      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-2.0.0-preview.175.tgz",
+      "integrity": "sha512-ApYfcXeBktioyq47EHG89CgWePfwXmlpNAd0pjh3B+83qZN2UK5uTsi2hkD+48fES6mTJ3aPshigq4triDxdPQ==",
       "license": "MIT",
       "peerDependencies": {
         "chart.js": ">=3.0.0"

--- a/src/Modules/CrestApps.OrchardCore.AI.Chat/package.json
+++ b/src/Modules/CrestApps.OrchardCore.AI.Chat/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@crestapps/ai-chat-ui": "2.0.0-preview.173"
+    "@crestapps/ai-chat-ui": "2.0.0-preview.175"
   }
 }

--- a/src/Modules/CrestApps.OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
+++ b/src/Modules/CrestApps.OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
@@ -172,8 +172,8 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/technical-name-generator.min.js",
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/technical-name-generator.js")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/technical-name-generator.min.js",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/technical-name-generator.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/technical-name-generator.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/technical-name-generator.js")
             .SetCdnIntegrity(
                 "sha384-vk5MiCC6biz7ygKi3CY+whjnNoLe2Ol+ZWoxUr/aoifSyfm9c2WFazGMhNLi8g7I",
                 "sha384-9cJ5WEY0z1tJkCLND8ZMhN+rT6IySJKbK/R1yJcaSqmWgiCMuOyZJ+UUobxuScNs")
@@ -185,8 +185,8 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/document-drop-zone.min.js",
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/document-drop-zone.js")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/document-drop-zone.min.js",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/document-drop-zone.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/document-drop-zone.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/document-drop-zone.js")
             .SetCdnIntegrity(
                 "sha384-AvXYh7cCLTVJu3IoIikt5045awzgrmZ4S6e8Z5mHQydf5f9mHIPAbZ2xTP+LT5BC",
                 "sha384-8W/wOs7j6d1l50bR3wLRiY6M3/yf0acllYpEJRFraFBwtAXwvYcoyITxQ6FxyNkb")
@@ -198,8 +198,8 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/document-drop-zone.min.css",
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/document-drop-zone.css")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/document-drop-zone.min.css",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/document-drop-zone.css")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/document-drop-zone.min.css",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/document-drop-zone.css")
             .SetCdnIntegrity(
                 "sha384-cTjcD1YHMzaJ5FIvmpJhm3VZDBheTcbiNfGCQfFvBTDg1pZi7PWE5lO6VHRYX9zq",
                 "sha384-NLPKccGh39Ymb5v2aC3tD6zdtg+MhT/Sa+QpCRmDVY2xXSC10rxBNBh0iRqLUQkK")
@@ -213,8 +213,8 @@ internal sealed class ResourceManagementOptionsConfiguration : IConfigureOptions
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/realtime-audio.min.js",
                 "~/CrestApps.OrchardCore.Resources/vendors/crestapps/realtime-audio.js")
             .SetCdn(
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/realtime-audio.min.js",
-                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.173/dist/realtime-audio.js")
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/realtime-audio.min.js",
+                "https://cdn.jsdelivr.net/npm/@crestapps/ai-chat-ui@2.0.0-preview.175/dist/realtime-audio.js")
             .SetCdnIntegrity(
                 "sha384-8BMMYE2/teNp6CXSt4hKOFQbN0HGEl4hZaNC5QYDCwjxrg0SoV8O4W4OZqBUqV3U",
                 "sha384-J5nV53+rOG9KryOl4zjs0pGDNLLZLOHdiNqHd71t+sr2fJ3IzHc00OtGjHiXpkw7")

--- a/src/Modules/CrestApps.OrchardCore.Resources/package-lock.json
+++ b/src/Modules/CrestApps.OrchardCore.Resources/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "crestapps.orchardcore.resources",
       "dependencies": {
-        "@crestapps/ai-chat-ui": "2.0.0-preview.173",
+        "@crestapps/ai-chat-ui": "2.0.0-preview.175",
         "@crestapps/bootstrap-select": "1.2.1",
         "chart.js": "^4.5.1",
         "intl-tel-input": "29.1.0"
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@crestapps/ai-chat-ui": {
-      "version": "2.0.0-preview.173",
-      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-2.0.0-preview.173.tgz",
-      "integrity": "sha512-7ECRQzdodadd/5lCsRebp/oVqA4LhA4ec3fDGnabOnwfam2S7KSTT777GAznpKJ+EP3HuuUSnftrtAy4suYLVg==",
+      "version": "2.0.0-preview.175",
+      "resolved": "https://registry.npmjs.org/@crestapps/ai-chat-ui/-/ai-chat-ui-2.0.0-preview.175.tgz",
+      "integrity": "sha512-ApYfcXeBktioyq47EHG89CgWePfwXmlpNAd0pjh3B+83qZN2UK5uTsi2hkD+48fES6mTJ3aPshigq4triDxdPQ==",
       "license": "MIT",
       "peerDependencies": {
         "chart.js": ">=3.0.0"

--- a/src/Modules/CrestApps.OrchardCore.Resources/package.json
+++ b/src/Modules/CrestApps.OrchardCore.Resources/package.json
@@ -9,7 +9,7 @@
     "marked": "^18.0.5"
   },
   "dependencies": {
-    "@crestapps/ai-chat-ui": "2.0.0-preview.173",
+    "@crestapps/ai-chat-ui": "2.0.0-preview.175",
     "@crestapps/bootstrap-select": "1.2.1",
     "chart.js": "^4.5.1",
     "intl-tel-input": "29.1.0"


### PR DESCRIPTION
## Why

The deployment was still serving an older `@crestapps/ai-chat-ui` bundle and an older `CrestApps.Core`, so it hadn't picked up the realtime ICE server changes (the Cloudflare TURN matrix trim that stops the browser's *"Using five or more STUN/TURN servers slows down discovery"* warning). That trim ships server-side in `CrestApps.Core.AI.Chat`, so both the front-end bundle and the NuGet packages need bumping.

## Changes

**npm — `@crestapps/ai-chat-ui` `2.0.0-preview.173` → `2.0.0-preview.175`**
- Updated the dependency in all three module `package.json` files (`AI.Chat`, `AI.Chat.Interactions`, `Resources`) and their `package-lock.json`.
- Updated the jsdelivr CDN URLs in each `ResourceManagementOptionsConfiguration` (18 URLs across the three modules).
- Regenerated the vendored `wwwroot` assets via `gulp build`. Only the source maps changed — the bundled JS/CSS is byte-identical between `.173` and `.175`, so **the SRI integrity tokens are unchanged**; I re-computed sha384 for every CDN file against the new package and confirmed each still matches.

**NuGet — `CrestAppsCoreVersion` `2.0.0-preview.265` → `2.0.0-preview.266`**
- Single change in `Directory.Packages.props`; this is the package that carries the server-side realtime ICE server trim. `dotnet restore` resolves the new version cleanly from the Cloudsmith feed.

## Verification
- `npm install` in all three modules; installed `@crestapps/ai-chat-ui` confirmed at `2.0.0-preview.175`.
- Vendored `wwwroot` files confirmed byte-in-sync with the installed dist.
- All 20 SRI tokens re-verified against the freshly installed files.
- `dotnet restore --force --no-cache` on the AI.Chat module resolved every CrestApps.Core package at `2.0.0-preview.266`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)